### PR TITLE
Set react as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,9 @@
     "build:dist": "BABEL_ENV=build babel src --out-dir dist --copy-files --ignore spec.js,example.js,.md",
     "build": "npm run test -- --browsers PhantomJS && npm run build:examples && npm run build:docs && npm run build:js && npm run build:dist"
   },
+  "peerDependencies": {
+    "react": "15.6.1"
+  },
   "dependencies": {
     "antd": "2.12.8",
     "lodash": "4.17.4",
@@ -84,7 +87,6 @@
     "enzyme": "2.9.1",
     "eslint": "4.6.1",
     "eslint-plugin-html": "3.2.1",
-    "css-loader": "0.28.7",
     "eslint-plugin-markdown": "1.0.0-beta.7",
     "eslint-plugin-react": "7.3.0",
     "expect.js": "0.3.1",


### PR DESCRIPTION
This introduces the `react` dependency as `peerDependency`. Otherwise applications using this package may encounter the error explained [here](https://facebook.github.io/react/warnings/refs-must-have-owner.html).

