### PR TITLE
Some fixes to the ScaleCombo

### DIFF
--- a/src/Map/ScaleCombo/ScaleCombo.spec.jsx
+++ b/src/Map/ScaleCombo/ScaleCombo.spec.jsx
@@ -88,7 +88,8 @@ describe('<ScaleCombo />', () => {
       expect(wrapper.props().scales).to.be.an('array');
       expect(wrapper.props().scales).to.have.length(testResolutions.length);
 
-      let roundScale = (Math.round(MapUtil.getScaleForResolution(testResolutions[0] ,'m'))).toString();
+      let roundScale = (Math.round(MapUtil.getScaleForResolution(
+        testResolutions[testResolutions.length - 1] ,'m'))).toString();
       expect(wrapper.props().scales[0].key).to.be(roundScale);
     });
   });


### PR DESCRIPTION
  * Map received `zoomLevel` prop to state.
  * Round scale values to a multiple of 10.
  * Calculate scale entries in correct order out of given map resolutions.