### PR TITLE
LayerTree improvements

### DIFF
--- a/src/LayerTree/LayerTree.example.jsx
+++ b/src/LayerTree/LayerTree.example.jsx
@@ -73,7 +73,7 @@ render(
     </div>
 
     <div className="example-block">
-      <span>{'A LayerTree configured with concrete layerGroup:'}:</span>
+      <span>{'A LayerTree configured with concrete layerGroup:'}</span>
 
       <LayerTree
         layerGroup={layerGroup}

--- a/src/LayerTree/LayerTree.jsx
+++ b/src/LayerTree/LayerTree.jsx
@@ -22,8 +22,8 @@ class LayerTree extends React.Component {
 
 
   /**
-   * @type {Array<ol.EventsKey>} An array of ol.EventsKey as returned by on() or
-   *                             once().
+   *  An array of ol.EventsKey as returned by on() or once().
+   * @type {Array<ol.EventsKey>}
    * @private
    */
   olListenerKeys = []
@@ -42,6 +42,7 @@ class LayerTree extends React.Component {
 
   /**
    * The default properties.
+   *
    * @type {Object}
    */
   static defaultProps = {
@@ -168,8 +169,7 @@ class LayerTree extends React.Component {
   /**
    * Unregisters the Events of a given layer.
    *
-   * @param {[type]} layer [description]
-   * @return {[type]} [description]
+   * @param {ol.layer.Base} layer An ol.layer.Base.
    */
   unregisterEventsByLayer = (layer) => {
     this.olListenerKeys = this.olListenerKeys.filter((key) => {
@@ -194,7 +194,7 @@ class LayerTree extends React.Component {
   }
 
   /**
-   * Rebuilds the treeNodes and its checked staes.
+   * Rebuilds the treeNodes and its checked states.
    */
   rebuildTreeNodes = () => {
     this.treeNodesFromLayerGroup(this.state.layerGroup);
@@ -242,7 +242,7 @@ class LayerTree extends React.Component {
   }
 
   /**
-   * Determines if the target has allready registered the given listener for the
+   * Determines if the target has already registered the given listener for the
    * given eventtype.
    *
    * @param {Object} target The event target.

--- a/src/LayerTree/LayerTree.spec.jsx
+++ b/src/LayerTree/LayerTree.spec.jsx
@@ -12,15 +12,17 @@ import TestUtils from '../Util/TestUtils';
 describe('<LayerTree />', () => {
   let layerGroup;
   let map;
+  let layer1;
+  let layer2;
 
   beforeEach(() => {
     const layerSource1 = new OlTileWMS();
-    const layer1 = new OlTileLayer({
+    layer1 = new OlTileLayer({
       name: 'layer1',
       source: layerSource1
     });
     const layerSource2 = new OlTileWMS();
-    const layer2 = new OlTileLayer({
+    layer2 = new OlTileLayer({
       name: 'layer2',
       visible: false,
       source: layerSource2
@@ -40,23 +42,6 @@ describe('<LayerTree />', () => {
   it('can be rendered', () => {
     const wrapper = TestUtils.mountComponent(LayerTree);
     expect(wrapper).not.to.be(undefined);
-  });
-
-  describe('new layerGroup as prop', () => {
-
-    it('calls treeNodesFromLayerGroup and checkedKeysFromLayerGroup', () => {
-      const wrapper = TestUtils.mountComponent(LayerTree);
-      const spy1 = sinon.spy(wrapper.instance(), 'treeNodesFromLayerGroup');
-      const spy2 = sinon.spy(wrapper.instance(), 'checkedKeysFromLayerGroup');
-
-      wrapper.setProps({
-        layerGroup: new OlGroupLayer({})
-      });
-
-      expect(spy1).to.have.property('callCount', 1);
-      expect(spy2).to.have.property('callCount', 1);
-
-    });
   });
 
   describe('<TreeNode> creation', () => {
@@ -79,7 +64,6 @@ describe('<LayerTree />', () => {
         layerGroup,
         map
       };
-
       const subLayer = new OlTileLayer({
         name: 'subLayer',
         source: new OlTileWMS()
@@ -162,61 +146,26 @@ describe('<LayerTree />', () => {
     });
   });
 
-  describe('onDrop', () => {
+  describe('visiblity changes triggerd by ol', () => {
 
-    describe('getLayerPositionInfo', () => {
-      let props;
-      let subLayer;
-      let nestedLayerGroup;
+    it('sets the correct visibility to the layer from the checked state', () => {
+      const props = {
+        layerGroup,
+        map
+      };
+      const wrapper = TestUtils.mountComponent(LayerTree, props);
+      const treeNode = wrapper.childAt(0).node;
 
-      beforeEach(() => {
-        props = {
-          layerGroup,
-          map
-        };
-        subLayer = new OlTileLayer({
-          name: 'subLayer',
-          source: new OlTileWMS()
-        });
-        nestedLayerGroup = new OlGroupLayer({
-          name: 'nestedLayerGroup',
-          layers: [subLayer]
-        });
-        layerGroup.getLayers().push(nestedLayerGroup);
-      });
-
-      it('uses the map if second argument is empty', () => {
-        const wrapper = TestUtils.mountComponent(LayerTree, props);
-        const layer = layerGroup.getLayers().item(0);
-        const layerPositionInfo = wrapper.instance().getLayerPositionInfo(layer);
-
-        expect(layerPositionInfo).to.be.eql({
-          position: 0,
-          collection: layerGroup.getLayers()
-        });
-      });
-
-      it('uses the layerGroup if given as second argument', () => {
-        const wrapper = TestUtils.mountComponent(LayerTree, props);
-        const layerPositionInfo = wrapper.instance().getLayerPositionInfo(subLayer, nestedLayerGroup);
-
-        expect(layerPositionInfo).to.be.eql({
-          position: 0,
-          collection: nestedLayerGroup.getLayers()
-        });
-      });
-
-      it('works iterative', () => {
-        const wrapper = TestUtils.mountComponent(LayerTree, props);
-        const layerPositionInfo = wrapper.instance().getLayerPositionInfo(subLayer, map);
-
-        expect(layerPositionInfo).to.be.eql({
-          position: 0,
-          collection: nestedLayerGroup.getLayers()
-        });
-      });
-
+      expect(treeNode.props.checked).to.be(true);
+      layer1.setVisible(false);
+      expect(treeNode.props.checked).to.be(false);
+      layer1.setVisible(true);
+      expect(treeNode.props.checked).to.be(true);
     });
+
+  });
+
+  describe('onDrop', () => {
 
     // TODO add test when bug in react-component/tree is fixed
     // let props = {};

--- a/src/LayerTree/LayerTree.spec.jsx
+++ b/src/LayerTree/LayerTree.spec.jsx
@@ -1,6 +1,5 @@
 /*eslint-env mocha*/
 import expect from 'expect.js';
-import sinon from 'sinon';
 
 import OlGroupLayer from 'ol/layer/group';
 import OlTileLayer from 'ol/layer/tile';

--- a/src/LayerTree/LayerTree.spec.jsx
+++ b/src/LayerTree/LayerTree.spec.jsx
@@ -1,12 +1,16 @@
 /*eslint-env mocha*/
 import expect from 'expect.js';
+import sinon from 'sinon';
 
 import OlGroupLayer from 'ol/layer/group';
 import OlTileLayer from 'ol/layer/tile';
 import OlTileWMS from 'ol/source/tilewms';
+import olObservable from 'ol/observable';
+
+import Logger from '../Util/Logger.js';
+import TestUtils from '../Util/TestUtils';
 
 import LayerTree from './LayerTree.jsx';
-import TestUtils from '../Util/TestUtils';
 
 describe('<LayerTree />', () => {
   let layerGroup;
@@ -27,6 +31,7 @@ describe('<LayerTree />', () => {
       source: layerSource2
     });
     layerGroup = new OlGroupLayer({
+      name: 'layerGroup',
       layers: [layer1, layer2]
     });
 
@@ -41,6 +46,40 @@ describe('<LayerTree />', () => {
   it('can be rendered', () => {
     const wrapper = TestUtils.mountComponent(LayerTree);
     expect(wrapper).not.to.be(undefined);
+  });
+
+  it('unmount removes listeners', () => {
+    const unByKeySpy = sinon.spy(olObservable, 'unByKey');
+    const wrapper = TestUtils.mountComponent(LayerTree);
+    const olListenerKeys = wrapper.instance().olListenerKeys;
+    wrapper.unmount();
+    expect(unByKeySpy.callCount).to.equal(1);
+    expect(unByKeySpy.calledWith(olListenerKeys)).to.be.ok();
+
+    unByKeySpy.restore();
+  });
+
+  it('CWR with new layerGroup rebuild listeners and treenodes ', () => {
+    const props = {
+      layerGroup,
+      map
+    };
+    const wrapper = TestUtils.mountComponent(LayerTree, props);
+
+    const subLayer = new OlTileLayer({
+      name: 'subLayer',
+      source: new OlTileWMS()
+    });
+    const nestedLayerGroup = new OlGroupLayer({
+      name: 'nestedLayerGroup',
+      layers: [subLayer]
+    });
+
+    expect(wrapper.instance().olListenerKeys).to.have.length(4);
+    wrapper.setProps({
+      layerGroup: nestedLayerGroup
+    });
+    expect(wrapper.instance().olListenerKeys).to.have.length(3);
   });
 
   describe('<TreeNode> creation', () => {
@@ -121,9 +160,43 @@ describe('<LayerTree />', () => {
         expect(layer.getVisible()).to.eql(node.props().checked);
       });
     });
+
+    describe('#treeNodeFromLayer', () => {
+
+      it('logs an error if called with an invisible layergroup', () => {
+        const props = {
+          layerGroup,
+          map
+        };
+        layerGroup.setVisible(false);
+
+        const logSpy = sinon.spy(Logger, 'warn');
+        const wrapper = TestUtils.mountComponent(LayerTree, props);
+        wrapper.instance().treeNodeFromLayer(layerGroup);
+
+        expect(logSpy).to.have.property('callCount', 1);
+
+        logSpy.restore();
+        layerGroup.setVisible(true);
+      });
+
+      it('returns a TreeNode when called with a layer', () => {
+        const props = {
+          layerGroup,
+          map
+        };
+        layerGroup.setVisible(false);
+
+        const wrapper = TestUtils.mountComponent(LayerTree, props);
+        const treeNode = wrapper.instance().treeNodeFromLayer(layer1);
+
+        expect(treeNode.props.title).to.eql(layer1.get('name'));
+        expect(treeNode.key).to.eql(layer1.ol_uid);
+      });
+    });
   });
 
-  describe('onCheck', () => {
+  describe('#onCheck', () => {
 
     it('sets the correct visibility to the layer from the checked state', () => {
       const props = {
@@ -145,9 +218,9 @@ describe('<LayerTree />', () => {
     });
   });
 
-  describe('visiblity changes triggerd by ol', () => {
+  describe('event handling', () => {
 
-    it('sets the correct visibility to the layer from the checked state', () => {
+    it('sets checked state corresponding to layer.setVisible', () => {
       const props = {
         layerGroup,
         map
@@ -162,11 +235,217 @@ describe('<LayerTree />', () => {
       expect(treeNode.props.checked).to.be(true);
     });
 
+    it('triggers tree rebuild on layer add', () => {
+      const props = {
+        layerGroup,
+        map
+      };
+      const layer = new OlTileLayer({
+        source: new OlTileWMS()
+      });
+      const wrapper = TestUtils.mountComponent(LayerTree, props);
+      const rebuildSpy = sinon.spy(wrapper.instance(), 'rebuildTreeNodes');
+
+      layerGroup.getLayers().push(layer);
+      expect(rebuildSpy.callCount).to.equal(1);
+
+      rebuildSpy.restore();
+    });
+
+    it('… also registers add/remove events for added groups ', () => {
+      const props = {
+        layerGroup,
+        map
+      };
+      const layer = new OlTileLayer({
+        source: new OlTileWMS()
+      });
+      const group = new OlGroupLayer({
+        layers: [layer]
+      });
+      const wrapper = TestUtils.mountComponent(LayerTree, props);
+      const rebuildSpy = sinon.spy(wrapper.instance(), 'rebuildTreeNodes');
+      const registerSpy = sinon.spy(wrapper.instance(), 'registerAddRemoveListeners');
+
+      layerGroup.getLayers().push(group);
+      expect(rebuildSpy.callCount).to.equal(1);
+      expect(registerSpy.callCount).to.equal(1);
+
+      rebuildSpy.restore();
+      registerSpy.restore();
+    });
+
+    it('trigger unregisterEventsByLayer and rebuildTreeNodes for removed layers ', () => {
+      const props = {
+        layerGroup,
+        map
+      };
+      const wrapper = TestUtils.mountComponent(LayerTree, props);
+      const rebuildSpy = sinon.spy(wrapper.instance(), 'rebuildTreeNodes');
+      const unregisterSpy = sinon.spy(wrapper.instance(), 'unregisterEventsByLayer');
+
+      layerGroup.getLayers().remove(layer1);
+      expect(rebuildSpy.callCount).to.equal(1);
+      expect(unregisterSpy.callCount).to.equal(1);
+
+      rebuildSpy.restore();
+      unregisterSpy.restore();
+    });
+
+    it('… unregister recursively for removed groups', () => {
+      const props = {
+        layerGroup,
+        map
+      };
+      const subLayer1 = new OlTileLayer({
+        source: new OlTileWMS()
+      });
+      const subLayer2 = new OlTileLayer({
+        source: new OlTileWMS()
+      });
+      const nestedLayerGroup = new OlGroupLayer({
+        name: 'nestedLayerGroup',
+        layers: [subLayer1, subLayer2]
+      });
+      layerGroup.getLayers().push(nestedLayerGroup);
+
+      const wrapper = TestUtils.mountComponent(LayerTree, props);
+      const rebuildSpy = sinon.spy(wrapper.instance(), 'rebuildTreeNodes');
+      const unregisterSpy = sinon.spy(wrapper.instance(), 'unregisterEventsByLayer');
+
+      layerGroup.getLayers().remove(nestedLayerGroup);
+      expect(rebuildSpy.callCount).to.equal(1);
+      expect(unregisterSpy.callCount).to.equal(3);
+
+      rebuildSpy.restore();
+      unregisterSpy.restore();
+    });
+
+    describe('#unregisterEventsByLayer', () => {
+
+      it('removes the listener and the eventKey from olListenerKeys', () => {
+        const props = {
+          layerGroup,
+          map
+        };
+        const subLayer1 = new OlTileLayer({
+          source: new OlTileWMS()
+        });
+        const subLayer2 = new OlTileLayer({
+          source: new OlTileWMS()
+        });
+        const nestedLayerGroup = new OlGroupLayer({
+          name: 'nestedLayerGroup',
+          layers: [subLayer1, subLayer2]
+        });
+        layerGroup.getLayers().push(nestedLayerGroup);
+
+        const wrapper = TestUtils.mountComponent(LayerTree, props);
+        const oldOlListenerKey = wrapper.instance().olListenerKeys;
+        const unByKeySpy = sinon.spy(olObservable, 'unByKey');
+
+        wrapper.instance().unregisterEventsByLayer(subLayer1);
+
+        const newOlListenerKey = wrapper.instance().olListenerKeys;
+
+        expect(unByKeySpy.callCount).to.equal(1);
+        expect(newOlListenerKey.length).to.equal(oldOlListenerKey.length - 1);
+
+        unByKeySpy.restore();
+      });
+
+      it('… of children for groups', () => {
+        const props = {
+          layerGroup,
+          map
+        };
+        const subLayer1 = new OlTileLayer({
+          source: new OlTileWMS()
+        });
+        const subLayer2 = new OlTileLayer({
+          source: new OlTileWMS()
+        });
+        const nestedLayerGroup = new OlGroupLayer({
+          name: 'nestedLayerGroup',
+          layers: [subLayer1, subLayer2]
+        });
+        layerGroup.getLayers().push(nestedLayerGroup);
+
+        const wrapper = TestUtils.mountComponent(LayerTree, props);
+        const oldOlListenerKey = wrapper.instance().olListenerKeys;
+        const unByKeySpy = sinon.spy(olObservable, 'unByKey');
+
+        wrapper.instance().unregisterEventsByLayer(nestedLayerGroup);
+
+        const newOlListenerKey = wrapper.instance().olListenerKeys;
+
+        expect(unByKeySpy.callCount).to.equal(2);
+        expect(newOlListenerKey.length).to.equal(oldOlListenerKey.length - 2);
+
+        unByKeySpy.restore();
+      });
+
+    });
+
   });
 
-  describe('onDrop', () => {
+  describe('#setLayerVisibility', () => {
 
-    // TODO add test when bug in react-component/tree is fixed
+    it('logs an error if called with invalid arguments', () => {
+      const logSpy = sinon.spy(Logger, 'error');
+      const props = {
+        layerGroup,
+        map
+      };
+      const wrapper = TestUtils.mountComponent(LayerTree, props);
+
+      wrapper.instance().setLayerVisibility();
+      expect(logSpy.callCount).to.equal(1);
+      wrapper.instance().setLayerVisibility('peter');
+      expect(logSpy.callCount).to.equal(2);
+      wrapper.instance().setLayerVisibility(layer1 , 'peter');
+      expect(logSpy.callCount).to.equal(3);
+    });
+
+    it('sets the visibility of a single layer', () => {
+      const props = {
+        layerGroup,
+        map
+      };
+      const wrapper = TestUtils.mountComponent(LayerTree, props);
+      layer1.setVisible(true);
+
+      wrapper.instance().setLayerVisibility(layer1, false);
+      expect(layer1.getVisible()).to.be(false);
+      wrapper.instance().setLayerVisibility(layer1, true);
+      expect(layer1.getVisible()).to.be(true);
+    });
+
+    it('sets the visibility only for the children when called with a layerGroup', () => {
+      const props = {
+        layerGroup,
+        map
+      };
+      const wrapper = TestUtils.mountComponent(LayerTree, props);
+      layer1.setVisible(true);
+      layer2.setVisible(true);
+
+      wrapper.instance().setLayerVisibility(layerGroup, false);
+      expect(layerGroup.getVisible()).to.be(true);
+      expect(layer1.getVisible()).to.be(false);
+      expect(layer2.getVisible()).to.be(false);
+
+      wrapper.instance().setLayerVisibility(layerGroup, true);
+      expect(layerGroup.getVisible()).to.be(true);
+      expect(layer1.getVisible()).to.be(true);
+      expect(layer2.getVisible()).to.be(true);
+    });
+
+  });
+
+  // TODO rc-tree drop event seems to be broken in PhantomJS / cant be simulated
+  describe('#onDrop', () => {
+
     // let props = {};
     //
     // beforeEach(() => {
@@ -193,14 +472,30 @@ describe('<LayerTree />', () => {
     // it('can handle drop on leaf', () => {
     //   const wrapper = TestUtils.mountComponent(LayerTree, props);
     //   const firstNode = wrapper.childAt(0);
-    //   const firstLayer = layerGroup.getLayers().item(0);
     //   const thirdNode = wrapper.childAt(2);
-    //   const thirdLayer = layerGroup.getLayers().item(2);
     //   const dragTarget = firstNode.find('.ant-tree-node-content-wrapper');
-    //   const dropTarget = thirdNode.find('.ant-tree-node-content-wrapper');
+    //   const dropTarget = thirdNode.find('.react-geo-layertree-node');
     //
+    //   console.log(props.layerGroup.getLayers().getLength());
+    //   console.log(props.layerGroup.getLayers().item(0).get('name'));
+    //   console.log(props.layerGroup.getLayers().item(1).get('name'));
+    //   console.log(props.layerGroup.getLayers().item(2).get('name'));
+    //   console.log(props.layerGroup.getLayers().item(3).get('name'));
+    //
+    //   debugger
+    //
+    //   console.log('--------');
     //   dragTarget.simulate('dragStart');
-    //   thirdNode.simulate('drop');
+    //   dropTarget.simulate('dragOver');
+    //   dropTarget.simulate('drop');
+    //
+    //   console.log(props.layerGroup.getLayers().getLength());
+    //   console.log(props.layerGroup.getLayers().item(0).get('name'));
+    //   console.log(props.layerGroup.getLayers().item(1).get('name'));
+    //   console.log(props.layerGroup.getLayers().item(2).get('name'));
+    //   console.log(props.layerGroup.getLayers().item(3).get('name'));
+    //
+    //
     // });
 
     // it('can handle drop before leaf', () => {
@@ -209,14 +504,14 @@ describe('<LayerTree />', () => {
     //   const firstNode = treeNodes.get(0);
     //   const thirdNode = treeNodes.get(2);
     // });
-
+    //
     // it('can handle drop after leaf', () => {
     //   const wrapper = TestUtils.mountComponent(LayerTree, props);
     //   const treeNodes = wrapper.children('TreeNode');
     //   const firstNode = treeNodes.get(0);
     //   const thirdNode = treeNodes.get(2);
     // });
-
+    //
     // it('can handle drop on folder', () => {
     //   const wrapper = TestUtils.mountComponent(LayerTree, props);
     //   const treeNodes = wrapper.children('TreeNode');

--- a/src/Util/MapUtil.js
+++ b/src/Util/MapUtil.js
@@ -244,7 +244,7 @@ export class MapUtil {
 
     if (layers.indexOf(layer) < 0) {
       layers.forEach((childLayer) => {
-        if (childLayer instanceof OlLayerGroup) {
+        if (childLayer instanceof OlLayerGroup && !info.groupLayer) {
           info = MapUtil.getLayerPositionInfo(layer, childLayer);
         }
       });


### PR DESCRIPTION
- Adds `visibility:change` listeners to layers in tree
- Adds `add` and `remove` listeners to grouplayers in tree
- Fixes the drag and drop behaviour

OT:
- Adds optional filter to  `MapUtil.getAllLayers`
