### PR TITLE
Update several dependencies and package-lock.json

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-- node
+- 8.4.0 # to work around https://github.com/jsdoc3/jsdoc/issues/1438
 before_install:
 - npm install -g greenkeeper-lockfile@1
 before_script:

--- a/package-lock.json
+++ b/package-lock.json
@@ -174,9 +174,9 @@
       "dev": true
     },
     "antd": {
-      "version": "2.13.0",
-      "resolved": "http://10.133.7.204:4873/antd/-/antd-2.13.0.tgz",
-      "integrity": "sha512-rTkVATLi2LK9lveXEq0hfeTgMvhQl37byjpxNXkQclqven3lzj2NfBOU004ziRs8w9+Wx8A9YzL8qWPFVELErg==",
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/antd/-/antd-2.13.1.tgz",
+      "integrity": "sha1-nAmu3wei0b3THA1pgi+eMsn3M4Y=",
       "requires": {
         "array-tree-filter": "1.0.1",
         "babel-runtime": "6.26.0",
@@ -200,14 +200,14 @@
         "rc-input-number": "3.6.7",
         "rc-menu": "5.0.11",
         "rc-notification": "2.0.5",
-        "rc-pagination": "1.12.4",
+        "rc-pagination": "1.12.6",
         "rc-progress": "2.2.2",
         "rc-rate": "2.1.1",
         "rc-select": "6.9.1",
         "rc-slider": "8.2.0",
         "rc-steps": "2.5.1",
         "rc-switch": "1.5.2",
-        "rc-table": "5.6.5",
+        "rc-table": "5.6.7",
         "rc-tabs": "9.1.4",
         "rc-time-picker": "2.4.1",
         "rc-tooltip": "3.4.8",
@@ -221,54 +221,28 @@
         "warning": "3.0.0"
       },
       "dependencies": {
-        "rc-pagination": {
-          "version": "1.12.4",
-          "resolved": "http://10.133.7.204:4873/rc-pagination/-/rc-pagination-1.12.4.tgz",
-          "integrity": "sha512-rwMK6rbiM0FBr3QY5MR9PHUJ0liR9jmP5t7rw3PmHIo9JT5GiISb9Txz8W/owHKHSpOKZO4HRpQj9knSXK2JCA==",
+        "rc-table": {
+          "version": "5.6.7",
+          "resolved": "https://registry.npmjs.org/rc-table/-/rc-table-5.6.7.tgz",
+          "integrity": "sha512-MJERM1L86d7RFCBQc0Xird+3+A+ng3sJ1K93sIVExiIAXR10L6pw6WsRv3i4PrxrMs2L7V393MmtCR3j+z9EyQ==",
           "requires": {
             "babel-runtime": "6.26.0",
-            "prop-types": "15.5.10"
-          }
-        },
-        "rc-select": {
-          "version": "6.9.1",
-          "resolved": "http://10.133.7.204:4873/rc-select/-/rc-select-6.9.1.tgz",
-          "integrity": "sha512-c9rqCH+jZgoueR+bOT0UXD7PlPVCTyK4ULXKtveJCpsh5YJrn/Vu+xrjpCWijI629ddMJYLcmIyvJc9/fGvaeA==",
-          "requires": {
-            "babel-runtime": "6.26.0",
-            "classnames": "2.2.5",
             "component-classes": "1.2.6",
-            "dom-scroll-into-view": "1.2.1",
+            "lodash.get": "4.4.2",
             "prop-types": "15.5.10",
-            "rc-animate": "2.4.1",
-            "rc-menu": "5.0.11",
-            "rc-trigger": "1.11.3",
             "rc-util": "4.0.4",
-            "warning": "2.1.0"
+            "shallowequal": "0.2.2",
+            "warning": "3.0.0"
           },
           "dependencies": {
-            "warning": {
-              "version": "2.1.0",
-              "resolved": "http://10.133.7.204:4873/warning/-/warning-2.1.0.tgz",
-              "integrity": "sha1-ISINnGOvx3qMkhEeARr3Bc4MaQE=",
+            "shallowequal": {
+              "version": "0.2.2",
+              "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-0.2.2.tgz",
+              "integrity": "sha1-HjL9W8q2rWiKSBLLDMBO/HXHAU4=",
               "requires": {
-                "loose-envify": "1.3.1"
+                "lodash.keys": "3.1.2"
               }
             }
-          }
-        },
-        "react-slick": {
-          "version": "0.15.4",
-          "resolved": "http://10.133.7.204:4873/react-slick/-/react-slick-0.15.4.tgz",
-          "integrity": "sha512-RXKA8V6NmpTz6Ngo3XB5dg4GrGwDln89j5uG9Z4NXOedlVCzfG3LcHBVC5Pqs411Arbcp8nlzcg39g+rT6OPHw==",
-          "requires": {
-            "can-use-dom": "0.1.0",
-            "classnames": "2.2.5",
-            "create-react-class": "15.6.0",
-            "enquire.js": "2.1.6",
-            "json2mq": "0.2.0",
-            "object-assign": "4.1.1",
-            "slick-carousel": "1.7.1"
           }
         }
       }
@@ -553,15 +527,151 @@
       }
     },
     "babel-eslint": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-7.2.3.tgz",
-      "integrity": "sha1-sv4tgBJkcPXBlELcdXJTqJdxCCc=",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-8.0.0.tgz",
+      "integrity": "sha512-tN1B3adZ3tw8pr9oGsZ18iKCbdKBSvsn9ab6cGdbED+61LpGLhIVcf76eh59XejbdRLTBe+OYezxmYIaTgPiYA==",
       "dev": true,
       "requires": {
-        "babel-code-frame": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0"
+        "babel-code-frame": "7.0.0-beta.0",
+        "babel-traverse": "7.0.0-beta.0",
+        "babel-types": "7.0.0-beta.0",
+        "babylon": "7.0.0-beta.22"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.0"
+          }
+        },
+        "babel-code-frame": {
+          "version": "7.0.0-beta.0",
+          "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-7.0.0-beta.0.tgz",
+          "integrity": "sha512-/xr1ADm5bnTjjN+xwoXb7lF4v2rnxMzNZzFU7h8SxB+qB6+IqSTOOqVcpaPTUC2Non/MbQxS3OIZnJpQ2X21aQ==",
+          "dev": true,
+          "requires": {
+            "chalk": "2.1.0",
+            "esutils": "2.0.2",
+            "js-tokens": "3.0.2"
+          }
+        },
+        "babel-helper-function-name": {
+          "version": "7.0.0-beta.0",
+          "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-7.0.0-beta.0.tgz",
+          "integrity": "sha512-DaQccFBBWBEzMdqbKmNXamY0m1yLHJGOdbbEsNoGdJrrU7wAF3wwowtDDPzF0ZT3SqJXPgZW/P2kgBX9moMuAA==",
+          "dev": true,
+          "requires": {
+            "babel-helper-get-function-arity": "7.0.0-beta.0",
+            "babel-template": "7.0.0-beta.0",
+            "babel-traverse": "7.0.0-beta.0",
+            "babel-types": "7.0.0-beta.0"
+          }
+        },
+        "babel-helper-get-function-arity": {
+          "version": "7.0.0-beta.0",
+          "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-7.0.0-beta.0.tgz",
+          "integrity": "sha512-csqAic15/2Vm1951nJxkkL9K8E6ojyNF/eAOjk7pqJlO8kvgrccGNFCV9eDwcGHDPe5AjvJGwVSAcQ5fit9wuA==",
+          "dev": true,
+          "requires": {
+            "babel-types": "7.0.0-beta.0"
+          }
+        },
+        "babel-messages": {
+          "version": "7.0.0-beta.0",
+          "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-7.0.0-beta.0.tgz",
+          "integrity": "sha512-eXdShsm9ZTh9AQhlIaAn6HR3xWpxCnK9ZwIDA9QyjnwTgMctGxHHflw4b4RJ3/ZjTL0Vrmvm0tQXPkp49mTAUw==",
+          "dev": true
+        },
+        "babel-template": {
+          "version": "7.0.0-beta.0",
+          "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-7.0.0-beta.0.tgz",
+          "integrity": "sha512-tmdH+MmmU0F6Ur8humpevSmFzYKbrN3Oru0g5Qyg4R6+sxjnzZmnvzUbsP0aKMr7tB0Ua6xhEb9arKTOsEMkyA==",
+          "dev": true,
+          "requires": {
+            "babel-traverse": "7.0.0-beta.0",
+            "babel-types": "7.0.0-beta.0",
+            "babylon": "7.0.0-beta.22",
+            "lodash": "4.17.4"
+          }
+        },
+        "babel-traverse": {
+          "version": "7.0.0-beta.0",
+          "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-7.0.0-beta.0.tgz",
+          "integrity": "sha512-IKzuTqUcQtMRZ0Vv5RjIrGGj33eBKmNTNeRexWSyjPPuAciyNkva1rt7WXPfHfkb+dX7coRAIUhzeTUEzhnwdA==",
+          "dev": true,
+          "requires": {
+            "babel-code-frame": "7.0.0-beta.0",
+            "babel-helper-function-name": "7.0.0-beta.0",
+            "babel-messages": "7.0.0-beta.0",
+            "babel-types": "7.0.0-beta.0",
+            "babylon": "7.0.0-beta.22",
+            "debug": "3.0.1",
+            "globals": "10.1.0",
+            "invariant": "2.2.2",
+            "lodash": "4.17.4"
+          }
+        },
+        "babel-types": {
+          "version": "7.0.0-beta.0",
+          "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-7.0.0-beta.0.tgz",
+          "integrity": "sha512-rJc2kV9iPJGLlqIY71AM3nPcdkoeLRCDuR07GFgfd3lFl4TsBQq76TxYQQIZ2MONg1HpsqmuoCXr9aZ1Oa4wYw==",
+          "dev": true,
+          "requires": {
+            "esutils": "2.0.2",
+            "lodash": "4.17.4",
+            "to-fast-properties": "2.0.0"
+          }
+        },
+        "babylon": {
+          "version": "7.0.0-beta.22",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.22.tgz",
+          "integrity": "sha512-Yl7iT8QGrS8OfR7p6R12AJexQm+brKwrryai4VWZ7NHUbPoZ5al3+klhvl/14shXZiLa7uK//OIFuZ1/RKHgoA==",
+          "dev": true
+        },
+        "chalk": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
+          "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.4.0"
+          }
+        },
+        "debug": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.0.1.tgz",
+          "integrity": "sha512-6nVc6S36qbt/mutyt+UGMnawAMrPDZUPQjRZI3FS9tCtDRhvxJbK79unYBLPi+z5SLXQ3ftoVBFCblQtNSls8w==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "globals": {
+          "version": "10.1.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-10.1.0.tgz",
+          "integrity": "sha1-RCWhiBvg0za0qCOoKnvnJdXdmHw=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
+          "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        },
+        "to-fast-properties": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+          "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+          "dev": true
+        }
       }
     },
     "babel-generator": {
@@ -752,9 +862,9 @@
       }
     },
     "babel-loader": {
-      "version": "7.1.1",
-      "resolved": "http://10.133.7.204:4873/babel-loader/-/babel-loader-7.1.1.tgz",
-      "integrity": "sha1-uHE0yLEuPkwqlOBUYIW8aAorhIg=",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-7.1.2.tgz",
+      "integrity": "sha512-jRwlFbINAeyDStqK6Dd5YuY0k5YuzQUvlz2ZamuXrXmxav3pNqe9vfJ402+2G+OmlJSXxCOpB6Uz0INM7RQe2A==",
       "dev": true,
       "requires": {
         "find-cache-dir": "1.0.0",
@@ -1595,7 +1705,7 @@
         "decompress": "3.0.0",
         "download": "4.4.3",
         "exec-series": "1.0.3",
-        "rimraf": "2.6.1",
+        "rimraf": "2.6.2",
         "tempfile": "1.1.1",
         "url-regex": "3.2.0"
       },
@@ -2252,7 +2362,7 @@
             "jsonfile": "2.4.0",
             "klaw": "1.3.1",
             "path-is-absolute": "1.0.1",
-            "rimraf": "2.6.1"
+            "rimraf": "2.6.2"
           }
         },
         "klaw": {
@@ -2550,29 +2660,6 @@
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
     },
-    "cosmiconfig": {
-      "version": "2.2.2",
-      "resolved": "http://10.133.7.204:4873/cosmiconfig/-/cosmiconfig-2.2.2.tgz",
-      "integrity": "sha512-GiNXLwAFPYHy25XmTPpafYvn3CLAkJ8FLsscq78MQd1Kh0OU6Yzhn4eV2MVF4G9WEQZoWEGltatdR+ntGPMl5A==",
-      "dev": true,
-      "requires": {
-        "is-directory": "0.3.1",
-        "js-yaml": "3.6.1",
-        "minimist": "1.2.0",
-        "object-assign": "4.1.1",
-        "os-homedir": "1.0.2",
-        "parse-json": "2.2.0",
-        "require-from-string": "1.2.1"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "http://10.133.7.204:4873/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
-        }
-      }
-    },
     "coveralls": {
       "version": "2.13.1",
       "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-2.13.1.tgz",
@@ -2703,9 +2790,9 @@
       "dev": true
     },
     "css-loader": {
-      "version": "0.28.4",
-      "resolved": "http://10.133.7.204:4873/css-loader/-/css-loader-0.28.4.tgz",
-      "integrity": "sha1-bPNXkZLONV6LONX0Ldeh8uyJjQ8=",
+      "version": "0.28.7",
+      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-0.28.7.tgz",
+      "integrity": "sha512-GxMpax8a/VgcfRrVy0gXD6yLd5ePYbXX/5zGgTVYp4wXtJklS8Z2VaUArJgc//f6/Dzil7BaJObdSv8eKKCPgg==",
       "dev": true,
       "requires": {
         "babel-code-frame": "6.26.0",
@@ -2721,15 +2808,7 @@
         "postcss-modules-scope": "1.1.0",
         "postcss-modules-values": "1.3.0",
         "postcss-value-parser": "3.3.0",
-        "source-list-map": "0.1.8"
-      },
-      "dependencies": {
-        "source-list-map": {
-          "version": "0.1.8",
-          "resolved": "http://10.133.7.204:4873/source-list-map/-/source-list-map-0.1.8.tgz",
-          "integrity": "sha1-xVCyq1Qn9rPyH1r+rYjE9Vh7IQY=",
-          "dev": true
-        }
+        "source-list-map": "2.0.0"
       }
     },
     "css-select": {
@@ -2856,6 +2935,17 @@
       "resolved": "https://registry.npmjs.org/custom-event/-/custom-event-1.0.1.tgz",
       "integrity": "sha1-XQKkaFCt8bSjF5RqOSj8y1v9BCU=",
       "dev": true
+    },
+    "cwebp-bin": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/cwebp-bin/-/cwebp-bin-3.2.0.tgz",
+      "integrity": "sha1-rgLfRT2MFTQbHY1JmlImvPO/Sm8=",
+      "dev": true,
+      "requires": {
+        "bin-build": "2.2.0",
+        "bin-wrapper": "3.0.2",
+        "logalot": "2.1.0"
+      }
     },
     "d": {
       "version": "1.0.0",
@@ -3119,7 +3209,7 @@
         "object-assign": "4.1.1",
         "pify": "2.3.0",
         "pinkie-promise": "2.0.1",
-        "rimraf": "2.6.1"
+        "rimraf": "2.6.2"
       }
     },
     "delayed-stream": {
@@ -4024,7 +4114,7 @@
         "execa": "0.7.0",
         "p-finally": "1.0.0",
         "pify": "3.0.0",
-        "rimraf": "2.6.1",
+        "rimraf": "2.6.2",
         "tempfile": "2.0.0"
       },
       "dependencies": {
@@ -5159,6 +5249,12 @@
         "sntp": "1.0.9"
       }
     },
+    "he": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+      "dev": true
+    },
     "hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
@@ -5395,9 +5491,9 @@
       "optional": true
     },
     "image-webpack-loader": {
-      "version": "3.3.1",
-      "resolved": "http://10.133.7.204:4873/image-webpack-loader/-/image-webpack-loader-3.3.1.tgz",
-      "integrity": "sha1-0tcr4CT4l15IyYTyQBwMSEiXy9M=",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/image-webpack-loader/-/image-webpack-loader-3.4.2.tgz",
+      "integrity": "sha512-Y0FbngBbdzXNBfUtecoCs62Ow7ggeIAmhCVqzV6+SK+W4Wi4ZPkn8q/N4JvVQnA1EUq17KW9PzBRvSwYVQsSYA==",
       "dev": true,
       "requires": {
         "imagemin": "5.3.1",
@@ -5406,6 +5502,7 @@
         "imagemin-optipng": "5.2.1",
         "imagemin-pngquant": "5.0.1",
         "imagemin-svgo": "5.2.2",
+        "imagemin-webp": "4.0.0",
         "loader-utils": "1.1.0",
         "object-assign": "4.1.1"
       }
@@ -5491,6 +5588,17 @@
       "requires": {
         "is-svg": "2.1.0",
         "svgo": "0.7.2"
+      }
+    },
+    "imagemin-webp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/imagemin-webp/-/imagemin-webp-4.0.0.tgz",
+      "integrity": "sha1-osrzK19SrSG5Sab+2O/JAdr3JJ0=",
+      "dev": true,
+      "requires": {
+        "cwebp-bin": "3.2.0",
+        "exec-buffer": "3.2.0",
+        "is-cwebp-readable": "1.0.3"
       }
     },
     "immutable": {
@@ -5752,6 +5860,23 @@
       "integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI=",
       "dev": true
     },
+    "is-cwebp-readable": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-cwebp-readable/-/is-cwebp-readable-1.0.3.tgz",
+      "integrity": "sha1-mo/eK+1380F66TcSWMWOLsMoURg=",
+      "dev": true,
+      "requires": {
+        "file-type": "3.9.0"
+      },
+      "dependencies": {
+        "file-type": {
+          "version": "3.9.0",
+          "resolved": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
+          "integrity": "sha1-JXoHg4TR24CHvESdEH1SpSZyuek=",
+          "dev": true
+        }
+      }
+    },
     "is-date-object": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
@@ -5762,12 +5887,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.1.tgz",
       "integrity": "sha1-9ftqlJlq2ejjdh+/vQkfH8qMToI=",
-      "dev": true
-    },
-    "is-directory": {
-      "version": "0.3.1",
-      "resolved": "http://10.133.7.204:4873/is-directory/-/is-directory-0.3.1.tgz",
-      "integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=",
       "dev": true
     },
     "is-dotfile": {
@@ -6396,7 +6515,7 @@
         "optimist": "0.6.1",
         "qjobs": "1.1.5",
         "range-parser": "1.2.0",
-        "rimraf": "2.6.1",
+        "rimraf": "2.6.2",
         "safe-buffer": "5.1.1",
         "socket.io": "1.7.3",
         "source-map": "0.5.7",
@@ -7119,9 +7238,9 @@
       }
     },
     "loglevel": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.4.1.tgz",
-      "integrity": "sha1-lbOD+Ro8J1b9SrCTZn5DCRYfK80="
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.5.0.tgz",
+      "integrity": "sha512-OQ2jhWI5G2qsvO0UFNyCQWgKl/tFiwuPIXxELzACeUO2FqstN/R7mmL09+nhv6xOWVPPojQO1A90sCEoJSgBcQ=="
     },
     "lolex": {
       "version": "2.1.2",
@@ -7324,7 +7443,7 @@
         "is": "3.2.1",
         "is-utf8": "0.2.1",
         "recursive-readdir": "2.2.1",
-        "rimraf": "2.6.1",
+        "rimraf": "2.6.2",
         "stat-mode": "0.2.2",
         "thunkify": "2.1.2",
         "unyield": "0.0.1",
@@ -7486,9 +7605,9 @@
       }
     },
     "mocha": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.5.0.tgz",
-      "integrity": "sha1-EyhWfScX+ZcDD4AGI0vOm4zXJGU=",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.5.3.tgz",
+      "integrity": "sha512-/6na001MJWEtYxHOV1WLfsmR4YIynkUEhBwzsb+fk2qmQ3iqsi258l/Q2MWHJMImAcNpZ8DEdYAK72NHoIQ9Eg==",
       "dev": true,
       "requires": {
         "browser-stdout": "1.3.0",
@@ -7498,6 +7617,7 @@
         "escape-string-regexp": "1.0.5",
         "glob": "7.1.1",
         "growl": "1.9.2",
+        "he": "1.1.1",
         "json3": "3.3.2",
         "lodash.create": "3.1.1",
         "mkdirp": "0.5.1",
@@ -8603,92 +8723,6 @@
         "uniqid": "4.1.1"
       }
     },
-    "postcss-load-config": {
-      "version": "1.2.0",
-      "resolved": "http://10.133.7.204:4873/postcss-load-config/-/postcss-load-config-1.2.0.tgz",
-      "integrity": "sha1-U56a/J3chiASHr+djDZz4M5Q0oo=",
-      "dev": true,
-      "requires": {
-        "cosmiconfig": "2.2.2",
-        "object-assign": "4.1.1",
-        "postcss-load-options": "1.2.0",
-        "postcss-load-plugins": "2.3.0"
-      }
-    },
-    "postcss-load-options": {
-      "version": "1.2.0",
-      "resolved": "http://10.133.7.204:4873/postcss-load-options/-/postcss-load-options-1.2.0.tgz",
-      "integrity": "sha1-sJixVZ3awt8EvAuzdfmaXP4rbYw=",
-      "dev": true,
-      "requires": {
-        "cosmiconfig": "2.2.2",
-        "object-assign": "4.1.1"
-      }
-    },
-    "postcss-load-plugins": {
-      "version": "2.3.0",
-      "resolved": "http://10.133.7.204:4873/postcss-load-plugins/-/postcss-load-plugins-2.3.0.tgz",
-      "integrity": "sha1-dFdoEWWZrKLwCfrUJrABdQSdjZI=",
-      "dev": true,
-      "requires": {
-        "cosmiconfig": "2.2.2",
-        "object-assign": "4.1.1"
-      }
-    },
-    "postcss-loader": {
-      "version": "2.0.6",
-      "resolved": "http://10.133.7.204:4873/postcss-loader/-/postcss-loader-2.0.6.tgz",
-      "integrity": "sha512-HIq7yy1hh9KI472Y38iSRV4WupZUNy6zObkxQM/ZuInoaE2+PyX4NcO6jjP5HG5mXL7j5kcNEl0fAG4Kva7O9w==",
-      "dev": true,
-      "requires": {
-        "loader-utils": "1.1.0",
-        "postcss": "6.0.11",
-        "postcss-load-config": "1.2.0",
-        "schema-utils": "0.3.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "3.2.0",
-          "resolved": "http://10.133.7.204:4873/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-          "dev": true,
-          "requires": {
-            "color-convert": "1.9.0"
-          }
-        },
-        "chalk": {
-          "version": "2.1.0",
-          "resolved": "http://10.133.7.204:4873/chalk/-/chalk-2.1.0.tgz",
-          "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "3.2.0",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "4.4.0"
-          }
-        },
-        "postcss": {
-          "version": "6.0.11",
-          "resolved": "http://10.133.7.204:4873/postcss/-/postcss-6.0.11.tgz",
-          "integrity": "sha512-DsnIzznNRQprsGTALpkC0xjDygo+QcOd+qVjP9+RjyzrPiyYOXBGOwoJ4rAiiE4lu6JggQ/jW4niY24WLxuncg==",
-          "dev": true,
-          "requires": {
-            "chalk": "2.1.0",
-            "source-map": "0.5.7",
-            "supports-color": "4.4.0"
-          }
-        },
-        "supports-color": {
-          "version": "4.4.0",
-          "resolved": "http://10.133.7.204:4873/supports-color/-/supports-color-4.4.0.tgz",
-          "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
-          "dev": true,
-          "requires": {
-            "has-flag": "2.0.0"
-          }
-        }
-      }
-    },
     "postcss-merge-idents": {
       "version": "2.1.7",
       "resolved": "https://registry.npmjs.org/postcss-merge-idents/-/postcss-merge-idents-2.1.7.tgz",
@@ -9528,6 +9562,15 @@
         "rc-util": "4.0.4"
       }
     },
+    "rc-pagination": {
+      "version": "1.12.6",
+      "resolved": "https://registry.npmjs.org/rc-pagination/-/rc-pagination-1.12.6.tgz",
+      "integrity": "sha512-cYZLucn2ngLn+XOpneADewBerJOqDSOEx0mU5Wbsx1wP0r8qE0c7cpP+G4qJ8NUHKSn9s2QJNHvakH6k1Zi41g==",
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "prop-types": "15.5.10"
+      }
+    },
     "rc-progress": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/rc-progress/-/rc-progress-2.2.2.tgz",
@@ -9544,6 +9587,33 @@
       "requires": {
         "classnames": "2.2.5",
         "prop-types": "15.5.10"
+      }
+    },
+    "rc-select": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/rc-select/-/rc-select-6.9.1.tgz",
+      "integrity": "sha512-c9rqCH+jZgoueR+bOT0UXD7PlPVCTyK4ULXKtveJCpsh5YJrn/Vu+xrjpCWijI629ddMJYLcmIyvJc9/fGvaeA==",
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "classnames": "2.2.5",
+        "component-classes": "1.2.6",
+        "dom-scroll-into-view": "1.2.1",
+        "prop-types": "15.5.10",
+        "rc-animate": "2.4.1",
+        "rc-menu": "5.0.11",
+        "rc-trigger": "1.11.3",
+        "rc-util": "4.0.4",
+        "warning": "2.1.0"
+      },
+      "dependencies": {
+        "warning": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/warning/-/warning-2.1.0.tgz",
+          "integrity": "sha1-ISINnGOvx3qMkhEeARr3Bc4MaQE=",
+          "requires": {
+            "loose-envify": "1.3.1"
+          }
+        }
       }
     },
     "rc-slider": {
@@ -9578,30 +9648,6 @@
         "babel-runtime": "6.26.0",
         "classnames": "2.2.5",
         "prop-types": "15.5.10"
-      }
-    },
-    "rc-table": {
-      "version": "5.6.5",
-      "resolved": "https://registry.npmjs.org/rc-table/-/rc-table-5.6.5.tgz",
-      "integrity": "sha512-Z0Fp1SlQU4Z695vpfnWU7xy7UdtpyZE3FfZuolXV47zp4N91AjDS5QQ8iF5K9eCnv+eOQXC7Ob4JkKYvJ3/Pxg==",
-      "requires": {
-        "babel-runtime": "6.26.0",
-        "component-classes": "1.2.6",
-        "lodash.get": "4.4.2",
-        "prop-types": "15.5.10",
-        "rc-util": "4.0.4",
-        "shallowequal": "0.2.2",
-        "warning": "3.0.0"
-      },
-      "dependencies": {
-        "shallowequal": {
-          "version": "0.2.2",
-          "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-0.2.2.tgz",
-          "integrity": "sha1-HjL9W8q2rWiKSBLLDMBO/HXHAU4=",
-          "requires": {
-            "lodash.keys": "3.1.2"
-          }
-        }
       }
     },
     "rc-tabs": {
@@ -9731,17 +9777,10 @@
         }
       }
     },
-    "react": {
-      "version": "15.6.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-15.6.1.tgz",
-      "integrity": "sha1-uqhDTsZ4C96ZfNw4C3nNM7ljk98=",
-      "requires": {
-        "create-react-class": "15.6.0",
-        "fbjs": "0.8.14",
-        "loose-envify": "1.3.1",
-        "object-assign": "4.1.1",
-        "prop-types": "15.5.10"
-      }
+    "re-resizable": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/re-resizable/-/re-resizable-3.0.0.tgz",
+      "integrity": "sha1-t55RXQTTvckhKs7NAHXjF2zjU9M="
     },
     "react-dom": {
       "version": "15.6.1",
@@ -9773,9 +9812,9 @@
       }
     },
     "react-i18next": {
-      "version": "5.2.0",
-      "resolved": "http://10.133.7.204:4873/react-i18next/-/react-i18next-5.2.0.tgz",
-      "integrity": "sha1-z+3DSbNoYOJhB3zKevR5SQewoS8=",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-5.3.0.tgz",
+      "integrity": "sha512-jdGkABorSHqEbtgPxTmIWoY9jKoF6NzQ6z3Elopa1DtShpGPjWOQmBMrkAV2CR66j2ucLWCh2QbXjOvfUfZmnQ==",
       "requires": {
         "hoist-non-react-statics": "1.2.0"
       }
@@ -9791,18 +9830,27 @@
         "prop-types": "15.5.10"
       }
     },
-    "react-resizable-box": {
-      "version": "2.1.0",
-      "resolved": "http://10.133.7.204:4873/react-resizable-box/-/react-resizable-box-2.1.0.tgz",
-      "integrity": "sha1-i7oIG1rb4q8L5HaMTx3mqEpCOq0="
-    },
     "react-rnd": {
-      "version": "5.1.2",
-      "resolved": "http://10.133.7.204:4873/react-rnd/-/react-rnd-5.1.2.tgz",
-      "integrity": "sha1-Ztgoyr7tTAHdLx9Czg+x0Zs7rNo=",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/react-rnd/-/react-rnd-7.0.0.tgz",
+      "integrity": "sha512-LzmmRP0Jk0oXK8opEYlQZRi7II057Dz46WlvDOpwb8uttQj15QAy3+6v9V7nlqO+e8hKL63dZOocpautaXKKgA==",
       "requires": {
-        "react-draggable": "3.0.3",
-        "react-resizable-box": "2.1.0"
+        "re-resizable": "3.0.0",
+        "react-draggable": "3.0.3"
+      }
+    },
+    "react-slick": {
+      "version": "0.15.4",
+      "resolved": "https://registry.npmjs.org/react-slick/-/react-slick-0.15.4.tgz",
+      "integrity": "sha512-RXKA8V6NmpTz6Ngo3XB5dg4GrGwDln89j5uG9Z4NXOedlVCzfG3LcHBVC5Pqs411Arbcp8nlzcg39g+rT6OPHw==",
+      "requires": {
+        "can-use-dom": "0.1.0",
+        "classnames": "2.2.5",
+        "create-react-class": "15.6.0",
+        "enquire.js": "2.1.6",
+        "json2mq": "0.2.0",
+        "object-assign": "4.1.1",
+        "slick-carousel": "1.7.1"
       }
     },
     "react-test-renderer": {
@@ -10141,12 +10189,6 @@
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
       "dev": true
     },
-    "require-from-string": {
-      "version": "1.2.1",
-      "resolved": "http://10.133.7.204:4873/require-from-string/-/require-from-string-1.2.1.tgz",
-      "integrity": "sha1-UpyczvJzgK3+yaL5ZbZJu+5jZBg=",
-      "dev": true
-    },
     "require-main-filename": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
@@ -10166,8 +10208,7 @@
     "requires-port": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
-      "dev": true
+      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
     },
     "requizzle": {
       "version": "0.2.1",
@@ -10229,9 +10270,9 @@
       }
     },
     "rimraf": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
-      "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "dev": true,
       "requires": {
         "glob": "7.1.2"
@@ -11642,7 +11683,6 @@
       "version": "1.1.9",
       "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.1.9.tgz",
       "integrity": "sha1-xn8dd11R8KGJEd17P/rSe7nlvRk=",
-      "dev": true,
       "requires": {
         "querystringify": "1.0.0",
         "requires-port": "1.0.0"
@@ -11651,8 +11691,7 @@
         "querystringify": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-1.0.0.tgz",
-          "integrity": "sha1-YoYkIRLFtxL6ZU5SZlK/ahP/Bcs=",
-          "dev": true
+          "integrity": "sha1-YoYkIRLFtxL6ZU5SZlK/ahP/Bcs="
         }
       }
     },
@@ -11936,9 +11975,9 @@
       }
     },
     "webpack": {
-      "version": "3.5.5",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-3.5.5.tgz",
-      "integrity": "sha1-Mibwn8iz5DX/eB5680+CtosmmWw=",
+      "version": "3.5.6",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-3.5.6.tgz",
+      "integrity": "sha512-sXnxfx6KoZVrFAGLjdhCCwDtDwkYMfwm8mJjkQv3thr5pjTlbxopVlr/kJwc9Bz317gL+gNjvz++ir9TgG1MDg==",
       "dev": true,
       "requires": {
         "acorn": "5.1.1",
@@ -11974,7 +12013,7 @@
         "async": {
           "version": "2.5.0",
           "resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
-          "integrity": "sha1-hDGQ/WtzV6C54clW7d3V7IRitU0=",
+          "integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
           "dev": true,
           "requires": {
             "lodash": "4.17.4"
@@ -12070,7 +12109,7 @@
         "supports-color": {
           "version": "4.4.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
-          "integrity": "sha1-iD992rwWUUKyphQn8zUt7RldGj4=",
+          "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
           "dev": true,
           "requires": {
             "has-flag": "2.0.0"
@@ -12129,7 +12168,7 @@
         "http-proxy-middleware": "0.17.4",
         "internal-ip": "1.2.0",
         "ip": "1.1.5",
-        "loglevel": "1.4.1",
+        "loglevel": "1.5.0",
         "opn": "4.0.2",
         "portfinder": "1.0.13",
         "selfsigned": "1.10.1",
@@ -12171,7 +12210,7 @@
             "is-path-in-cwd": "1.0.0",
             "p-map": "1.1.1",
             "pify": "3.0.0",
-            "rimraf": "2.6.1"
+            "rimraf": "2.6.2"
           }
         },
         "globby": {

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "prop-types": "15.5.10",
     "react-dom": "15.6.1",
     "react-fa": "4.2.0",
-    "react-i18next": "5.2.0",
+    "react-i18next": "5.3.0",
     "react-rnd": "7.0.0",
     "url-parse": "1.1.9"
   },

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "react-dom": "15.6.1",
     "react-fa": "4.2.0",
     "react-i18next": "5.2.0",
-    "react-rnd": "5.1.2",
+    "react-rnd": "7.0.0",
     "url-parse": "1.1.9"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "antd": "2.13.1",
     "i18next": "9.0.0",
     "lodash": "4.17.4",
-    "loglevel": "1.4.1",
+    "loglevel": "1.5.0",
     "ol": "4.3.2",
     "prop-types": "15.5.10",
     "react-dom": "15.6.1",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
   "devDependencies": {
     "babel-cli": "6.26.0",
     "babel-core": "6.26.0",
-    "babel-eslint": "7.2.3",
+    "babel-eslint": "8.0.0",
     "babel-loader": "7.1.2",
     "babel-plugin-import": "1.4.0",
     "babel-plugin-istanbul": "4.1.4",

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "metalsmith-layouts": "1.8.1",
     "metalsmith-markdown": "0.2.1",
     "minami": "1.2.3",
-    "mocha": "3.5.1",
+    "mocha": "3.5.3",
     "react-test-renderer": "15.6.1",
     "rimraf": "2.6.2",
     "sinon": "3.2.1",

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "minami": "1.2.3",
     "mocha": "3.5.1",
     "react-test-renderer": "15.6.1",
-    "rimraf": "2.6.1",
+    "rimraf": "2.6.2",
     "sinon": "3.2.1",
     "style-loader": "0.18.2",
     "url-loader": "0.5.9",


### PR DESCRIPTION
This updates the following dependencies:

* Update `rimraf` to v2.6.2
* Update `react-rnd` to v7.0.0
* Update `react-i18next` to v5.3.0
* Update `mocha` to v3.5.3
* Update `loglevel` to v1.5.0
* Update `babel-eslint` to v8.0.0

And also adds a current `package-lock.json`.

* Closes #43
* Closes #44 
* Closes #45
* Closes #46 
* Closes #48 
* Closes #49

The build failures are related to https://github.com/jsdoc3/jsdoc/issues/1438, where jsdoc cannot copy files as it used to copy due to using a native node method introduced in Node.js 8.5.0 which behaves differently than their fallback. To work around this, the travis configuration is changed to build on Node.JS v8.4.0 (d530a7d9c35eb15be19606bab8390d8a7d5fe4ca).
