### PR TITLE
Use latest Node.js

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-- 8.4.0 # to work around https://github.com/jsdoc3/jsdoc/issues/1438
+- "8"
 before_install:
 - npm install -g greenkeeper-lockfile@1
 before_script:


### PR DESCRIPTION
Basicaly reverts d530a7d9c35eb15be19606bab8390d8a7d5fe4ca and uses the latest Node.js 8.x when building on Travis.

Please review.