### PR TITLE
Harmonize named imports

### DIFF
--- a/src/LayerTree/LayerTree.example.jsx
+++ b/src/LayerTree/LayerTree.example.jsx
@@ -3,10 +3,10 @@ import { render } from 'react-dom';
 
 import OlMap from 'ol/map';
 import OlView from 'ol/view';
-import OlGroupLayer from 'ol/layer/group';
-import OlTileLayer from 'ol/layer/tile';
-import OlTileJsonSource from 'ol/source/tilejson';
-import OlOsmSource from 'ol/source/osm';
+import OlLayerGroup from 'ol/layer/group';
+import OlLayerTile from 'ol/layer/tile';
+import OlSourceTileJson from 'ol/source/tilejson';
+import OlSourceOsm from 'ol/source/osm';
 import olProj from 'ol/proj';
 
 import LayerTree from './LayerTree.jsx'; //@react-geo@
@@ -15,19 +15,19 @@ import LayerTree from './LayerTree.jsx'; //@react-geo@
 //
 // ***************************** SETUP *****************************************
 //
-const layerGroup = new OlGroupLayer({
+const layerGroup = new OlLayerGroup({
   name: 'Layergroup',
   layers: [
-    new OlTileLayer({
+    new OlLayerTile({
       name: 'Food insecurity layer',
-      source: new OlTileJsonSource({
+      source: new OlSourceTileJson({
         url: 'https://api.tiles.mapbox.com/v3/mapbox.20110804-hoa-foodinsecurity-3month.json?secure',
         crossOrigin: 'anonymous'
       })
     }),
-    new OlTileLayer({
+    new OlLayerTile({
       name: 'World borders layer',
-      source: new OlTileJsonSource({
+      source: new OlSourceTileJson({
         url: 'https://api.tiles.mapbox.com/v3/mapbox.world-borders-light.json?secure',
         crossOrigin: 'anonymous'
       })
@@ -37,9 +37,9 @@ const layerGroup = new OlGroupLayer({
 
 const map = new OlMap({
   layers: [
-    new OlTileLayer({
+    new OlLayerTile({
       name: 'OSM',
-      source: new OlOsmSource()
+      source: new OlSourceOsm()
     }),
     layerGroup
   ],

--- a/src/LayerTree/LayerTree.jsx
+++ b/src/LayerTree/LayerTree.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { isEqual, isBoolean } from 'lodash';
 import { Tree } from 'antd';
 import OlLayerBase from 'ol/layer/base';
-import OlGroupLayer from 'ol/layer/group';
+import OlLayerGroup from 'ol/layer/group';
 import olObservable from 'ol/observable';
 
 import Logger from '../Util/Logger';
@@ -35,7 +35,7 @@ class LayerTree extends React.Component {
   static propTypes = {
     draggable: PropTypes.bool,
 
-    layerGroup: PropTypes.instanceOf(OlGroupLayer),
+    layerGroup: PropTypes.instanceOf(OlLayerGroup),
 
     map: PropTypes.object
   }
@@ -130,7 +130,7 @@ class LayerTree extends React.Component {
     this.olListenerKeys.push(addEvtKey, removeEvtKey);
 
     collection.forEach((layer) => {
-      if (layer instanceof OlGroupLayer) {
+      if (layer instanceof OlLayerGroup) {
         this.registerAddRemoveListeners(layer);
       }
     });
@@ -144,7 +144,7 @@ class LayerTree extends React.Component {
    * @param {ol.Collection.Event} evt The add event.
    */
   onCollectionAdd = (evt) => {
-    if (evt.element instanceof OlGroupLayer) {
+    if (evt.element instanceof OlLayerGroup) {
       this.registerAddRemoveListeners(evt.element);
     }
     this.rebuildTreeNodes();
@@ -158,7 +158,7 @@ class LayerTree extends React.Component {
    */
   onCollectionRemove = (evt) => {
     this.unregisterEventsByLayer(evt.element);
-    if (evt.element instanceof OlGroupLayer) {
+    if (evt.element instanceof OlLayerGroup) {
       evt.element.getLayers().forEach((layer) => {
         this.unregisterEventsByLayer(layer);
       });
@@ -173,7 +173,7 @@ class LayerTree extends React.Component {
    */
   unregisterEventsByLayer = (layer) => {
     this.olListenerKeys = this.olListenerKeys.filter((key) => {
-      if (layer instanceof OlGroupLayer) {
+      if (layer instanceof OlLayerGroup) {
         const layers = layer.getLayers();
         if (key.target === layers) {
           if ((key.type === 'add' && key.listener === this.onCollectionAdd) ||
@@ -214,7 +214,7 @@ class LayerTree extends React.Component {
     let childNodes;
     let treeNode;
 
-    if (layer instanceof OlGroupLayer) {
+    if (layer instanceof OlLayerGroup) {
       if (!layer.getVisible()) {
         Logger.warn('Your map configuration contains layerGroups that are' +
         'invisible. This might lead to buggy behaviour.');
@@ -278,7 +278,7 @@ class LayerTree extends React.Component {
    */
   getVisibleOlUids = () => {
     const layers = MapUtil.getAllLayers(this.state.layerGroup, (layer) => {
-      return !(layer instanceof OlGroupLayer) && layer.getVisible();
+      return !(layer instanceof OlLayerGroup) && layer.getVisible();
     });
     return layers.map(l => l.ol_uid.toString());
   }
@@ -308,7 +308,7 @@ class LayerTree extends React.Component {
       Logger.error('setLayerVisibility called without layer or visiblity.');
       return;
     }
-    if (layer instanceof OlGroupLayer) {
+    if (layer instanceof OlLayerGroup) {
       layer.getLayers().forEach((subLayer) => {
         this.setLayerVisibility(subLayer, visiblity);
       });
@@ -346,7 +346,7 @@ class LayerTree extends React.Component {
       }
     // drop on node
     } else if (location === 0) {
-      if (dropLayer instanceof OlGroupLayer) {
+      if (dropLayer instanceof OlLayerGroup) {
         dropLayer.getLayers().push(dragLayer);
       } else {
         dropCollection.insertAt(dropPosition + 1, dragLayer);

--- a/src/LayerTree/LayerTree.spec.jsx
+++ b/src/LayerTree/LayerTree.spec.jsx
@@ -2,9 +2,9 @@
 import expect from 'expect.js';
 import sinon from 'sinon';
 
-import OlGroupLayer from 'ol/layer/group';
-import OlTileLayer from 'ol/layer/tile';
-import OlTileWMS from 'ol/source/tilewms';
+import OlLayerGroup from 'ol/layer/group';
+import OlLayerTile from 'ol/layer/tile';
+import OlSourceTileWMS from 'ol/source/tilewms';
 import olObservable from 'ol/observable';
 
 import TestUtil from '../Util/TestUtil';
@@ -21,18 +21,18 @@ describe('<LayerTree />', () => {
   let layer2;
 
   beforeEach(() => {
-    const layerSource1 = new OlTileWMS();
-    layer1 = new OlTileLayer({
+    const layerSource1 = new OlSourceTileWMS();
+    layer1 = new OlLayerTile({
       name: 'layer1',
       source: layerSource1
     });
-    const layerSource2 = new OlTileWMS();
-    layer2 = new OlTileLayer({
+    const layerSource2 = new OlSourceTileWMS();
+    layer2 = new OlLayerTile({
       name: 'layer2',
       visible: false,
       source: layerSource2
     });
-    layerGroup = new OlGroupLayer({
+    layerGroup = new OlLayerGroup({
       name: 'layerGroup',
       layers: [layer1, layer2]
     });
@@ -68,11 +68,11 @@ describe('<LayerTree />', () => {
     };
     const wrapper = TestUtil.mountComponent(LayerTree, props);
 
-    const subLayer = new OlTileLayer({
+    const subLayer = new OlLayerTile({
       name: 'subLayer',
-      source: new OlTileWMS()
+      source: new OlSourceTileWMS()
     });
-    const nestedLayerGroup = new OlGroupLayer({
+    const nestedLayerGroup = new OlLayerGroup({
       name: 'nestedLayerGroup',
       layers: [subLayer]
     });
@@ -104,11 +104,11 @@ describe('<LayerTree />', () => {
         layerGroup,
         map
       };
-      const subLayer = new OlTileLayer({
+      const subLayer = new OlLayerTile({
         name: 'subLayer',
-        source: new OlTileWMS()
+        source: new OlSourceTileWMS()
       });
-      const nestedLayerGroup = new OlGroupLayer({
+      const nestedLayerGroup = new OlLayerGroup({
         name: 'nestedLayerGroup',
         layers: [subLayer]
       });
@@ -242,8 +242,8 @@ describe('<LayerTree />', () => {
         layerGroup,
         map
       };
-      const layer = new OlTileLayer({
-        source: new OlTileWMS()
+      const layer = new OlLayerTile({
+        source: new OlSourceTileWMS()
       });
       const wrapper = TestUtil.mountComponent(LayerTree, props);
       const rebuildSpy = sinon.spy(wrapper.instance(), 'rebuildTreeNodes');
@@ -259,10 +259,10 @@ describe('<LayerTree />', () => {
         layerGroup,
         map
       };
-      const layer = new OlTileLayer({
-        source: new OlTileWMS()
+      const layer = new OlLayerTile({
+        source: new OlSourceTileWMS()
       });
-      const group = new OlGroupLayer({
+      const group = new OlLayerGroup({
         layers: [layer]
       });
       const wrapper = TestUtil.mountComponent(LayerTree, props);
@@ -299,13 +299,13 @@ describe('<LayerTree />', () => {
         layerGroup,
         map
       };
-      const subLayer1 = new OlTileLayer({
-        source: new OlTileWMS()
+      const subLayer1 = new OlLayerTile({
+        source: new OlSourceTileWMS()
       });
-      const subLayer2 = new OlTileLayer({
-        source: new OlTileWMS()
+      const subLayer2 = new OlLayerTile({
+        source: new OlSourceTileWMS()
       });
-      const nestedLayerGroup = new OlGroupLayer({
+      const nestedLayerGroup = new OlLayerGroup({
         name: 'nestedLayerGroup',
         layers: [subLayer1, subLayer2]
       });
@@ -330,13 +330,13 @@ describe('<LayerTree />', () => {
           layerGroup,
           map
         };
-        const subLayer1 = new OlTileLayer({
-          source: new OlTileWMS()
+        const subLayer1 = new OlLayerTile({
+          source: new OlSourceTileWMS()
         });
-        const subLayer2 = new OlTileLayer({
-          source: new OlTileWMS()
+        const subLayer2 = new OlLayerTile({
+          source: new OlSourceTileWMS()
         });
-        const nestedLayerGroup = new OlGroupLayer({
+        const nestedLayerGroup = new OlLayerGroup({
           name: 'nestedLayerGroup',
           layers: [subLayer1, subLayer2]
         });
@@ -361,13 +361,13 @@ describe('<LayerTree />', () => {
           layerGroup,
           map
         };
-        const subLayer1 = new OlTileLayer({
-          source: new OlTileWMS()
+        const subLayer1 = new OlLayerTile({
+          source: new OlSourceTileWMS()
         });
-        const subLayer2 = new OlTileLayer({
-          source: new OlTileWMS()
+        const subLayer2 = new OlLayerTile({
+          source: new OlSourceTileWMS()
         });
-        const nestedLayerGroup = new OlGroupLayer({
+        const nestedLayerGroup = new OlLayerGroup({
           name: 'nestedLayerGroup',
           layers: [subLayer1, subLayer2]
         });
@@ -455,15 +455,15 @@ describe('<LayerTree />', () => {
     //     layerGroup,
     //     map
     //   };
-    //   const layer3 = new OlTileLayer({
+    //   const layer3 = new OlLayerTile({
     //     name: 'layer3',
-    //     source: new OlTileWMS()
+    //     source: new OlSourceTileWMS()
     //   });
-    //   const subLayer = new OlTileLayer({
+    //   const subLayer = new OlLayerTile({
     //     name: 'subLayer',
-    //     source: new OlTileWMS()
+    //     source: new OlSourceTileWMS()
     //   });
-    //   const nestedLayerGroup = new OlGroupLayer({
+    //   const nestedLayerGroup = new OlLayerGroup({
     //     name: 'nestedLayerGroup',
     //     layers: [subLayer]
     //   });

--- a/src/Legend/Legend.spec.jsx
+++ b/src/Legend/Legend.spec.jsx
@@ -1,10 +1,9 @@
 /*eslint-env mocha*/
 import expect from 'expect.js';
-// import sinon from 'sinon';
 
-import OlTileLayer from 'ol/layer/tile';
+import OlLayerTile from 'ol/layer/tile';
 import OlSourceTileWMS from 'ol/source/tilewms';
-import OlTileJsonSource from 'ol/source/tilejson';
+import OlSourceTileJson from 'ol/source/tilejson';
 
 import TestUtil from '../Util/TestUtil';
 
@@ -18,7 +17,7 @@ describe('<Legend />', () => {
   let layer2;
 
   beforeEach(() => {
-    layer1 = new OlTileLayer({
+    layer1 = new OlLayerTile({
       name: 'OSM-WMS',
       source: new OlSourceTileWMS({
         url: 'https://ows.terrestris.de/osm/service',
@@ -26,10 +25,10 @@ describe('<Legend />', () => {
         serverType: 'geoserver'
       })
     });
-    layer2 = new OlTileLayer({
+    layer2 = new OlLayerTile({
       legendUrl: 'http://www.koeln.de/files/images/Karnevalstrikot_Spieler_270.jpg',
       name: 'Food insecurity',
-      source: new OlTileJsonSource({
+      source: new OlSourceTileJson({
         url: 'https://api.tiles.mapbox.com/v3/mapbox.20110804-hoa-foodinsecurity-3month.json?secure',
         crossOrigin: 'anonymous'
       })

--- a/src/Map/ScaleCombo/ScaleCombo.example.jsx
+++ b/src/Map/ScaleCombo/ScaleCombo.example.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render } from 'react-dom';
 
-import MapUtils from '../../Util/MapUtil'; //@react-geo@
+import MapUtil from '../../Util/MapUtil'; //@react-geo@
 import ScaleCombo from './ScaleCombo.jsx'; //@react-geo@
 
 let scaleCombo;
@@ -24,7 +24,7 @@ __EXAMPLE_MAP__.on('moveend', function(evt) {
  **/
 var onZoomLevelSelect = (selectedScale) => {
   let mv = __EXAMPLE_MAP__.getView();
-  let calculatedResolution = MapUtils.getResolutionForScale(selectedScale, mv.getProjection().getUnits());
+  let calculatedResolution = MapUtil.getResolutionForScale(selectedScale, mv.getProjection().getUnits());
   mv.setResolution(calculatedResolution);
 };
 

--- a/src/Util/MapUtil.spec.js
+++ b/src/Util/MapUtil.spec.js
@@ -1,10 +1,10 @@
 /*eslint-env mocha*/
 import expect from 'expect.js';
-import OlDragRotateAndZoom from 'ol/interaction/dragrotateandzoom';
-import OlDraw from 'ol/interaction/draw';
+import OlInteractionDragRotateAndZoom from 'ol/interaction/dragrotateandzoom';
+import OlInteractionDraw from 'ol/interaction/draw';
 import OlLayerTile from 'ol/layer/tile';
 import OlSourceTileWMS from 'ol/source/tilewms';
-import OlTileJsonSource from 'ol/source/tilejson';
+import OlSourceTileJson from 'ol/source/tilejson';
 import OlFeature from 'ol/feature';
 import OlGeomPoint from 'ol/geom/point';
 import OlLayerGroup from 'ol/layer/group';
@@ -59,7 +59,7 @@ describe('MapUtil', () => {
 
     it('returns an empty array if no interaction candidate is found', () => {
       let dragInteractionName = 'Drag Queen';
-      let dragInteraction = new OlDragRotateAndZoom();
+      let dragInteraction = new OlInteractionDragRotateAndZoom();
       dragInteraction.set('name', dragInteractionName);
       map.addInteraction(dragInteraction);
 
@@ -71,7 +71,7 @@ describe('MapUtil', () => {
 
     it('returns the requested interactions by name', () => {
       let dragInteractionName = 'Drag Queen';
-      let dragInteraction = new OlDragRotateAndZoom();
+      let dragInteraction = new OlInteractionDragRotateAndZoom();
       dragInteraction.set('name', dragInteractionName);
       map.addInteraction(dragInteraction);
 
@@ -80,7 +80,7 @@ describe('MapUtil', () => {
 
       expect(returnedInteractions).to.have.length(1);
 
-      let anotherDragInteraction = new OlDragRotateAndZoom();
+      let anotherDragInteraction = new OlInteractionDragRotateAndZoom();
       anotherDragInteraction.set('name', dragInteractionName);
       map.addInteraction(anotherDragInteraction);
 
@@ -99,7 +99,7 @@ describe('MapUtil', () => {
     it('needs to be called with a map instance', () => {
       const logSpy = sinon.spy(Logger, 'debug');
 
-      let returnedInteractions = MapUtil.getInteractionsByClass(null, OlDragRotateAndZoom);
+      let returnedInteractions = MapUtil.getInteractionsByClass(null, OlInteractionDragRotateAndZoom);
 
       expect(logSpy).to.have.property('callCount', 1);
       expect(returnedInteractions).to.have.length(0);
@@ -108,29 +108,29 @@ describe('MapUtil', () => {
     });
 
     it('returns an empty array if no interaction candidate is found', () => {
-      let dragInteraction = new OlDragRotateAndZoom();
+      let dragInteraction = new OlInteractionDragRotateAndZoom();
       map.addInteraction(dragInteraction);
 
       let returnedInteractions = MapUtil.getInteractionsByClass(
-        map, OlDraw);
+        map, OlInteractionDraw);
 
       expect(returnedInteractions).to.have.length(0);
     });
 
     it('returns the requested interactions by class', () => {
-      let dragInteraction = new OlDragRotateAndZoom();
+      let dragInteraction = new OlInteractionDragRotateAndZoom();
       map.addInteraction(dragInteraction);
 
       let returnedInteractions = MapUtil.getInteractionsByClass(
-        map, OlDragRotateAndZoom);
+        map, OlInteractionDragRotateAndZoom);
 
       expect(returnedInteractions).to.have.length(1);
 
-      let anotherDragInteraction = new OlDragRotateAndZoom();
+      let anotherDragInteraction = new OlInteractionDragRotateAndZoom();
       map.addInteraction(anotherDragInteraction);
 
       returnedInteractions = MapUtil.getInteractionsByClass(
-        map, OlDragRotateAndZoom);
+        map, OlInteractionDragRotateAndZoom);
 
       expect(returnedInteractions).to.have.length(2);
     });
@@ -455,7 +455,7 @@ describe('MapUtil', () => {
       });
       layer2 = new OlLayerTile({
         name: 'Food insecurity',
-        source: new OlTileJsonSource({
+        source: new OlSourceTileJson({
           url: 'https://api.tiles.mapbox.com/v3/mapbox.20110804-hoa-foodinsecurity-3month.json?secure',
           crossOrigin: 'anonymous'
         })

--- a/src/Util/TestUtil.js
+++ b/src/Util/TestUtil.js
@@ -5,7 +5,7 @@ import OlView from 'ol/view';
 import OlMap from 'ol/map';
 import OlSourceVector from 'ol/source/vector';
 import OlLayerVector from 'ol/layer/vector';
-import OlPointerEvent from 'ol/pointer/pointerevent';
+import OlPointerPointerEvent from 'ol/pointer/pointerevent';
 import OlMapBrowserPointerEvent from 'ol/mapbrowserpointerevent';
 
 /**
@@ -122,7 +122,7 @@ export class TestUtil {
     // Calculated in case body has top < 0 (test runner with small window).
     let position = viewport.getBoundingClientRect();
     let shiftKey = opt_shiftKey !== undefined ? opt_shiftKey : false;
-    let event = new OlPointerEvent(type, {
+    let event = new OlPointerPointerEvent(type, {
       clientX: position.left + x + TestUtil.mapDivWidth / 2,
       clientY: position.top + y + TestUtil.mapDivHeight / 2,
       shiftKey: shiftKey


### PR DESCRIPTION
This PR suggests to harmonize our imports, so that we have more confidence whether a class we import from 'ol/layer/group'  has to be referred to as `OlLayerGroup` or OlGroupLayer`, for example.

Please review.

Fixes #57 