### PR TITLE
Introduces unified css-className for current classes

### DIFF
--- a/src/Button/SimpleButton/SimpleButton.jsx
+++ b/src/Button/SimpleButton/SimpleButton.jsx
@@ -19,10 +19,22 @@ import './SimpleButton.less';
 class SimpleButton extends React.Component {
 
   /**
+   * The className added to this component.
+   * @type {String}
+   * @private
+   */
+  className = 'react-geo-simplebutton'
+
+  /**
    * The properties.
    * @type {Object}
    */
   static propTypes = {
+    /**
+     * The className which should be added.
+     * @type {String}
+     */
+    className: PropTypes.string,
     icon: PropTypes.string,
     fontIcon: PropTypes.string,
     shape: PropTypes.string,
@@ -75,8 +87,13 @@ class SimpleButton extends React.Component {
       tooltipPlacement,
       icon,
       fontIcon,
+      className,
       ...antBtnProps
     } = this.props;
+
+    const finalClassName = className
+      ? `${className} ${this.className}`
+      : this.className;
 
     return (
       <Tooltip
@@ -84,7 +101,7 @@ class SimpleButton extends React.Component {
         placement={tooltipPlacement}
       >
         <Button
-          className="btn-simple"
+          className={finalClassName}
           onClick={this.onClick}
           {...antBtnProps}
         >

--- a/src/Button/SimpleButton/SimpleButton.less
+++ b/src/Button/SimpleButton/SimpleButton.less
@@ -1,6 +1,6 @@
 @import '../../style/variables.less';
 
-button.btn-simple {
+button.react-geo-simplebutton {
   color: #fff;
   background-color: @primary-color;
   border-color: @primary-color;

--- a/src/Button/ToggleButton/ToggleButton.jsx
+++ b/src/Button/ToggleButton/ToggleButton.jsx
@@ -19,6 +19,20 @@ import './ToggleButton.less';
  */
 class ToggleButton extends React.Component {
 
+
+  /**
+   * The className added to this component.
+   * @type {String}
+   * @private
+   */
+  className = 'react-geo-togglebutton'
+
+  /**
+   * The class to apply for a toggled/pressed button.
+   * @type {String}
+   */
+  pressedClass = 'btn-pressed';
+
   /**
    * The properties.
    * @type {Object}
@@ -67,12 +81,6 @@ class ToggleButton extends React.Component {
    */
   constructor(props) {
     super(props);
-
-    /**
-     * The class to apply for a toggled/pressed button.
-     * @type {String}
-     */
-    this.toggleClass = 'btn-pressed';
 
     if (!props.onToggle) {
       Logger.debug('No onToggle method given. Please provide it as ' +
@@ -126,11 +134,13 @@ class ToggleButton extends React.Component {
    * The render function.
    */
   render() {
-    const pressedClass = this.state.pressed ? ' ' + this.toggleClass : '';
-    const className = this.props.className ? ' ' + this.props.className : '';
     const iconName = this.state.pressed
       ? this.props.pressedIcon || this.props.icon
       : this.props.icon;
+    const className = this.props.className
+      ? `${this.props.className} ${this.className}`
+      : this.className;
+    const pressedClass = this.state.pressed ? ' ' + this.pressedClass : '';
 
     return (
       <Tooltip
@@ -143,7 +153,7 @@ class ToggleButton extends React.Component {
           size={this.props.size}
           disabled={this.props.disabled}
           onClick={this.onClick}
-          className={`btn-toggle${pressedClass}${className}`}
+          className={`${className}${pressedClass}`}
         >
           <Icon
             name={iconName}

--- a/src/Button/ToggleButton/ToggleButton.less
+++ b/src/Button/ToggleButton/ToggleButton.less
@@ -1,6 +1,6 @@
 @import '../../style/variables.less';
 
-button.btn-toggle {
+button.react-geo-togglebutton {
   color: #fff;
   background-color: @primary-color;
   border-color: darken(@component-background, 10);

--- a/src/Button/ToggleButton/ToggleButton.spec.jsx
+++ b/src/Button/ToggleButton/ToggleButton.spec.jsx
@@ -52,16 +52,16 @@ describe('<ToggleButton />', () => {
     const wrapper = TestUtil.mountComponent(ToggleButton, {
       onToggle: () => {}
     });
-    let toggleClass = wrapper.instance().toggleClass;
+    let pressedClass = wrapper.instance().pressedClass;
 
-    expect(toggleClass).to.be.a('string');
-    expect(wrapper.find(`button.${toggleClass}`).length).to.equal(0);
+    expect(pressedClass).to.be.a('string');
+    expect(wrapper.find(`button.${pressedClass}`).length).to.equal(0);
 
     wrapper.setProps({
       pressed: true
     });
 
-    expect(wrapper.find(`button.${toggleClass}`).length).to.equal(1);
+    expect(wrapper.find(`button.${pressedClass}`).length).to.equal(1);
   });
 
   it('warns if no toggle callback method is given', () => {

--- a/src/Button/ToggleGroup/ToggleGroup.jsx
+++ b/src/Button/ToggleGroup/ToggleGroup.jsx
@@ -12,11 +12,25 @@ import './ToggleGroup.less';
  */
 class ToggleGroup extends React.Component {
 
+
+  /**
+   * The className added to this component.
+   * @type {String}
+   * @private
+   */
+  className = 'react-geo-togglegroup'
+
   /**
    * The properties.
    * @type {Object}
    */
   static propTypes = {
+    /**
+     * The className which should be added.
+     * @type {String}
+     */
+    className: PropTypes.string,
+
     /**
      * The name of this group.
      * @type {String}
@@ -129,6 +143,12 @@ class ToggleGroup extends React.Component {
    */
   render() {
     const {orientation, children} = this.props;
+    const className = this.props.className
+      ? `${this.props.className} ${this.className}`
+      : this.className;
+    const orientationClass = (orientation === 'vertical')
+      ? 'vertical-toggle-group'
+      : 'horizontal-toggle-group';
 
     const childrenWithProps = React.Children.map(children,
       (child) => React.cloneElement(child, {
@@ -138,10 +158,7 @@ class ToggleGroup extends React.Component {
 
     return (
       <div
-        className={(orientation === 'vertical') ?
-          'vertical-toggle-group' :
-          'horizontal-toggle-group'
-        }
+        className={`${className} ${orientationClass}`}
       >
         {childrenWithProps}
       </div>

--- a/src/LayerTree/LayerTree.jsx
+++ b/src/LayerTree/LayerTree.jsx
@@ -22,6 +22,14 @@ class LayerTree extends React.Component {
 
 
   /**
+   * The className added to this component.
+   * @type {String}
+   * @private
+   */
+  className = 'react-geo-layertree'
+
+
+  /**
    *  An array of ol.EventsKey as returned by on() or once().
    * @type {Array<ol.EventsKey>}
    * @private
@@ -33,6 +41,12 @@ class LayerTree extends React.Component {
    * @type {Object}
    */
   static propTypes = {
+    /**
+     * The className which should be added.
+     * @type {String}
+     */
+    className: PropTypes.string,
+
     draggable: PropTypes.bool,
 
     layerGroup: PropTypes.instanceOf(OlGroupLayer),

--- a/src/Map/FloatingMapLogo/FloatingMapLogo.jsx
+++ b/src/Map/FloatingMapLogo/FloatingMapLogo.jsx
@@ -11,10 +11,23 @@ import './FloatingMapLogo.less';
 class FloatingMapLogo extends React.Component {
 
   /**
+   * The className added to this component.
+   * @type {String}
+   * @private
+   */
+  className = 'react-geo-floatingmaplogo'
+
+  /**
    * The properties.
    * @type {Object}
    */
   static propTypes = {
+    /**
+     * The className which should be added.
+     * @type {String}
+     */
+    className: PropTypes.string,
+
     /**
      * The imageSrc (required property).
      * @type {String}
@@ -57,8 +70,13 @@ class FloatingMapLogo extends React.Component {
       imageSrc,
       imageHeight,
       absolutelyPostioned,
+      className,
       style
     } = this.props;
+
+    const finalClassName = className
+      ? `${className} ${this.className}`
+      : this.className;
 
     if (absolutelyPostioned) {
       Object.assign(style, {'position': 'absolute'});
@@ -66,7 +84,7 @@ class FloatingMapLogo extends React.Component {
 
     return (
       <img
-        className="map-logo"
+        className={finalClassName}
         src={imageSrc}
         height={imageHeight}
         style={style}

--- a/src/Map/FloatingMapLogo/FloatingMapLogo.less
+++ b/src/Map/FloatingMapLogo/FloatingMapLogo.less
@@ -1,4 +1,4 @@
-.map-logo {
+.react-geo-floatingmaplogo {
   position: absolute;
   left: 5px;
   bottom: 5px;

--- a/src/Map/FloatingMapLogo/FloatingMapLogo.spec.jsx
+++ b/src/Map/FloatingMapLogo/FloatingMapLogo.spec.jsx
@@ -25,12 +25,12 @@ describe('<FloatingMapLogo />', () => {
 
   it('contains img element with predefined class', () => {
     let imageElement = wrapper.find('img');
-    expect(imageElement.node.className).to.be('map-logo');
+    expect(imageElement.node.className).to.be(wrapper.instance().className);
   });
 
   it('is not positioned absolutely by default', () => {
     let imageElement = wrapper.find('img');
-    expect(imageElement.node.className).to.be('map-logo');
+    expect(imageElement.node.className).to.be(wrapper.instance().className);
   });
 
   it('passes style prop', () => {
@@ -39,11 +39,14 @@ describe('<FloatingMapLogo />', () => {
       style: {
         backgroundColor: 'yellow',
         position: 'inherit'
-      }
+      },
+      className: 'peter'
     };
     wrapper = TestUtil.mountComponent(FloatingMapLogo, props);
     let imageElement = wrapper.find('img');
     expect(imageElement.node.style.backgroundColor).to.be('yellow');
+    expect(imageElement.node.className).to.contain(wrapper.instance().className);
+    expect(imageElement.node.className).to.contain('peter');
     expect(imageElement.node.style.position).to.be('inherit');
   });
 
@@ -57,7 +60,7 @@ describe('<FloatingMapLogo />', () => {
     };
     wrapper = TestUtil.mountComponent(FloatingMapLogo, props);
     let imageElement = wrapper.find('img');
-    expect(imageElement.node.className).to.be('map-logo');
+    expect(imageElement.node.className).to.be(wrapper.instance().className);
     expect(imageElement.node.style.position).to.be('absolute');
     expect(imageElement.node.style.backgroundColor).to.be('yellow');
   });

--- a/src/Map/ScaleCombo/ScaleCombo.jsx
+++ b/src/Map/ScaleCombo/ScaleCombo.jsx
@@ -15,7 +15,21 @@ import MapUtils from '../../Util/MapUtil';
  */
 class ScaleCombo extends React.Component {
 
+
+  /**
+   * The className added to this component.
+   * @type {String}
+   * @private
+   */
+  className = 'react-geo-scalecombo'
+
   static propTypes = {
+    /**
+     * The className which should be added.
+     * @type {String}
+     */
+    className: PropTypes.string,
+
     /**
      * The zoomLevel.
      * @type {Number}
@@ -193,26 +207,30 @@ class ScaleCombo extends React.Component {
    * The render function.
    */
   render() {
-    let {
+    const {
       onZoomLevelSelect,
-      style
+      style,
+      className
     } = this.props;
 
+    const finalClassName = className
+      ? `${className} ${this.className}`
+      : this.className;
+
     return (
-      <div>
-        <Select
-          showSearch
-          onChange={onZoomLevelSelect}
-          getInputElement={this.getInputElement}
-          filterOption={false}
-          value={this.determineOptionKeyForZoomLevel(this.state.zoomLevel)}
-          size="small"
-          style={style}
-          className = "scale-select"
-        >
-          {this.state.scales}
-        </Select>
-      </div>);
+      <Select
+        showSearch
+        onChange={onZoomLevelSelect}
+        getInputElement={this.getInputElement}
+        filterOption={false}
+        value={this.determineOptionKeyForZoomLevel(this.state.zoomLevel)}
+        size="small"
+        style={style}
+        className={finalClassName}
+      >
+        {this.state.scales}
+      </Select>
+    );
   }
 }
 

--- a/src/Map/ScaleCombo/ScaleCombo.spec.jsx
+++ b/src/Map/ScaleCombo/ScaleCombo.spec.jsx
@@ -40,7 +40,7 @@ describe('<ScaleCombo />', () => {
       }
     };
     const wrapper = TestUtil.mountComponent(ScaleCombo, props);
-    expect(wrapper.find('div.scale-select').node.style.backgroundColor).to.be('yellow');
+    expect(wrapper.props().style.backgroundColor).to.be('yellow');
   });
 
   describe('#getOptionsFromMap', () => {

--- a/src/Panel/Panel/Panel.jsx
+++ b/src/Panel/Panel/Panel.jsx
@@ -39,6 +39,13 @@ const defaultWindowProps = {
 export class Panel extends React.Component {
 
   /**
+   * The className added to this component.
+   * @type {String}
+   * @private
+   */
+  className = 'react-geo-panel'
+
+  /**
    * The properties.
    * @type {Object}
    */
@@ -235,7 +242,11 @@ export class Panel extends React.Component {
       ...rndOpts
     } = this.props;
 
-    const rndClassName = `panel ${this.state.id} ${className}`;
+    const finalClassName = className
+      ? `${className} ${this.className}`
+      : this.className;
+
+    const rndClassName = `${finalClassName} ${this.state.id}`;
     const disableDragging = !draggable;
     const enableResizing = resizeOpts === true ? undefined : resizeOpts;
 
@@ -290,7 +301,7 @@ export class Panel extends React.Component {
         dragHandlerClassName=".drag-handle"
         disableDragging={disableDragging}
         enableResizing={enableResizing}
-        resizeHandlerClasses={{
+        resizeHandleClasses={{
           bottom: 'resize-handle resize-handle-bottom',
           bottomLeft: 'resize-handle resize-handle-bottom-left',
           bottomRight: 'resize-handle resize-handle-bottom-right',

--- a/src/Panel/Panel/Panel.less
+++ b/src/Panel/Panel/Panel.less
@@ -2,7 +2,7 @@
 
 @handlestyle: 5px solid fade(@primary-color, 50%);
 
-.panel {
+.react-geo-panel {
   z-index: 100;
 
   .body {

--- a/src/Panel/Titlebar/Titlebar.jsx
+++ b/src/Panel/Titlebar/Titlebar.jsx
@@ -12,6 +12,13 @@ import './Titlebar.less';
 export class Titlebar extends React.Component {
 
   /**
+   * The className added to this component.
+   * @type {String}
+   * @private
+   */
+  className = 'react-geo-titlebar'
+
+  /**
    * The properties.
    * @type {Object}
    */
@@ -76,14 +83,17 @@ export class Titlebar extends React.Component {
    * The render function.
    */
   render() {
-    let {
+    const {
       className,
       tools
     } = this.props;
-    className = className ? className + ' titlebar' : 'titlebar';
+
+    const finalClassName = className
+      ? `${className} ${this.className}`
+      : this.className;
 
     return (
-      <div className={className}>
+      <div className={finalClassName}>
         <span className="title">
           {this.props.children}
         </span>

--- a/src/Panel/Titlebar/Titlebar.less
+++ b/src/Panel/Titlebar/Titlebar.less
@@ -1,6 +1,6 @@
 @import '../../style/variables.less';
 
-.titlebar {
+.react-geo-titlebar {
   overflow: auto;
   background-color: darken(@component-background, 10);
   color: @primary-color;

--- a/src/Toolbar/Toolbar.jsx
+++ b/src/Toolbar/Toolbar.jsx
@@ -13,10 +13,24 @@ import './Toolbar.less';
 class Toolbar extends React.Component {
 
   /**
+   * The className added to this component.
+   * @type {String}
+   * @private
+   */
+  className = 'react-geo-toolbar'
+
+  /**
    * The properties.
    * @type {Object}
    */
   static propTypes = {
+
+    /**
+     * The className which should be added.
+     * @type {String}
+     */
+    className: PropTypes.string,
+
     /**
      * The children.
      * @type {Array}
@@ -49,9 +63,17 @@ class Toolbar extends React.Component {
    * The render function
    */
   render() {
-    const {style} = this.props;
+    const {
+      style,
+      className
+    } = this.props;
+
+    const finalClassName = className
+      ? `${className} ${this.className}`
+      : this.className;
+
     return (
-      <div className={this.props.alignment + '-toolbar'} style={style}>
+      <div className={`${finalClassName} ${this.props.alignment}-toolbar`} style={style}>
         {this.props.children}
       </div>
     );

--- a/src/UserChip/UserChip.jsx
+++ b/src/UserChip/UserChip.jsx
@@ -12,7 +12,20 @@ import './UserChip.less';
  */
 class UserChip extends React.Component {
 
+  /**
+   * The className added to this component.
+   * @type {String}
+   * @private
+   */
+  className = 'react-geo-userchip'
+
   static propTypes = {
+    /**
+     * The className which should be added.
+     * @type {String}
+     */
+    className: PropTypes.string,
+
     /**
      * The user aname.
      * @type {String}
@@ -81,8 +94,18 @@ class UserChip extends React.Component {
    * @return {type} Description
    */
   getUserMenu() {
-    return <div className="userchip" style={this.props.style}>
-      <Avatar src={this.props.imageSrc} size="large" className="userimage"> {this.props.imageSrc ? '' : this.getInitials()} </Avatar>
+
+    const className = this.props.className
+      ? `${this.props.className} ${this.className}`
+      : this.className;
+
+    return <div className={className} style={this.props.style}>
+      <Avatar
+        src={this.props.imageSrc}
+        size="large"
+        className="userimage">
+        {this.props.imageSrc ? '' : this.getInitials()}
+      </Avatar>
       <span className="username">{this.props.userName}</span>
     </div>;
   }
@@ -91,9 +114,16 @@ class UserChip extends React.Component {
    * The render function
    */
   render() {
+
     if (this.props.userMenu && React.isValidElement(this.props.userMenu)) {
       return (
-        <Dropdown overlay={this.props.userMenu} trigger={['click']} getPopupContainer={() => document.getElementsByClassName('userchip')[0]}>
+        <Dropdown
+          overlay={this.props.userMenu}
+          trigger={['click']}
+          getPopupContainer={() => {
+            return document.getElementsByClassName('userchip')[0];
+          }}
+        >
           {this.getUserMenu()}
         </Dropdown>
       );

--- a/src/UserChip/UserChip.less
+++ b/src/UserChip/UserChip.less
@@ -1,4 +1,4 @@
-.userchip {
+.react-geo-userchip {
   display: flex;
   justify-content: center;
   align-items: center;
@@ -6,8 +6,5 @@
 
   .username {
     margin-left: 5px;
-  }
-
-  .userimage {
   }
 }

--- a/src/UserChip/UserChip.spec.jsx
+++ b/src/UserChip/UserChip.spec.jsx
@@ -52,8 +52,9 @@ describe('<UserChip />', () => {
         'backgroundColor': 'yellow'
       }
     };
-    const wrapper =TestUtil.mountComponent(UserChip, props);
-    expect(wrapper.find('div.userchip').node.style.backgroundColor).to.be('yellow');
+    const wrapper = TestUtil.mountComponent(UserChip, props);
+    const className = wrapper.instance().className;
+    expect(wrapper.find(`div.${className}`).node.style.backgroundColor).to.be('yellow');
   });
 
 });


### PR DESCRIPTION
This introduces a private `className` property and `className` as a react-property for all components.

The pattern of the components className is like: `react-geo-{class}`

A optional className from props will be added to the class to.

closes #57 