### PR TITLE
Adjust babel import plugin to import LESS styles

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -24,9 +24,11 @@
     }
   },
   "plugins": [
-    ["import", {
-      "libraryName": "antd",
-      "style": "css"
-    }]
+    [
+      "import", {
+        "libraryName": "antd",
+        "style": true
+      }
+    ]
   ]
 }


### PR DESCRIPTION
This adjusts the `babel-plugin-import` configuration to import all `antd` style definitions via less instead of  css. From the official documentation:

Before:

```js
import { Button } from 'antd';
ReactDOM.render(<Button>xxxx</Button>);

      ↓ ↓ ↓ ↓ ↓ ↓
      
var _button = require('antd/lib/button');
require('antd/lib/button/style/css');
ReactDOM.render(<_button>xxxx</_button>);
```

Now:

```js
import { Button } from 'antd';
ReactDOM.render(<Button>xxxx</Button>);

      ↓ ↓ ↓ ↓ ↓ ↓
      
var _button = require('antd/lib/button');
require('antd/lib/button/style');
ReactDOM.render(<_button>xxxx</_button>);
```

Having this set, all modify variables an application might set, will be directly applied to all `antd` components wrapped by `react-geo`.