### PR TITLE
LayerTree extensions

### DIFF
--- a/src/LayerTree/LayerTree.jsx
+++ b/src/LayerTree/LayerTree.jsx
@@ -402,9 +402,16 @@ class LayerTree extends React.Component {
    * The render function.
    */
   render() {
-    const props = {...this.props};
+    const {
+      className,
+      draggable,
+      layerGroup,
+      map,
+      ...passThroughProps
+    } = this.props;
+
     let ddListeners;
-    if (props.draggable) {
+    if (draggable) {
       ddListeners = {
         onDragStart: this.onDragStart,
         onDragEnter: this.onDragEnter,
@@ -415,13 +422,18 @@ class LayerTree extends React.Component {
       };
     }
 
+    const finalClassName = className
+      ? `${className} ${this.className}`
+      : this.className;
+
     return (
       <Tree
+        className={finalClassName}
         checkable
-        {...ddListeners}
-        {...props}
         checkedKeys={this.state.checkedKeys}
         onCheck={this.onCheck}
+        {...ddListeners}
+        {...passThroughProps}
       >
         {this.state.treeNodes}
       </Tree>

--- a/src/LayerTree/LayerTree.jsx
+++ b/src/LayerTree/LayerTree.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { isEqual, isBoolean } from 'lodash';
+import { isEqual, isBoolean, isFunction } from 'lodash';
 import { Tree } from 'antd';
 import OlLayerBase from 'ol/layer/base';
 import OlLayerGroup from 'ol/layer/group';
@@ -51,7 +51,15 @@ class LayerTree extends React.Component {
 
     layerGroup: PropTypes.instanceOf(OlLayerGroup),
 
-    map: PropTypes.object
+    map: PropTypes.object,
+
+    /**
+     * A function that can be used to pass a custom node title. It can return
+     * any renderable element (String, Number, Element etc.) and receives
+     * the layer instance of the current tree node.
+     * @type {Function}
+     */
+    nodeTitleRenderer: PropTypes.func
   }
 
   /**
@@ -219,10 +227,27 @@ class LayerTree extends React.Component {
   }
 
   /**
+   * Returns the title to render in the LayerTreeNode. If a nodeTitleRenderer
+   * has been passed as prop, it will be called and the (custom) return value
+   * will be rendered. Note: This can be any renderable element collection! If
+   * no function is given (the default) the layer name will be passed.
+   *
+   * @param {ol.layer.Base} layer The layer attached to the tree node.
+   * @return {Element} The title composition to render.
+   */
+  getTreeNodeTitle(layer) {
+    if (isFunction(this.props.nodeTitleRenderer)) {
+      return this.props.nodeTitleRenderer.call(this, layer);
+    } else {
+      return layer.get('name');
+    }
+  }
+
+  /**
    * Creates a treeNode from a given layer.
    *
-   * @param {ol.layer.Layer} layer The given layer.
-   * @return {TreeNode} The corresponding TreeNode Element.
+   * @param {ol.layer.Base} layer The given layer.
+   * @return {LayerTreeNode} The corresponding LayerTreeNode Element.
    */
   treeNodeFromLayer(layer) {
     let childNodes;
@@ -246,7 +271,7 @@ class LayerTree extends React.Component {
     }
 
     treeNode = <LayerTreeNode
-      title={layer.get('name')}
+      title={this.getTreeNodeTitle(layer)}
       key={layer.ol_uid}
     >
       {childNodes}

--- a/src/LayerTree/LayerTree.jsx
+++ b/src/LayerTree/LayerTree.jsx
@@ -47,8 +47,6 @@ class LayerTree extends React.Component {
      */
     className: PropTypes.string,
 
-    draggable: PropTypes.bool,
-
     layerGroup: PropTypes.instanceOf(OlLayerGroup),
 
     map: PropTypes.object,
@@ -68,7 +66,8 @@ class LayerTree extends React.Component {
    * @type {Object}
    */
   static defaultProps = {
-    draggable: true
+    draggable: true,
+    checkable: true
   }
 
   /**
@@ -404,14 +403,14 @@ class LayerTree extends React.Component {
   render() {
     const {
       className,
-      draggable,
       layerGroup,
       map,
+      nodeTitleRenderer,
       ...passThroughProps
     } = this.props;
 
     let ddListeners;
-    if (draggable) {
+    if (passThroughProps.draggable) {
       ddListeners = {
         onDragStart: this.onDragStart,
         onDragEnter: this.onDragEnter,
@@ -429,7 +428,6 @@ class LayerTree extends React.Component {
     return (
       <Tree
         className={finalClassName}
-        checkable
         checkedKeys={this.state.checkedKeys}
         onCheck={this.onCheck}
         {...ddListeners}

--- a/src/LayerTree/LayerTree.jsx
+++ b/src/LayerTree/LayerTree.jsx
@@ -8,7 +8,7 @@ import olObservable from 'ol/observable';
 
 import Logger from '../Util/Logger';
 import MapUtil from '../Util/MapUtil';
-const TreeNode = Tree.TreeNode;
+import LayerTreeNode from '../LayerTreeNode/LayerTreeNode.jsx';
 
 /**
  * The LayerTree.
@@ -245,13 +245,13 @@ class LayerTree extends React.Component {
       }
     }
 
-    treeNode = <TreeNode
-      className="react-geo-layertree-node"
+    treeNode = <LayerTreeNode
       title={layer.get('name')}
       key={layer.ol_uid}
     >
       {childNodes}
-    </TreeNode>;
+    </LayerTreeNode>;
+
     return treeNode;
   }
 

--- a/src/LayerTree/LayerTree.spec.jsx
+++ b/src/LayerTree/LayerTree.spec.jsx
@@ -1,4 +1,5 @@
 /*eslint-env mocha*/
+import React from 'react';
 import expect from 'expect.js';
 import sinon from 'sinon';
 
@@ -122,7 +123,7 @@ describe('<LayerTree />', () => {
       expect(subNode.props.title).to.eql(subLayer.get('name'));
     });
 
-    it('sets the right titles for the layers', () => {
+    it('sets the layer name as title per default', () => {
       const props = {
         layerGroup,
         map
@@ -132,6 +133,34 @@ describe('<LayerTree />', () => {
       treeNodes.forEach((node, index) => {
         const layer = layerGroup.getLayers().item(index);
         expect(node.props().title).to.eql(layer.get('name'));
+      });
+    });
+
+    it('accepts a custom title renderer function', () => {
+      const nodeTitleRenderer = function(layer) {
+        return (
+          <span className="span-1">
+            <span className="sub-span-1">
+              {layer.get('name')}
+            </span>
+            <span className="sub-span-2" />
+          </span>
+        );
+      };
+      const props = {
+        layerGroup,
+        map,
+        nodeTitleRenderer
+      };
+      const wrapper = TestUtil.mountComponent(LayerTree, props);
+      const treeNodes = wrapper.children('LayerTreeNode');
+
+      treeNodes.forEach((node, index) => {
+        const layer = layerGroup.getLayers().item(index);
+        expect(node.find('span.span-1').length).to.equal(1);
+        expect(node.find('span.sub-span-1').length).to.equal(1);
+        expect(node.find('span.sub-span-1').props().children).to.equal(layer.get('name'));
+        expect(node.find('span.sub-span-2').length).to.equal(1);
       });
     });
 

--- a/src/LayerTree/LayerTree.spec.jsx
+++ b/src/LayerTree/LayerTree.spec.jsx
@@ -84,15 +84,15 @@ describe('<LayerTree />', () => {
     expect(wrapper.instance().olListenerKeys).to.have.length(3);
   });
 
-  describe('<TreeNode> creation', () => {
+  describe('<LayerTreeNode> creation', () => {
 
-    it('adds a <TreeNode> for every child', () => {
+    it('adds a <LayerTreeNode> for every child', () => {
       const props = {
         layerGroup,
         map
       };
       const wrapper = TestUtil.mountComponent(LayerTree, props);
-      const treeNodes = wrapper.children('TreeNode');
+      const treeNodes = wrapper.children('LayerTreeNode');
 
       expect(treeNodes).to.have.length(layerGroup.getLayers().getLength());
     });
@@ -115,7 +115,7 @@ describe('<LayerTree />', () => {
       layerGroup.getLayers().push(nestedLayerGroup);
 
       const wrapper = TestUtil.mountComponent(LayerTree, props);
-      const treeNodes = wrapper.children('TreeNode');
+      const treeNodes = wrapper.children('LayerTreeNode');
 
       // It is not an instanceof TreeNode see: https://github.com/ant-design/ant-design/issues/4688
       const subNode = treeNodes.nodes[2].props.children[0];
@@ -128,7 +128,7 @@ describe('<LayerTree />', () => {
         map
       };
       const wrapper = TestUtil.mountComponent(LayerTree, props);
-      const treeNodes = wrapper.children('TreeNode');
+      const treeNodes = wrapper.children('LayerTreeNode');
       treeNodes.forEach((node, index) => {
         const layer = layerGroup.getLayers().item(index);
         expect(node.props().title).to.eql(layer.get('name'));
@@ -141,7 +141,7 @@ describe('<LayerTree />', () => {
         map
       };
       const wrapper = TestUtil.mountComponent(LayerTree, props);
-      const treeNodes = wrapper.children('TreeNode');
+      const treeNodes = wrapper.children('LayerTreeNode');
 
       treeNodes.forEach((node, index) => {
         const layer = layerGroup.getLayers().item(index);
@@ -155,7 +155,7 @@ describe('<LayerTree />', () => {
         map
       };
       const wrapper = TestUtil.mountComponent(LayerTree, props);
-      const treeNodes = wrapper.children('TreeNode');
+      const treeNodes = wrapper.children('LayerTreeNode');
 
       treeNodes.forEach((node, index) => {
         const layer = layerGroup.getLayers().item(index);
@@ -182,7 +182,7 @@ describe('<LayerTree />', () => {
         layerGroup.setVisible(true);
       });
 
-      it('returns a TreeNode when called with a layer', () => {
+      it('returns a LayerTreeNode when called with a layer', () => {
         const props = {
           layerGroup,
           map
@@ -206,7 +206,7 @@ describe('<LayerTree />', () => {
         map
       };
       const wrapper = TestUtil.mountComponent(LayerTree, props);
-      const treeNodes = wrapper.children('TreeNode');
+      const treeNodes = wrapper.children('LayerTreeNode');
 
       treeNodes.forEach((node, index) => {
         const layer = layerGroup.getLayers().item(index);

--- a/src/LayerTreeNode/LayerTreeNode.jsx
+++ b/src/LayerTreeNode/LayerTreeNode.jsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import {
+  Tree
+} from 'antd';
+const TreeNode = Tree.TreeNode;
+
+import './LayerTreeNode.less';
+
+/**
+ *
+ */
+class LayerTreeNode extends React.Component {
+
+  /**
+   * The prop types.
+   * @type {Object}
+   */
+  static propTypes = {
+  }
+
+  /**
+   * The constructor.
+   *
+   * @param {Object} props The initial props.
+   */
+  constructor(props) {
+    super(props);
+  }
+
+  /**
+   * The render function.
+   *
+   * @return {Element} The element.
+   */
+  render() {
+    const {
+      ...passThroughProps
+    } = this.props;
+
+    return(
+      <TreeNode
+        className="react-geo-layertree-node"
+        {...passThroughProps}
+      />
+    );
+  }
+
+}
+
+// Otherwise rc-tree wouldn't recognize this component as TreeNode, see
+// https://github.com/react-component/tree/blob/master/src/TreeNode.jsx#L328
+LayerTreeNode.isTreeNode = 1;
+
+export default LayerTreeNode;

--- a/src/LayerTreeNode/LayerTreeNode.less
+++ b/src/LayerTreeNode/LayerTreeNode.less
@@ -1,9 +1,3 @@
 .react-geo-layertree-node {
-  display: flex;
-  align-items: center;
 
-  .ant-tree-node-content-wrapper {
-    flex: 1;
-    overflow: hidden;
-  }
 }

--- a/src/LayerTreeNode/LayerTreeNode.less
+++ b/src/LayerTreeNode/LayerTreeNode.less
@@ -1,0 +1,9 @@
+.react-geo-layertree-node {
+  display: flex;
+  align-items: center;
+
+  .ant-tree-node-content-wrapper {
+    flex: 1;
+    overflow: hidden;
+  }
+}

--- a/src/LayerTreeNode/LayerTreeNode.spec.jsx
+++ b/src/LayerTreeNode/LayerTreeNode.spec.jsx
@@ -1,0 +1,14 @@
+/*eslint-env mocha*/
+import expect from 'expect.js';
+
+import {
+  LayerTreeNode
+} from '../index';
+
+describe('<LayerTreeNode />', () => {
+
+  it('is defined', () => {
+    expect(LayerTreeNode).not.to.be(undefined);
+  });
+
+});

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ import SimpleButton from './Button/SimpleButton/SimpleButton.jsx';
 import ToggleButton from './Button/ToggleButton/ToggleButton.jsx';
 import ToggleGroup from './Button/ToggleGroup/ToggleGroup.jsx';
 import LayerTree from './LayerTree/LayerTree.jsx';
+import LayerTreeNode from './LayerTreeNode/LayerTreeNode.jsx';
 import Legend from './Legend/Legend.jsx';
 import FloatingMapLogo from './Map/FloatingMapLogo/FloatingMapLogo.jsx';
 import ScaleCombo from './Map/ScaleCombo/ScaleCombo.jsx';
@@ -25,6 +26,7 @@ export {
   ToggleButton,
   ToggleGroup,
   LayerTree,
+  LayerTreeNode,
   Legend,
   FloatingMapLogo,
   ScaleCombo,


### PR DESCRIPTION
This PR proposes some extensions to the `LayerTree`:
  * Wrapping the `TreeNode` in it's own class `LayerTreeNode`.
    * Currently this component doesn't do anything (except having a custom `className` set), but it may be useful for future development and/or refactoring.
  * Adding the property `nodeTileRenderer`.
    *  `nodeTileRenderer` is an optional function that can be used to pass a custom title to the `TreeNode` (`LayerTreeNode`). As the `TreeNode` is capable of receiving an `ReactNode`, the function can return any renderable element (String, Number, Element etc.) composition. Additionally it receives the layer instance of the current tree node as argument, so any title can do custom layer-specific stuff.
  * Setting `className` and pass filtered props down to `antd` component only.