### PR TITLE
Add link to gh-pages, removed unused command

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,6 @@ Build everything (outputs will live in `build/`-directory)
 
     npm run build
 
-Start development server with hot reloading (open `http://0.0.0.0:4809/` and find your way through the directory listing)
+## Examples and API documentation
 
-    npm start
+Visit https://terrestris.github.io/react-geo/


### PR DESCRIPTION
This removes the `npm start` command as there seems to be no real use for it.
A link to the gh-pages has been added instead.
Should fix https://github.com/terrestris/react-geo/issues/84