### PR TITLE
Fix the layout of LayerTransparencySlider example

### DIFF
--- a/src/Slider/LayerTransparencySlider.example.jsx
+++ b/src/Slider/LayerTransparencySlider.example.jsx
@@ -35,8 +35,7 @@ render(
     <div id="map" style={{
       width: '400px',
       height: '400px',
-      right: '0px',
-      position: 'absolute'
+      position: 'relative'
     }} />
 
     <div className="example-block">


### PR DESCRIPTION
This prevents the slider going through the whole map.
Slider is now below the map.