### PR TITLE
Rebuild treeNodes on layer visibility change

### DIFF
--- a/src/LayerTree/LayerTree.jsx
+++ b/src/LayerTree/LayerTree.jsx
@@ -306,6 +306,8 @@ class LayerTree extends React.Component {
     const checkedKeys = this.getVisibleOlUids();
     this.setState({
       checkedKeys
+    }, () => {
+      this.rebuildTreeNodes();
     });
   }
 


### PR DESCRIPTION
This way we can ensure the `nodeTitleRenderer` function will be called on every prop/state/layer change.