### PR TITLE
Basic handling of scale dependant layers

### DIFF
--- a/example-templates/basic.html
+++ b/example-templates/basic.html
@@ -11,15 +11,18 @@
   <script>/*global hljs*/ hljs.initHighlightingOnLoad();</script>
 </head>
 <style>
+body.example {
+  padding: 1.5em;
+}
 .example-block {
-  padding: 20px;
+  padding: 2em;
 }
 .example-block > span {
   margin-right: 10px;
 }
 </style>
 
-<body>
+<body class="example">
   <h2>{{ title }}</h2>
   <div id="exampleContainer" class="app"></div>
   {{{ contents }}}

--- a/src/LayerTree/LayerTree.example.jsx
+++ b/src/LayerTree/LayerTree.example.jsx
@@ -20,6 +20,8 @@ const layerGroup = new OlLayerGroup({
   layers: [
     new OlLayerTile({
       name: 'Food insecurity layer',
+      minResolution: 200,
+      maxResolution: 2000,
       source: new OlSourceTileJson({
         url: 'https://api.tiles.mapbox.com/v3/mapbox.20110804-hoa-foodinsecurity-3month.json?secure',
         crossOrigin: 'anonymous'
@@ -27,6 +29,8 @@ const layerGroup = new OlLayerGroup({
     }),
     new OlLayerTile({
       name: 'World borders layer',
+      minResolution: 2000,
+      maxResolution: 20000,
       source: new OlSourceTileJson({
         url: 'https://api.tiles.mapbox.com/v3/mapbox.world-borders-light.json?secure',
         crossOrigin: 'anonymous'
@@ -45,7 +49,7 @@ const map = new OlMap({
   ],
   view: new OlView({
     center: olProj.fromLonLat([37.40570, 8.81566]),
-    zoom: 4
+    zoom: 6
   })
 });
 
@@ -56,12 +60,10 @@ const map = new OlMap({
 render(
   <div>
     <div id="map" style={{
-      width: '400px',
-      height: '400px',
-      right: '0px',
-      position: 'absolute'
+      height: '400px'
     }} />
 
+    <span>{'Please note that the layers have resolution restrictions, please zoom in and out to see how the trees react to this.'}</span>
     <div className="example-block">
       <span>{'Configured with \'map.getLayerGroup()\':'}</span>
 

--- a/src/LayerTree/LayerTree.jsx
+++ b/src/LayerTree/LayerTree.jsx
@@ -286,26 +286,12 @@ class LayerTree extends React.Component {
     treeNode = <LayerTreeNode
       title={this.getTreeNodeTitle(layer)}
       key={layer.ol_uid}
-      inResolutionRange={this.layerInResolutionRange(layer)}
+      inResolutionRange={MapUtil.layerInResolutionRange(layer, this.props.map)}
     >
       {childNodes}
     </LayerTreeNode>;
 
     return treeNode;
-  }
-
-  /**
-   * [layerInResolutionRange description]
-   * @param  {[type]} layer [description]
-   * @return {[type]}       [description]
-   */
-  layerInResolutionRange(layer) {
-    const layerMinRes = Math.max(layer.getMinResolution(), -Infinity);
-    const layerMaxRes = Math.min(layer.getMaxResolution(), Infinity);
-    const mapView = this.props.map.getView();
-    const currentRes = mapView.getResolution();
-    const inResolutionRange = currentRes < layerMaxRes && currentRes >= layerMinRes;
-    return inResolutionRange;
   }
 
   /**

--- a/src/LayerTree/LayerTree.jsx
+++ b/src/LayerTree/LayerTree.jsx
@@ -159,8 +159,8 @@ class LayerTree extends React.Component {
   }
 
   /**
-   * [registerResolutionChangeHandler description]
-   * @return {[type]} [description]
+   * Registers an eventhandler on the `ol.View`, which will rebuild the tree
+   * nodes whenever the view's resolution changes.
    */
   registerResolutionChangeHandler() {
     const mapView = this.props.map.getView();

--- a/src/LayerTree/LayerTree.spec.jsx
+++ b/src/LayerTree/LayerTree.spec.jsx
@@ -82,7 +82,7 @@ describe('<LayerTree />', () => {
       layers: [subLayer]
     });
 
-    expect(wrapper.instance().olListenerKeys).to.have.length(4);
+    expect(wrapper.instance().olListenerKeys).to.have.length(5);
     wrapper.setProps({
       layerGroup: nestedLayerGroup
     });

--- a/src/LayerTreeNode/LayerTreeNode.jsx
+++ b/src/LayerTreeNode/LayerTreeNode.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import {
   Tree
 } from 'antd';
@@ -16,6 +17,7 @@ class LayerTreeNode extends React.Component {
    * @type {Object}
    */
   static propTypes = {
+    inResolutionRange: PropTypes.boolean
   }
 
   /**
@@ -34,12 +36,15 @@ class LayerTreeNode extends React.Component {
    */
   render() {
     const {
+      inResolutionRange,
       ...passThroughProps
     } = this.props;
 
+    const addClassName = (inResolutionRange ? 'within' : 'out-off') + '-range';
+    const finalClassname = `react-geo-layertree-node ${addClassName}`;
     return(
       <TreeNode
-        className="react-geo-layertree-node"
+        className={finalClassname}
         {...passThroughProps}
       />
     );

--- a/src/LayerTreeNode/LayerTreeNode.less
+++ b/src/LayerTreeNode/LayerTreeNode.less
@@ -1,3 +1,7 @@
 .react-geo-layertree-node {
+  transition: opacity 1s;
 
+  &.out-off-range {
+    opacity: 0.5;
+  }
 }

--- a/src/Util/MapUtil/MapUtil.js
+++ b/src/Util/MapUtil/MapUtil.js
@@ -296,6 +296,35 @@ export class MapUtil {
     }
   }
 
+  /**
+   * Checks whether the resolution of the passed map's view lies inside of the
+   * min- and max-resolution of the passed layer, e.g. whether the layer should
+   * be displayed at the current map view resolution.
+   *
+   * @param {ol.layer.Layer} layer The layer to check.
+   * @param {ol.Map} map The map to get the view resolution for comparison
+   *     from.
+   * @return {Boolean} Whether the resolution of the passed map's view lies
+   *     inside of the min- and max-resolution of the passed layer, e.g. whether
+   *     the layer should be displayed at the current map view resolution. Will
+   *     be `false` when no `layer` or no `map` is passed or if the view of the
+   *     map is falsy or does not have a resolution (yet).
+   */
+  static layerInResolutionRange(layer, map) {
+    const mapView = map && map.getView();
+    const currentRes = mapView && mapView.getResolution();
+    if (!layer || !mapView || !currentRes) {
+      // It is questionable what we should return in this case, I opted for
+      // false, since we cannot sanely determine a correct answer.
+      return false;
+    }
+    const layerMinRes = layer.getMinResolution(); // default: 0 if unset
+    const layerMaxRes = layer.getMaxResolution(); // default: Infinity if unset
+    // minimum resolution is inclusive, maximum resolution exclusive
+    const within = currentRes >= layerMinRes && currentRes < layerMaxRes;
+    return within;
+  }
+
 }
 
 export default MapUtil;

--- a/src/Util/MapUtil/MapUtil.spec.js
+++ b/src/Util/MapUtil/MapUtil.spec.js
@@ -8,6 +8,9 @@ import OlSourceTileJson from 'ol/source/tilejson';
 import OlFeature from 'ol/feature';
 import OlGeomPoint from 'ol/geom/point';
 import OlLayerGroup from 'ol/layer/group';
+import OlMap from 'ol/map';
+import OlView from 'ol/view';
+
 import sinon from 'sinon';
 
 import TestUtil from '../TestUtil';
@@ -519,6 +522,127 @@ describe('MapUtil', () => {
       expect(legendUrl).to.contain(formatParam);
       expect(legendUrl).to.contain(heightParam);
       expect(legendUrl).to.contain(widthParam);
+    });
+
+  });
+
+  describe('layerInResolutionRange', () => {
+    it('is defined', () => {
+      expect(MapUtil.layerInResolutionRange).not.to.be(undefined);
+    });
+    it('is a function', () => {
+      expect(MapUtil.layerInResolutionRange).to.be.a('function');
+    });
+    it('returns false if not passed a layer', () => {
+      expect(MapUtil.layerInResolutionRange()).to.be(false);
+    });
+    it('returns false if not passed a map', () => {
+      const layer = new OlLayerTile();
+      expect(MapUtil.layerInResolutionRange(layer)).to.be(false);
+    });
+    it('returns false if map does not have a view', () => {
+      const layer = new OlLayerTile();
+      const map = new OlMap({view: null});
+      expect(MapUtil.layerInResolutionRange(layer, map)).to.be(false);
+    });
+    it('returns false if map view does not have a resolution', () => {
+      const layer = new OlLayerTile();
+      const view = new OlView();
+      const map = new OlMap({view: view});
+      expect(MapUtil.layerInResolutionRange(layer, map)).to.be(false);
+    });
+
+    it('returns true: layer (no limits) & any viewRes', () => {
+      const layer = new OlLayerTile();
+      const view = new OlView({resolution: 42});
+      const map = new OlMap({view: view});
+      expect(MapUtil.layerInResolutionRange(layer, map)).to.be(true);
+    });
+
+    it('returns true: layer (w/ minResolution) & viewRes > l.minres', () => {
+      const layer = new OlLayerTile({
+        minResolution: 42
+      });
+      const view = new OlView({resolution: 43});
+      const map = new OlMap({view: view});
+      expect(MapUtil.layerInResolutionRange(layer, map)).to.be(true);
+    });
+
+    it('returns true: layer (w/ minResolution) & viewRes = l.minres', () => {
+      const layer = new OlLayerTile({
+        minResolution: 42
+      });
+      const view = new OlView({resolution: 42});
+      const map = new OlMap({view: view});
+      expect(MapUtil.layerInResolutionRange(layer, map)).to.be(true);
+    });
+
+    it('returns true: layer (w/ maxResolution) & viewRes < l.maxres', () => {
+      const layer = new OlLayerTile({
+        maxResolution: 42
+      });
+      const view = new OlView({resolution: 41});
+      const map = new OlMap({view: view});
+      expect(MapUtil.layerInResolutionRange(layer, map)).to.be(true);
+    });
+
+    it('returns false: layer (w/ maxResolution) & viewRes = l.maxres', () => {
+      const layer = new OlLayerTile({
+        maxResolution: 42
+      });
+      const view = new OlView({resolution: 42});
+      const map = new OlMap({view: view});
+      expect(MapUtil.layerInResolutionRange(layer, map)).to.be(false);
+    });
+
+    it('returns true: layer (w/ min and max) & viewRes  within', () => {
+      const layer = new OlLayerTile({
+        minResolution: 42,
+        maxResolution: 50
+      });
+      const view = new OlView({resolution: 46});
+      const map = new OlMap({view: view});
+      expect(MapUtil.layerInResolutionRange(layer, map)).to.be(true);
+    });
+
+    it('returns false: layer (w/ min and max) & viewRes outside min', () => {
+      const layer = new OlLayerTile({
+        minResolution: 42,
+        maxResolution: 50
+      });
+      const view = new OlView({resolution: 38});
+      const map = new OlMap({view: view});
+      expect(MapUtil.layerInResolutionRange(layer, map)).to.be(false);
+    });
+
+    it('returns true: layer (w/ min and max) & viewRes = min', () => {
+      const layer = new OlLayerTile({
+        minResolution: 42,
+        maxResolution: 50
+      });
+      const view = new OlView({resolution: 42});
+      const map = new OlMap({view: view});
+      expect(MapUtil.layerInResolutionRange(layer, map)).to.be(true);
+    });
+
+    it('returns false: layer (w/ min and max) & viewRes outside max', () => {
+      const layer = new OlLayerTile({
+        minResolution: 42,
+        maxResolution: 50
+      });
+      const view = new OlView({resolution: 54});
+      const map = new OlMap({view: view});
+      expect(MapUtil.layerInResolutionRange(layer, map)).to.be(false);
+    });
+
+    it('returns false: layer (w/ min and max) & viewRes = max', () => {
+      const layer = new OlLayerTile({
+        minResolution: 42,
+        maxResolution: 50
+      });
+      const view = new OlView({resolution: 50});
+      const map = new OlMap({view: view});
+      expect(MapUtil.layerInResolutionRange(layer, map)).to.be(false);
     });
 
   });


### PR DESCRIPTION
This makes it so that layers that are shown/hidden because they are scale dependant also have another class in the layer tree node. 

The code contains some TODOs we should tackle later. Generally I would suggest to put some (bigger) part of the LayerTree class into the LayerTreeNode class.

Please review.


