### PR TITLE
Remove padding from simplebutton icon

### DIFF
--- a/src/Button/SimpleButton/SimpleButton.jsx
+++ b/src/Button/SimpleButton/SimpleButton.jsx
@@ -105,7 +105,6 @@ class SimpleButton extends React.Component {
             name={icon}
             className={fontIcon}
             style={{
-              paddingRight: '5px',
               display: icon ? 'inherit' : 'none'
             }}
           />


### PR DESCRIPTION
This fixes the shifted layout of the icon in `SimpleButton.`