### PR TITLE
Cleanup test environment

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "pretest": "npm run lint",
     "test": "npm run clean:test && BABEL_ENV=coverage karma start karma.conf.js --single-run -- --max_old_space_size=4096",
     "test:phantom": "npm run clean:test && BABEL_ENV=coverage karma start karma.conf.js --single-run --browsers PhantomJS -- --max_old_space_size=4096",
-    "test:watch": "karma start karma.conf.js -- --max_old_space_size=4096",
+    "test:watch": "karma start karma.conf.js --browsers PhantomJS -- --max_old_space_size=4096",
     "coveralls": "cat coverage/lcov.info | coveralls",
     "lint": "eslint --ext js,html,md example-templates/ examples/ src/",
     "lint:fix": "npm run lint -- --fix",

--- a/src/LayerTree/LayerTree.spec.jsx
+++ b/src/LayerTree/LayerTree.spec.jsx
@@ -42,6 +42,10 @@ describe('<LayerTree />', () => {
     map.setLayerGroup(layerGroup);
   });
 
+  afterEach(() => {
+    TestUtil.removeMap(map);
+  });
+
   it('is defined', () => {
     expect(LayerTree).not.to.be(undefined);
   });

--- a/src/Map/ScaleCombo/ScaleCombo.spec.jsx
+++ b/src/Map/ScaleCombo/ScaleCombo.spec.jsx
@@ -76,6 +76,8 @@ describe('<ScaleCombo />', () => {
       });
       wrapper.instance().getOptionsFromMap();
       expect(wrapper.props().scales).to.be.an('array');
+
+      TestUtil.removeMap(map);
     });
 
     it('creates options array from given map with resolutions and updates scales prop', () => {
@@ -94,6 +96,8 @@ describe('<ScaleCombo />', () => {
       let roundScale = (Math.round(MapUtil.getScaleForResolution(
         testResolutions[testResolutions.length - 1] ,'m'))).toString();
       expect(wrapper.props().scales[0].key).to.be(roundScale);
+
+      TestUtil.removeMap(map);
     });
   });
 

--- a/src/Panel/Panel/Panel.spec.jsx
+++ b/src/Panel/Panel/Panel.spec.jsx
@@ -133,6 +133,7 @@ describe('<Panel />', () => {
 
         //TearDown
         win.close();
+        testContainer.parentElement.removeChild(testContainer);
         done();
       });
 

--- a/src/Util/MapUtil/MapUtil.spec.js
+++ b/src/Util/MapUtil/MapUtil.spec.js
@@ -332,7 +332,6 @@ describe('MapUtil', () => {
       layerGroup = new OlLayerGroup({
         layers: [layer1, layer2, nestedLayerGroup]
       });
-      map = TestUtil.createMap();
       map.setLayerGroup(layerGroup);
     });
 
@@ -406,7 +405,6 @@ describe('MapUtil', () => {
       layerGroup = new OlLayerGroup({
         layers: [layer1, layer2, nestedLayerGroup]
       });
-      map = TestUtil.createMap();
       map.setLayerGroup(layerGroup);
     });
 


### PR DESCRIPTION
This aims to cleanup the test environment by removing every `div`-container created by `TestUtils.createMap()`.

Additionally `test:watch` will run in `PhantomJS` only.