### PR TITLE
Update peer dependencies (add ol)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ node_js:
 before_install:
 - npm install -g greenkeeper-lockfile@1
 before_script:
-- npm install --no-save react
+- npm install --no-save ol react
 - greenkeeper-lockfile-update
 script:
 - npm run build

--- a/package.json
+++ b/package.json
@@ -63,8 +63,8 @@
     "build": "npm run test:phantom && npm run build:examples && npm run build:docs && npm run build:js && npm run build:dist"
   },
   "peerDependencies": {
-    "ol": "4.3.3",
-    "react": "15.6.1"
+    "ol": "~4.0",
+    "react": "~15.0"
   },
   "dependencies": {
     "antd": "2.13.3",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "build": "npm run test:phantom && npm run build:examples && npm run build:docs && npm run build:js && npm run build:dist"
   },
   "peerDependencies": {
+    "ol": "4.3.3",
     "react": "15.6.1"
   },
   "dependencies": {
@@ -70,7 +71,6 @@
     "i18next": "9.0.0",
     "lodash": "4.17.4",
     "loglevel": "1.5.0",
-    "ol": "4.3.3",
     "prop-types": "15.6.0",
     "react-dom": "15.6.1",
     "react-fa": "4.2.0",


### PR DESCRIPTION
This makes ol (openlayers) a peer dependency.

Due to several scope-/instanceof-issues with webpack we need to ensure that the react-geo and the project that uses react-geo refer to the same instance of openlayers.

Therefore we make ol a peer dependency.

Additionaly we make the versions of our peer dependencies more lenient as @marcjansen suggested. :top: 