### PR TITLE
Examples: Public-path for image and font resources

### DIFF
--- a/webpack.examples.config.js
+++ b/webpack.examples.config.js
@@ -51,7 +51,7 @@ commonConfig.module = {
       options: {
         outputPath: 'resources/',
         name: '[hash].[ext]',
-        publicPath: basePath
+        publicPath: '/react-geo/examples/'
       }
     },
     'image-webpack-loader']
@@ -63,7 +63,7 @@ commonConfig.module = {
       mimetype: 'application/font-woff',
       outputPath: 'resources/',
       name: '[hash].[ext]',
-      publicPath: '/react-geo/' + basePath
+      publicPath: '/react-geo/examples/'
     }
   }, {
     test: /\.(ttf|eot|svg)(\?v=[0-9]\.[0-9]\.[0-9])?$/,
@@ -71,7 +71,7 @@ commonConfig.module = {
     options: {
       outputPath: 'resources/',
       name: '[hash].[ext]',
-      publicPath: '/react-geo/' + basePath
+      publicPath: '/react-geo/examples/'
     }
   }]
 };


### PR DESCRIPTION
Currently, the image and font resources cannot be found in the examples, as reported in https://github.com/terrestris/react-geo/issues/87. This PR should fix the `public-path` in `webpack.examples.config.js`.

Plz. review.