### PR TITLE
Fix failing examples (production build) for react 16

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -78,7 +78,7 @@ module.exports = function(config) {
       FirefoxHeadless: {
         base: 'Firefox',
         flags: [ '-headless' ],
-      },
+      }
     },
 
     // start these browsers

--- a/src/Button/SimpleButton/SimpleButton.example.jsx
+++ b/src/Button/SimpleButton/SimpleButton.example.jsx
@@ -32,7 +32,7 @@ render(
     </div>
 
     <div className="example-block">
-      <span>Icon:</span>
+      <span>Using shape config:</span>
 
       {/* A round SimpleButton.*/}
       <SimpleButton

--- a/webpack.examples.config.js
+++ b/webpack.examples.config.js
@@ -90,8 +90,7 @@ commonConfig.plugins = [
     compress: {
       warnings: false,
       pure_getters: true,
-      unsafe: true,
-      unsafe_comps: true,
+      unsafe: false,
       screw_ie8: true
     },
     output: {

--- a/webpack.production.config.js
+++ b/webpack.production.config.js
@@ -14,8 +14,7 @@ commonConfig.plugins = [
     compress: {
       warnings: false,
       pure_getters: true,
-      unsafe: true,
-      unsafe_comps: true,
+      unsafe: false,
       screw_ie8: true
     },
     output: {


### PR DESCRIPTION
This removes `unsafe:true` from `webpack.optimize.UglifyJsPlugin` as it causes bugs with react@16.