### PR TITLE
Renaming prop specifing selector of draggable component

### DIFF
--- a/src/Panel/Panel/Panel.jsx
+++ b/src/Panel/Panel/Panel.jsx
@@ -314,7 +314,7 @@ export class Panel extends React.Component {
             ? this.state.titleBarHeight
             : this.state.height
         }}
-        dragHandlerClassName=".drag-handle"
+        dragHandleClassName=".drag-handle"
         disableDragging={disableDragging}
         enableResizing={enableResizing}
         resizeHandleClasses={{


### PR DESCRIPTION
In version `v6.0.0` `dragHandlerClassName prop of  `Rnd` component has been renamed to `dragHandleClassName`. This PR transfers this to `react-geo`

Plz review.