### PR TITLE
Update replacement of imports to new namespace

### DIFF
--- a/src/Button/SimpleButton/SimpleButton.example.jsx
+++ b/src/Button/SimpleButton/SimpleButton.example.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render } from 'react-dom';
-import { SimpleButton } from '../../index.js'; //@react-geo@
+import { SimpleButton } from '../../index.js';
 
 render(
   <div>

--- a/src/Button/ToggleButton/ToggleButton.example.jsx
+++ b/src/Button/ToggleButton/ToggleButton.example.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render } from 'react-dom';
-import { ToggleButton } from '../../index.js'; //@react-geo@
+import { ToggleButton } from '../../index.js';
 
 render(
   <div>

--- a/src/Button/ToggleGroup/ToggleGroup.example.jsx
+++ b/src/Button/ToggleGroup/ToggleGroup.example.jsx
@@ -3,7 +3,7 @@ import { render } from 'react-dom';
 import {
   ToggleGroup,
   ToggleButton
-} from '../../index.js'; //@react-geo@
+} from '../../index.js';
 
 render(
   <div>

--- a/src/Field/NominatimSearch/NominatimSearch.example.jsx
+++ b/src/Field/NominatimSearch/NominatimSearch.example.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render } from 'react-dom';
-import { NominatimSearch } from '../../index.js'; //@react-geo@
+import { NominatimSearch } from '../../index.js';
 
 import OlMap from 'ol/map';
 import OlView from 'ol/view';

--- a/src/HigherOrderComponent/VisibleComponent/VisibleComponent.example.jsx
+++ b/src/HigherOrderComponent/VisibleComponent/VisibleComponent.example.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render } from 'react-dom';
 import { Button } from 'antd';
-import { isVisibleComponent } from '../../index.js'; //@react-geo@
+import { isVisibleComponent } from '../../index.js';
 
 // Enhance (any) Component by wrapping it using isVisibleComponent().
 const VisibleButton = isVisibleComponent(Button);

--- a/src/LayerTree/LayerTree.example.jsx
+++ b/src/LayerTree/LayerTree.example.jsx
@@ -9,7 +9,7 @@ import OlSourceTileJson from 'ol/source/tilejson';
 import OlSourceOsm from 'ol/source/osm';
 import olProj from 'ol/proj';
 
-import { LayerTree } from '../index.js'; //@react-geo@
+import { LayerTree } from '../index.js';
 
 
 //

--- a/src/Legend/Legend.example.jsx
+++ b/src/Legend/Legend.example.jsx
@@ -7,7 +7,7 @@ import OlLayerTile from 'ol/layer/tile';
 import OlSourceTileWMS from 'ol/source/tilewms';
 import olProj from 'ol/proj';
 
-import { Legend } from '../index.js'; //@react-geo@
+import { Legend } from '../index.js';
 
 
 //

--- a/src/Map/FloatingMapLogo/FloatingMapLogo.example.jsx
+++ b/src/Map/FloatingMapLogo/FloatingMapLogo.example.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { render } from 'react-dom';
 
 import logo from '../../UserChip/user.png';
-import { FloatingMapLogo } from '../../index.js'; //@react-geo@
+import { FloatingMapLogo } from '../../index.js';
 
 render(
   <FloatingMapLogo imageSrc={logo} />,

--- a/src/Map/ScaleCombo/ScaleCombo.example.jsx
+++ b/src/Map/ScaleCombo/ScaleCombo.example.jsx
@@ -4,7 +4,7 @@ import { render } from 'react-dom';
 import {
   MapUtil,
   ScaleCombo
-} from '../../index.js'; //@react-geo@
+} from '../../index.js';
 
 let scaleCombo;
 

--- a/src/Panel/Panel/Panel.example.jsx
+++ b/src/Panel/Panel/Panel.example.jsx
@@ -3,7 +3,7 @@ import { render } from 'react-dom';
 import {
   SimpleButton,
   Panel
-} from '../../index.js'; //@react-geo@
+} from '../../index.js';
 
 render(
   <div style={{

--- a/src/Panel/Titlebar/Titlebar.example.jsx
+++ b/src/Panel/Titlebar/Titlebar.example.jsx
@@ -3,7 +3,7 @@ import { render } from 'react-dom';
 import {
   SimpleButton,
   Titlebar
-} from '../../index.js'; //@react-geo@
+} from '../../index.js';
 
 render(
   <div>

--- a/src/Slider/LayerTransparencySlider.example.jsx
+++ b/src/Slider/LayerTransparencySlider.example.jsx
@@ -7,7 +7,7 @@ import OlLayerTile from 'ol/layer/tile';
 import OlSourceOsm from 'ol/source/osm';
 import olProj from 'ol/proj';
 
-import { LayerTransparencySlider } from '../index.js'; //@react-geo@
+import { LayerTransparencySlider } from '../index.js';
 
 //
 // ***************************** SETUP *****************************************

--- a/src/Toolbar/Toolbar.example.jsx
+++ b/src/Toolbar/Toolbar.example.jsx
@@ -3,7 +3,7 @@ import { render } from 'react-dom';
 import {
   SimpleButton,
   Toolbar
-} from '../index.js'; //@react-geo@
+} from '../index.js';
 
 render(
   <div>

--- a/src/UserChip/UserChip.example.jsx
+++ b/src/UserChip/UserChip.example.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render } from 'react-dom';
 import logo from './user.png';
-import { UserChip } from '../index.js'; //@react-geo@
+import { UserChip } from '../index.js';
 
 render(
   <div>

--- a/tasks/build-examples.js
+++ b/tasks/build-examples.js
@@ -10,15 +10,15 @@ var destDir = path.join(__dirname, '..', 'build', 'examples');
 var tplDir = path.join(__dirname, '..', 'example-templates');
 
 /**
- * Fixes the import string in the example source to use 'react-geo' instead of
- * the path.
+ * Fixes the import string in the example source to use '@terrestris/react-geo'
+ * instead of the path.
  *
  * @param {String} jsSource The source of the example.
  * @return {String} The fixed path.
  */
 function fixImports(jsSource) {
-  var re = /(import .* from)(.*@react-geo@)/g;
-  return jsSource.replace(re, '$1 \'react-geo\';');
+  var re = /from '(\.\.\/|\.\/)*index\.js'/g;
+  return jsSource.replace(re, 'from \'@terrestris/react-geo\'');
 }
 
 /**


### PR DESCRIPTION
This updates the replacement of imports in the examples.

` //@react-geo@` is not needed anymore.