### PR TITLE
Introduces MapProvider, mappify and MapComponent

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -39,7 +39,7 @@ module.exports = function(config) {
     },
 
     webpack: {
-      devtool: 'inline-source-map',
+      devtool: 'eval', // USE 'inline-source-map' for debugging tests
       module: {
         // Reuse the same loaders as declared in webpack.config.js.
         loaders: require('./webpack.common.config.js').module.loaders,

--- a/src/HigherOrderComponent/MapProvider/MapProvider.jsx
+++ b/src/HigherOrderComponent/MapProvider/MapProvider.jsx
@@ -22,14 +22,14 @@ class MapProvider extends React.Component {
 
     /**
      * The map can be either an OlMap or a Promise that resolves with an OlMap
-     * if your map is created asynchronusly.
+     * if your map is created asynchronously.
      *
      * @type {ol.Map|Promise}
      */
     map: PropTypes.oneOfType([
       PropTypes.instanceOf(OlMap),
       PropTypes.instanceOf(Promise)
-    ])
+    ]).isRequired
   }
 
   /**

--- a/src/HigherOrderComponent/MapProvider/MapProvider.jsx
+++ b/src/HigherOrderComponent/MapProvider/MapProvider.jsx
@@ -15,7 +15,7 @@ class MapProvider extends React.Component {
    */
   static propTypes = {
     /**
-     * The children of this group. Typically a set of `ToggleButton`s.
+     * The children of the MapProvider.
      * @type {Object}
      */
     children: PropTypes.node,
@@ -28,7 +28,7 @@ class MapProvider extends React.Component {
      */
     map: PropTypes.oneOfType([
       PropTypes.instanceOf(OlMap),
-      PropTypes.func
+      PropTypes.instanceOf(Promise)
     ])
   }
 
@@ -60,7 +60,7 @@ class MapProvider extends React.Component {
         ready: true
       });
     } else {
-      props.map().then((map) => {
+      props.map.then((map) => {
         this.setState({
           map: map,
           ready: true

--- a/src/HigherOrderComponent/MapProvider/MapProvider.jsx
+++ b/src/HigherOrderComponent/MapProvider/MapProvider.jsx
@@ -1,0 +1,97 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import OlMap from 'ol/map';
+
+/**
+ * The MapProvider.
+ *
+ * @type {Object}
+ */
+class MapProvider extends React.Component {
+
+  /**
+   * The properties.
+   * @type {Object}
+   */
+  static propTypes = {
+    /**
+     * The children of this group. Typically a set of `ToggleButton`s.
+     * @type {Object}
+     */
+    children: PropTypes.node,
+
+    /**
+     * The map can be either an OlMap or a Promise that resolves with an OlMap
+     * if your map is created asynchronusly.
+     *
+     * @type {ol.Map|Promise}
+     */
+    map: PropTypes.oneOfType([
+      PropTypes.instanceOf(OlMap),
+      PropTypes.func
+    ])
+  }
+
+  /**
+   * The child context types.
+   * @type {Object}
+   */
+  static childContextTypes = {
+    map: PropTypes.instanceOf(OlMap)
+  }
+
+  /**
+   * The constructor of the MapProvider sets the
+   *
+   * @constructs MapProvider
+   * @param {Object} props The initial props.
+   */
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      map: null,
+      ready: false
+    };
+
+    if (props.map instanceof OlMap) {
+      this.setState({
+        map: props.map,
+        ready: true
+      });
+    } else {
+      props.map().then((map) => {
+        this.setState({
+          map: map,
+          ready: true
+        });
+      });
+    }
+  }
+
+  /**
+   * Returns the context for the children.
+   *
+   * @return {Object} The child context.
+   */
+  getChildContext() {
+    const {
+      map
+    } = this.state;
+
+    return { map };
+  }
+
+  /**
+   * The render function.
+   */
+  render() {
+    if (!this.state.ready) {
+      return null;
+    } else {
+      return this.props.children;
+    }
+  }
+}
+
+export default MapProvider;

--- a/src/HigherOrderComponent/MapProvider/MapProvider.spec.jsx
+++ b/src/HigherOrderComponent/MapProvider/MapProvider.spec.jsx
@@ -1,0 +1,47 @@
+/*eslint-env mocha*/
+// import React from 'react';
+import expect from 'expect.js';
+// import { mount } from 'enzyme';
+//
+// import TestUtil from '../../Util/TestUtil';
+
+import {
+  MapProvider
+} from '../../index';
+
+describe('MapProvider', () => {
+  // let map;
+  //
+  // /* eslint-disable require-jsdoc */
+  // class MockComponent extends React.Component {
+  //   render() {
+  //     return (
+  //       <div>A mock Component</div>
+  //     );
+  //   }
+  // }
+  /* eslint-enable require-jsdoc */
+
+  // beforeEach(() => {
+  //   map = TestUtil.createMap();
+  // });
+
+  describe('Basics', () => {
+    it('is defined', () => {
+      expect(MapProvider).not.to.be(undefined);
+    });
+
+    // TODO
+    // it('provides a given map to its children', () => {
+    //   const wrapper = mount(
+    //     <MapProvider map={map}>
+    //       <MockComponent />
+    //     </MapProvider>
+    //   );
+    //
+    //   expect(wrapper).not.to.be(undefined);
+    //   expect(wrapper.context().map).to.eql(map);
+    // });
+
+  });
+});

--- a/src/HigherOrderComponent/MappifiedComponent/MappifiedComponent.jsx
+++ b/src/HigherOrderComponent/MappifiedComponent/MappifiedComponent.jsx
@@ -7,9 +7,7 @@ import { Logger } from '../../index';
 /**
  * The HOC factory function.
  *
- * Wrapped components will be checked against the activeModules array of
- * the state: If the wrapped component (identified by it's name) is included
- * in the state, it will be rendered, if not, it wont.
+ * Wrapped components will receive the map from the context as a prop.
  *
  * @param {Component} WrappedComponent The component to wrap and enhance.
  * @return {Component} The wrapped component.
@@ -21,7 +19,7 @@ export function mappify(WrappedComponent, {
   /**
    * The wrapper class for the given component.
    *
-   * @class The VisibleComponent
+   * @class The MappifiedComponent
    * @extends React.Component
    */
   class MappifiedComponent extends React.Component {

--- a/src/HigherOrderComponent/MappifiedComponent/MappifiedComponent.jsx
+++ b/src/HigherOrderComponent/MappifiedComponent/MappifiedComponent.jsx
@@ -50,7 +50,7 @@ export function mappify(WrappedComponent, {
     /**
      * Returns the wrapped instance. Only applicable if withRef is set to true.
      *
-     * @return {Element} The wrappend instance.
+     * @return {Element} The wrapped instance.
      */
     getWrappedInstance = () => {
       if (withRef) {

--- a/src/HigherOrderComponent/MappifiedComponent/MappifiedComponent.jsx
+++ b/src/HigherOrderComponent/MappifiedComponent/MappifiedComponent.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import OlMap from 'ol/map';
 
-import Logger from '../../index.js';
+import { Logger } from '../../index';
 
 /**
  * The HOC factory function.
@@ -83,8 +83,8 @@ export function mappify(WrappedComponent, {
       } = this.context;
 
       if (!map) {
-        Logger.warn(`You trying to mappify a component without any map in the
-          context. Did you implement the MapProvider?`);
+        Logger.warn('You trying to mappify a component without any map in the ' +
+        'context. Did you implement the MapProvider?');
       }
 
       return (

--- a/src/HigherOrderComponent/MappifiedComponent/MappifiedComponent.jsx
+++ b/src/HigherOrderComponent/MappifiedComponent/MappifiedComponent.jsx
@@ -1,0 +1,102 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import OlMap from 'ol/map';
+
+import Logger from '../../index.js';
+
+/**
+ * The HOC factory function.
+ *
+ * Wrapped components will be checked against the activeModules array of
+ * the state: If the wrapped component (identified by it's name) is included
+ * in the state, it will be rendered, if not, it wont.
+ *
+ * @param {Component} WrappedComponent The component to wrap and enhance.
+ * @return {Component} The wrapped component.
+ */
+export function mappify(WrappedComponent, {
+  withRef = false
+} = {}) {
+
+  /**
+   * The wrapper class for the given component.
+   *
+   * @class The VisibleComponent
+   * @extends React.Component
+   */
+  class MappifiedComponent extends React.Component {
+
+    /**
+     * The context types.
+     * @type {Object}
+     */
+    static contextTypes = {
+      map: PropTypes.instanceOf(OlMap).isRequired
+    }
+
+    /**
+     * Create the MappifiedComponent.
+     *
+     * @constructs MappifiedComponent
+     */
+    constructor(props) {
+      super(props);
+
+      /**
+       * The wrapped instance.
+       * @type {Element}
+       */
+      this.wrappedInstance = null;
+    }
+
+    /**
+     * Returns the wrapped instance. Only applicable if withRef is set to true.
+     *
+     * @return {Element} The wrappend instance.
+     */
+    getWrappedInstance = () => {
+      if (withRef) {
+        return this.wrappedInstance;
+      } else {
+        Logger.warn('No wrapped instance referenced, please call the '
+          + 'mappify with option withRef = true.');
+      }
+    }
+
+    /**
+     * Sets the wrapped instance.
+     *
+     * @param {Element} instance The instance to set.
+     */
+    setWrappedInstance = (instance) => {
+      if (withRef) {
+        this.wrappedInstance = instance;
+      }
+    }
+
+    /**
+     * The render function.
+     */
+    render() {
+      const {
+        map
+      } = this.context;
+
+      if (!map) {
+        Logger.warn(`You trying to mappify a component without any map in the
+          context. Did you implement the MapProvider?`);
+      }
+
+      return (
+        <WrappedComponent
+          ref={this.setWrappedInstance}
+          map={map}
+          {...this.props}
+        />
+      );
+
+    }
+  }
+
+  return MappifiedComponent;
+}

--- a/src/HigherOrderComponent/MappifiedComponent/MappifiedComponent.spec.jsx
+++ b/src/HigherOrderComponent/MappifiedComponent/MappifiedComponent.spec.jsx
@@ -1,0 +1,97 @@
+/*eslint-env mocha*/
+import React from 'react';
+import expect from 'expect.js';
+import sinon from 'sinon';
+
+import TestUtil from '../../Util/TestUtil';
+
+import {
+  Logger,
+  mappify
+} from '../../index';
+
+describe('mappify', () => {
+  let EnhancedComponent;
+  let map;
+
+  /* eslint-disable require-jsdoc */
+  class MockComponent extends React.Component {
+    render() {
+      return (
+        <div>A mock Component</div>
+      );
+    }
+  }
+  /* eslint-enable require-jsdoc */
+
+  beforeEach(() => {
+    map = TestUtil.createMap();
+    EnhancedComponent = mappify(MockComponent, {
+      withRef: true
+    });
+  });
+
+  describe('Basics', () => {
+    it('is defined', () => {
+      expect(mappify).not.to.be(undefined);
+    });
+
+    it('can be rendered', () => {
+      const wrapper = TestUtil.mountComponent(EnhancedComponent, {}, {map});
+
+      expect(wrapper).not.to.be(undefined);
+      expect(wrapper.first().is(EnhancedComponent)).to.be(true);
+    });
+
+    it('adds the map from the context as a prop', () => {
+      const wrapper = TestUtil.mountComponent(EnhancedComponent, {}, {map});
+      const wrappedInstance = wrapper.instance().getWrappedInstance();
+
+      expect(wrappedInstance.props.map).to.eql(map);
+    });
+
+    it('warns if no map is given in the context', () => {
+      const loggerSpy = sinon.spy(Logger, 'warn');
+      TestUtil.mountComponent(EnhancedComponent);
+      expect(loggerSpy.calledOnce).to.be.ok();
+      expect(loggerSpy.calledWith('You trying to mappify a component without any map in the '+
+      'context. Did you implement the MapProvider?')).to.be.ok();
+    });
+
+    it('passes through all props', () => {
+      const props = {
+        someProp: '10',
+        name: 'Podolski'
+      };
+      const expectedProps = {
+        someProp: '10',
+        name: 'Podolski',
+        map: map
+      };
+      const wrapper = TestUtil.mountComponent(EnhancedComponent, props, {map});
+      const wrappedInstance = wrapper.instance().getWrappedInstance();
+
+      expect(wrappedInstance.props).to.eql(expectedProps);
+    });
+
+    it('saves a reference to the wrapped instance if requested', () => {
+      const props = {
+        name: 'Podolski'
+      };
+      const wrapper = TestUtil.mountComponent(EnhancedComponent, props, {map});
+      const wrappedInstance = wrapper.instance().getWrappedInstance();
+
+      expect(wrappedInstance).to.be.an(MockComponent);
+
+      const EnhancedComponentNoRef = mappify(MockComponent, {
+        withRef: false
+      });
+
+      const wrapperNoRef = TestUtil.mountComponent(EnhancedComponentNoRef, props, {map});
+      const wrappedInstanceNoRef = wrapperNoRef.instance().getWrappedInstance();
+
+      expect(wrappedInstanceNoRef).to.be(undefined);
+    });
+
+  });
+});

--- a/src/HigherOrderComponent/MappifiedComponent/MappifiedComponent.spec.jsx
+++ b/src/HigherOrderComponent/MappifiedComponent/MappifiedComponent.spec.jsx
@@ -56,6 +56,7 @@ describe('mappify', () => {
       expect(loggerSpy.calledOnce).to.be.ok();
       expect(loggerSpy.calledWith('You trying to mappify a component without any map in the '+
       'context. Did you implement the MapProvider?')).to.be.ok();
+      loggerSpy.restore();
     });
 
     it('passes through all props', () => {

--- a/src/Map/MapComponent/MapComponent.example.jsx
+++ b/src/Map/MapComponent/MapComponent.example.jsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { render } from 'react-dom';
+import OlSourceOsm from 'ol/source/osm';
+import OlLayerTile from 'ol/layer/tile';
+import OlView from 'ol/view';
+import OlMap from 'ol/map';
+
+import {
+  MapComponent,
+  MapProvider,
+  NominatimSearch,
+  mappify
+} from '../../index.js';
+
+/**
+ * Create the OlMap (you could do some asynchronus stuff here).
+ *
+ * @return {Promise} Promise that resolves an OlMap.
+ */
+const mapPromise = function() {
+  const layer = new OlLayerTile({
+    source: new OlSourceOsm()
+  });
+
+  return new Promise((resolve) => {
+    const map = new OlMap({
+      view: new OlView({
+        center: [
+          135.1691495,
+          34.6565482
+        ],
+        projection: 'EPSG:4326',
+        zoom: 16,
+      }),
+      layers: [layer]
+    });
+
+    resolve(map);
+  });
+};
+
+const Map = mappify(MapComponent);
+const Search = mappify(NominatimSearch);
+
+render(
+  <MapProvider map={mapPromise}>
+    NominatimSearch: <Search />
+    <Map style={{
+      width: '512px',
+      height: '512px'
+    }} />
+  </MapProvider>,
+  document.getElementById('exampleContainer')
+);

--- a/src/Map/MapComponent/MapComponent.example.jsx
+++ b/src/Map/MapComponent/MapComponent.example.jsx
@@ -17,27 +17,25 @@ import {
  *
  * @return {Promise} Promise that resolves an OlMap.
  */
-const mapPromise = function() {
+const mapPromise = new Promise((resolve) => {
   const layer = new OlLayerTile({
     source: new OlSourceOsm()
   });
 
-  return new Promise((resolve) => {
-    const map = new OlMap({
-      view: new OlView({
-        center: [
-          135.1691495,
-          34.6565482
-        ],
-        projection: 'EPSG:4326',
-        zoom: 16,
-      }),
-      layers: [layer]
-    });
-
-    resolve(map);
+  const map = new OlMap({
+    view: new OlView({
+      center: [
+        135.1691495,
+        34.6565482
+      ],
+      projection: 'EPSG:4326',
+      zoom: 16,
+    }),
+    layers: [layer]
   });
-};
+
+  resolve(map);
+});
 
 const Map = mappify(MapComponent);
 const Search = mappify(NominatimSearch);

--- a/src/Map/MapComponent/MapComponent.example.md
+++ b/src/Map/MapComponent/MapComponent.example.md
@@ -1,0 +1,16 @@
+---
+layout: basic.html
+title: MapComponent example
+description: This example shows the usage of the MapComponent in combination with the MapProvider.
+collection: Examples
+---
+
+This example shows the usage of the MapComponent in combination with the MapProvider.
+It makes use of the `mappify` HOC function to supply the provided map to the MapComponent
+and the NominatimSearch.
+
+This way you can share the same mapobject across the whole application without passing
+it as prop to the whole rendertree.
+
+The map can be created asynchronusly so that every child of the MapProvider is just
+rendered when the map is ready.

--- a/src/Map/MapComponent/MapComponent.jsx
+++ b/src/Map/MapComponent/MapComponent.jsx
@@ -15,7 +15,16 @@ export class MapComponent extends React.Component {
    * @type {Object}
    */
   static propTypes = {
-    map: PropTypes.instanceOf(OlMap).isRequired
+    map: PropTypes.instanceOf(OlMap).isRequired,
+    mapDivId: PropTypes.string
+  }
+
+  /**
+   * The default properties.
+   * @type {Object}
+   */
+  static defaultProps = {
+    mapDivId: 'map'
   }
 
   /**
@@ -44,11 +53,16 @@ export class MapComponent extends React.Component {
 
     const {
       map,
+      mapDivId,
       ...passThroughProps
     } = this.props;
 
     if (map) {
-      mapDiv = <div className="map" id="map" {...passThroughProps} />;
+      mapDiv = <div
+        className="map"
+        id={mapDivId}
+        {...passThroughProps}
+      />;
     }
 
     return (

--- a/src/Map/MapComponent/MapComponent.jsx
+++ b/src/Map/MapComponent/MapComponent.jsx
@@ -15,7 +15,7 @@ export class MapComponent extends React.Component {
    * @type {Object}
    */
   static propTypes = {
-    map: PropTypes.instanceOf(OlMap)
+    map: PropTypes.instanceOf(OlMap).isRequired
   }
 
   /**

--- a/src/Map/MapComponent/MapComponent.jsx
+++ b/src/Map/MapComponent/MapComponent.jsx
@@ -5,7 +5,7 @@ import OlMap from 'ol/map';
 /**
  * Class representating a map.
  *
- * @class The Map.
+ * @class The MapComponent.
  * @extends React.Component
  */
 export class MapComponent extends React.Component {
@@ -15,6 +15,7 @@ export class MapComponent extends React.Component {
    * @type {Object}
    */
   static propTypes = {
+    children: PropTypes.node,
     map: PropTypes.instanceOf(OlMap).isRequired,
     mapDivId: PropTypes.string
   }
@@ -42,7 +43,7 @@ export class MapComponent extends React.Component {
    * @method componentDidMount
    */
   componentDidMount() {
-    this.props.map.setTarget('map');
+    this.props.map.setTarget(this.props.mapDivId);
   }
 
   /**
@@ -54,6 +55,7 @@ export class MapComponent extends React.Component {
     const {
       map,
       mapDivId,
+      children,
       ...passThroughProps
     } = this.props;
 
@@ -62,7 +64,9 @@ export class MapComponent extends React.Component {
         className="map"
         id={mapDivId}
         {...passThroughProps}
-      />;
+      >
+        {children}
+      </div>;
     }
 
     return (

--- a/src/Map/MapComponent/MapComponent.jsx
+++ b/src/Map/MapComponent/MapComponent.jsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import OlMap from 'ol/map';
+
+/**
+ * Class representating a map.
+ *
+ * @class The Map.
+ * @extends React.Component
+ */
+export class MapComponent extends React.Component {
+
+  /**
+   * The properties.
+   * @type {Object}
+   */
+  static propTypes = {
+    map: PropTypes.instanceOf(OlMap)
+  }
+
+  /**
+   * Create a MapComponent.
+   *
+   * @constructs Map
+   */
+  constructor(props) {
+    super(props);
+  }
+
+  /**
+   * The componentDidMount function
+   *
+   * @method componentDidMount
+   */
+  componentDidMount() {
+    this.props.map.setTarget('map');
+  }
+
+  /**
+   * The render function.
+   */
+  render() {
+    let mapDiv;
+
+    const {
+      map,
+      ...passThroughProps
+    } = this.props;
+
+    if (map) {
+      mapDiv = <div className="map" id="map" {...passThroughProps} />;
+    }
+
+    return (
+      mapDiv
+    );
+  }
+}
+
+export default MapComponent;

--- a/src/Map/MapComponent/MapComponent.spec.jsx
+++ b/src/Map/MapComponent/MapComponent.spec.jsx
@@ -1,0 +1,37 @@
+/*eslint-env mocha*/
+import expect from 'expect.js';
+
+import TestUtil from '../../Util/TestUtil';
+
+import {
+  MapComponent
+} from '../../index';
+
+describe('<MapComponent />', () => {
+  let map;
+
+  it('is defined', () => {
+    expect(MapComponent).not.to.be(undefined);
+  });
+
+  beforeEach(() => {
+    map = TestUtil.createMap();
+  });
+
+  it('can be rendered', () => {
+    const wrapper = TestUtil.mountComponent(MapComponent, {map});
+    expect(wrapper).not.to.be(undefined);
+  });
+
+  it('passes props', () => {
+    const wrapper = TestUtil.mountComponent(MapComponent, {
+      map: map,
+      className: 'podolski',
+      fc: 'koeln'
+    });
+    const div = wrapper.find('div').getElements()[0];
+    expect(div.props.className).to.contain('podolski');
+    expect(div.props.fc).to.equal('koeln');
+  });
+
+});

--- a/src/Panel/Panel/Panel.spec.jsx
+++ b/src/Panel/Panel/Panel.spec.jsx
@@ -15,7 +15,7 @@ describe('<Panel />', () => {
     expect(wrapper).not.to.be(undefined);
   });
 
-  it('passed props are added to Rnd', () => {
+  it('passes props to Rnd', () => {
     const wrapper = TestUtil.mountComponent(Panel, {
       className: 'podolski',
       fc: 'koeln'

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ import LayerTree from './LayerTree/LayerTree.jsx';
 import LayerTreeNode from './LayerTreeNode/LayerTreeNode.jsx';
 import Legend from './Legend/Legend.jsx';
 import FloatingMapLogo from './Map/FloatingMapLogo/FloatingMapLogo.jsx';
+import MapComponent from './Map/MapComponent/MapComponent.jsx';
 import ScaleCombo from './Map/ScaleCombo/ScaleCombo.jsx';
 import Panel from './Panel/Panel/Panel.jsx';
 import LayerTransparencySlider from './Slider/LayerTransparencySlider.jsx';
@@ -21,7 +22,10 @@ import ObjectUtil from './Util/ObjectUtil/ObjectUtil';
 import StringUtil from './Util/StringUtil/StringUtil';
 import UndoUtil from './Util/UndoUtil/UndoUtil';
 import UrlUtil from './Util/UrlUtil/UrlUtil';
+
+import MapProvider from './HigherOrderComponent/MapProvider/MapProvider.jsx';
 import { isVisibleComponent } from './HigherOrderComponent/VisibleComponent/VisibleComponent.jsx';
+import { mappify } from './HigherOrderComponent/MappifiedComponent/MappifiedComponent.jsx';
 
 export {
   SimpleButton,
@@ -46,5 +50,8 @@ export {
   StringUtil,
   UndoUtil,
   UrlUtil,
+  MapProvider,
+  MapComponent,
+  mappify,
   isVisibleComponent
 };

--- a/webpack.examples.config.js
+++ b/webpack.examples.config.js
@@ -8,6 +8,7 @@ commonConfig.entry = {
   'Button/ToggleGroup/ToggleGroup': './src/Button/ToggleGroup/ToggleGroup.example.jsx',
   'Field/NominatimSearch/NominatimSearch': './src/Field/NominatimSearch/NominatimSearch.example.jsx',
   'Map/FloatingMapLogo/FloatingMapLogo': './src/Map/FloatingMapLogo/FloatingMapLogo.example.jsx',
+  'Map/MapComponent/MapComponent': './src/Map/MapComponent/MapComponent.example.jsx',
   'Map/ScaleCombo/ScaleCombo': './src/Map/ScaleCombo/ScaleCombo.example.jsx',
   'Legend/Legend': './src/Legend/Legend.example.jsx',
   'LayerTree/LayerTree': './src/LayerTree/LayerTree.example.jsx',


### PR DESCRIPTION
This introduces the HOCs `MapProvider` the `MappifiedComponent` (`mappify`) and the `MapComponent`.

Short explanation:
- The `MapProvider` adds a map to the context of the application.
- The `mappfiy` function grabs the map from the context and adds it as prop to the according component.
- The `MapComponent` just returns a div containing an OlMap.

It also includes an example of how to use these three new Components together.

We should check/modify our examples and tests to make use of the `MapProvider`.

Thx @dnlkoch and @ahennr for your support.