### PR TITLE
Adds filter-function to metalsmith

### DIFF
--- a/tasks/build-examples.js
+++ b/tasks/build-examples.js
@@ -76,8 +76,21 @@ function augmentExamples(files) {
   }
 }
 
-// var templatesDir = path.join(__dirname, '..', 'config', 'examples');
+/**
+ * Filter files we don't want to be copied.
+ *
+ * @param {Object} files The files.
+ */
+function filter(files) {
+  for (var filename in files) {
+    if (filename.indexOf('.spec.') !== -1) {
+      delete files[filename];
+    }
+  }
+}
+
 new Metalsmith('.')
+  .use(filter)
   .source(srcDir)
   .destination(destDir)
   .clean(true)

--- a/webpack.examples.config.js
+++ b/webpack.examples.config.js
@@ -78,27 +78,4 @@ commonConfig.module = {
   }]
 };
 
-commonConfig.devtool = 'cheap-module-source-map';
-commonConfig.plugins = [
-  ...commonConfig.plugins || [],
-  new webpack.DefinePlugin({
-    'process.env': {
-      NODE_ENV: JSON.stringify('production')
-    }
-  }),
-  new webpack.optimize.UglifyJsPlugin({
-    sourceMap: 'source-map',
-    mangle: true,
-    compress: {
-      warnings: false,
-      pure_getters: true,
-      unsafe: false,
-      screw_ie8: true
-    },
-    output: {
-      comments: false
-    }
-  })
-];
-
 module.exports = commonConfig;

--- a/webpack.examples.config.js
+++ b/webpack.examples.config.js
@@ -78,4 +78,27 @@ commonConfig.module = {
   }]
 };
 
+commonConfig.devtool = 'cheap-module-source-map';
+commonConfig.plugins = [
+  ...commonConfig.plugins || [],
+  new webpack.DefinePlugin({
+    'process.env': {
+      NODE_ENV: JSON.stringify('production')
+    }
+  }),
+  new webpack.optimize.UglifyJsPlugin({
+    sourceMap: 'source-map',
+    mangle: true,
+    compress: {
+      warnings: false,
+      pure_getters: true,
+      unsafe: false,
+      screw_ie8: true
+    },
+    output: {
+      comments: false
+    }
+  })
+];
+
 module.exports = commonConfig;


### PR DESCRIPTION
This adds a filter function to Metalsmith to avoid copying the spec-files to the examples folder.