### PR TITLE
Change deprecated `prepublish` to `prepublishOnly`

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "test": "jest --coverage --maxWorkers=4",
     "test:watch": "jest --watchAll",
     "coveralls": "cat coverage/lcov.info | coveralls",
-    "prepublish": "npm run build",
+    "prepublishOnly": "npm run build",
     "lint": "eslint --ext js,html,md example-templates/ examples/ src/",
     "lint:fix": "npm run lint -- --fix",
     "start": "webpack-dev-server --config webpack.examples.config.js --content-base ./build/ --hot",


### PR DESCRIPTION
With this, we no longer call the prepublish script after `npm i`
(which was already weird) but keep the logic for our publishing
(untested, TBH).

This reomves the following warnings:

    npm WARN prepublish-on-install As of npm@5, `prepublish` scripts are deprecated.
    npm WARN prepublish-on-install Use `prepare` for build steps and `prepublishOnly` for upload-only.
    npm WARN prepublish-on-install See the deprecation note in `npm help scripts` for more information.

See also https://docs.npmjs.com/misc/scripts

Please review.