### PR TITLE
Ignor build-folder during test and make coverage optional

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -10,6 +10,9 @@ module.exports = {
     '\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$': '<rootDir>/jest/__mocks__/fileMock.js',
     '\\.(css|less)$': '<rootDir>/jest/__mocks__/styleMock.js'
   },
+  modulePathIgnorePatterns: [
+    '<rootDir>/build/'
+  ],
   transformIgnorePatterns: [
     'node_modules/(?!ol)'
   ],

--- a/package.json
+++ b/package.json
@@ -49,10 +49,10 @@
     "clean:build": "rimraf ./build/*",
     "clean:dist": "rimraf ./dist/*",
     "pretest": "npm run lint",
-    "test": "jest --coverage --maxWorkers=4",
+    "test": "jest --maxWorkers=4",
     "test:watch": "jest --watchAll",
     "coveralls": "cat coverage/lcov.info | coveralls",
-    "prepublish": "npm run build",
+    "prepublishOnly": "npm run build",
     "lint": "eslint --ext js,html,md example-templates/ examples/ src/",
     "lint:fix": "npm run lint -- --fix",
     "start": "webpack-dev-server --config webpack.examples.config.js --content-base ./build/ --hot",
@@ -61,7 +61,7 @@
     "build:js": "webpack --config webpack.development.config.js && webpack -p --config webpack.production.config.js",
     "build:dist": "npm run clean:dist && BABEL_ENV=build babel src --out-dir dist --copy-files --ignore spec.js,example.js,.md",
     "build:all": "npm run build:examples && npm run build:docs && npm run build:js && npm run build:dist",
-    "build": "npm run test && npm run build:all",
+    "build": "npm run test -- --coverage && npm run build:all",
     "release": "np --no-yarn && git push https://github.com/terrestris/react-geo.git --tags"
   },
   "peerDependencies": {


### PR DESCRIPTION
This PR suggests two changes:


**Ignore the build/`-directory when testing**

Locally for me the `npm test` failed with messages as follows.

    FAIL  build/examples/Util/FeatureUtil.spec.js
    ● Test suite failed to run

    Cannot find module 'expect.js' from 'FeatureUtil.spec.js'

      at Resolver.resolveModule (node_modules/jest-resolve/build/index.js:191:17)
      at Object.<anonymous> (build/examples/Util/FeatureUtil.spec.js:2:15)

I know that #231 will ensure that no spec files will be copied over, and this
is not a replacement for that PR.

**Don't always capture coverage** 

You can always reenable it with `npm test -- --coverage`, which is also done
during the `build`-script, which will ensure that CI will still have the
coverage.