### PR TITLE
Introduces segments to CircleMenu

### DIFF
--- a/src/CircleMenu/CircleMenu.example.jsx
+++ b/src/CircleMenu/CircleMenu.example.jsx
@@ -1,11 +1,90 @@
 import React from 'react';
+import OlSourceOsm from 'ol/source/osm';
+import OlSourceVector from 'ol/source/vector';
+import OlLayerTile from 'ol/layer/tile';
+import OlLayerVector from 'ol/layer/vector';
+import OlFeature from 'ol/feature';
+import OlGeomPoint from 'ol/geom/point';
+import OlView from 'ol/view';
+import OlMap from 'ol/map';
+import OlStyleStyle from 'ol/style/style';
+import OlStyleCircle from 'ol/style/circle';
+import OlStyleFill from 'ol/style/fill';
 import { render } from 'react-dom';
 import {
   CircleMenu,
-  SimpleButton
+  SimpleButton,
+  MapComponent,
+  MapProvider,
+  mappify
 } from '../index.js';
 
-let visible = false;
+let visibleButton = false;
+let visibleMap = false;
+
+/**
+ * Setup
+ */
+const buttonCoords = [100, 100];
+let mapMenuCoords;
+
+// Prepare map
+const mapPromise = new Promise((resolve) => {
+  const osmLayer = new OlLayerTile({
+    source: new OlSourceOsm()
+  });
+  const featureLayer = new OlLayerVector({
+    source: new OlSourceVector({
+      features: [new OlFeature({
+        geometry: new OlGeomPoint([
+          135.1691495,
+          34.6565482
+        ])
+      })]
+    }),
+    style: new OlStyleStyle({
+      image: new OlStyleCircle({
+        radius: 10,
+        fill: new OlStyleFill({
+          color: '#C62148'
+        })
+      })
+    })
+  });
+
+  const map = new OlMap({
+    view: new OlView({
+      center: [
+        135.1691495,
+        34.6565482
+      ],
+      projection: 'EPSG:4326',
+      zoom: 16,
+    }),
+    layers: [osmLayer,featureLayer],
+    interactions: []
+  });
+
+  // show menu when feature clicked
+  map.on('singleclick', (evt) => {
+    const mapEl = document.getElementById('map');
+    const pixel = map.getPixelFromCoordinate([135.1691495, 34.6565482]);
+    const evtPixel = map.getPixelFromCoordinate(evt.coordinate);
+    if(map.hasFeatureAtPixel(evtPixel)) {
+      visibleMap = true;
+      mapMenuCoords = [
+        pixel[0] + mapEl.offsetLeft,
+        pixel[1] + mapEl.offsetTop,
+      ];
+    } else {
+      visibleMap = false;
+    }
+    doRender();
+  });
+
+  resolve(map);
+});
+const Map = mappify(MapComponent);
 
 /**
  * The wrapper is needed to reRender the DomTree. Don't worry about it.
@@ -16,25 +95,70 @@ const doRender = () => {
     <div>
       <div className="example-block" style={{
         width: 500,
-        height: 500
+        height: 200
       }}>
-        <span>CircleMenu</span>
-        <SimpleButton onClick={() => {
-          visible = !visible;
-          doRender();
-        }}>
-          Toggle CircleMenu
-        </SimpleButton>
-        {visible ?
+        <div>CircleMenu with segment as submenu:</div>
+        <SimpleButton
+          id="segmentButton"
+          shape="circle"
+          icon="cross"
+          style={{
+            position: 'absolute',
+            top: buttonCoords[0]+ 'px',
+            left: buttonCoords[1]+ 'px'
+          }}
+          onClick={() => {
+            // TODO replace with evt.target once it is given to the callback
+            const button = document.getElementById('segmentButton');
+            visibleButton = !visibleButton;
+            if (visibleButton) {
+              button.style.transform = 'rotate(45deg)';
+            } else {
+              button.style.transform = 'rotate(0deg)';
+            }
+            doRender();
+          }}
+        />
+        {visibleButton ?
           <CircleMenu
-            position={[100, 100]}
+            style={{
+              position: 'absolute',
+              background: 'none',
+              border: 'none'
+            }}
+            position={[
+              buttonCoords[0] + 14, // buttonX - buttonWidth/2
+              buttonCoords[1] + 14 // buttonY - buttonHeight/2
+            ]}
+            diameter={80}
+            animationDuration={500}
+            segmentAngles={[0, 90]}
+          >
+            <SimpleButton icon="floppy-o" shape="circle" />
+            <SimpleButton icon="trash-o" shape="circle" />
+            <SimpleButton icon="pencil" shape="circle" />
+          </CircleMenu>
+          : null
+        }
+      </div>
+      <div className="example-block">
+        <span>CircleMenu in a Map (click the red feature)</span>
+        <MapProvider map={mapPromise}>
+          <Map style={{
+            width: '512px',
+            height: '512px'
+          }} />
+        </MapProvider>
+        {visibleMap ?
+          <CircleMenu
+            position={mapMenuCoords}
             diameter={80}
             animationDuration={500}
           >
-            <SimpleButton icon="bullhorn" shape="circle" />
-            <SimpleButton icon="bullhorn" shape="circle" />
-            <SimpleButton icon="bullhorn" shape="circle" />
-            <SimpleButton icon="bullhorn" shape="circle" />
+            <SimpleButton icon="pencil" shape="circle" />
+            <SimpleButton icon="line-chart" shape="circle" />
+            <SimpleButton icon="link" shape="circle" />
+            <SimpleButton icon="thumbs-o-up" shape="circle" />
             <SimpleButton icon="bullhorn" shape="circle" />
           </CircleMenu>
           : null

--- a/src/CircleMenu/CircleMenu.jsx
+++ b/src/CircleMenu/CircleMenu.jsx
@@ -28,6 +28,7 @@ export class CircleMenu extends React.Component {
 
   static propTypes = {
     className: PropTypes.string,
+    style: PropTypes.object,
     /**
      * The duration of the animation in milliseconds. Pass 0 to avoid animation.
      * Default is 300.
@@ -51,12 +52,17 @@ export class CircleMenu extends React.Component {
      * An array containing the x and y coordinates of the CircleMenus Center.
      * @type {Number[]}
      */
-    position: PropTypes.arrayOf(PropTypes.number).isRequired
+    position: PropTypes.arrayOf(PropTypes.number).isRequired,
+    /**
+     * Optional Segement of angles where to show the children. Default is [0, 360].
+     */
+    segmentAngles: PropTypes.arrayOf(PropTypes.number)
   };
 
   static defaultProps = {
     animationDuration: 300,
-    diameter: 100
+    diameter: 100,
+    segmentAngles: [0, 360]
   };
 
   /**
@@ -96,6 +102,8 @@ export class CircleMenu extends React.Component {
       diameter,
       children,
       position,
+      segmentAngles,
+      style,
       ...passThroughProps
     } = this.props;
 
@@ -109,20 +117,23 @@ export class CircleMenu extends React.Component {
         className={finalClassName}
         style={{
           transition: `all ${animationDuration}ms`,
-          opacity: 0,
-          width: 0,
-          height: 0,
-          top: position[0],
-          left: position[1]
+          left: position[0] - (diameter / 2),
+          top: position[1] - (diameter / 2),
+          ...style
         }}
         {...passThroughProps}
       >
         {
           children.map((child, idx, children) => {
+            const start = segmentAngles[0];
+            const end = segmentAngles[1];
+            const range = end-start;
+            const amount = range > 270 ? children.length : children.length - 1;
+            const rotationAngle = start + (range / amount) * idx;
             return (
               <CircleMenuItem
                 radius={diameter / 2}
-                rotationAngle={(360 / children.length) * idx}
+                rotationAngle={rotationAngle}
                 idx={idx}
                 animationDuration={this.props.animationDuration}
                 key={idx}

--- a/src/CircleMenu/CircleMenu.less
+++ b/src/CircleMenu/CircleMenu.less
@@ -3,8 +3,8 @@
 .react-geo-circlemenu {
   border: dashed 1px;
   border-radius: 50%;
-  position: relative;
-  z-index: 100;
+  position: absolute;
+  pointer-events:none;
   background: -moz-radial-gradient(center, ellipse cover, rgba(0,0,0,0) 0%,  @circle-menu-background-color 100%);
   background: -webkit-radial-gradient(center, ellipse cover, rgba(0,0,0,0) 0%, @circle-menu-background-color 100%);
   background: radial-gradient(ellipse at center, rgba(0,0,0,0) 0%, @circle-menu-background-color 100%);

--- a/src/CircleMenu/CircleMenu.spec.jsx
+++ b/src/CircleMenu/CircleMenu.spec.jsx
@@ -65,9 +65,6 @@ describe('<CircleMenu />', () => {
       });
       const instance = wrapper.instance();
 
-      expect(instance._ref.style.width).toBe('0px');
-      expect(instance._ref.style.height).toBe('0px');
-
       instance.applyTransformation();
 
       setTimeout(() => {

--- a/src/CircleMenu/CircleMenuItem/CircleMenuItem.less
+++ b/src/CircleMenu/CircleMenuItem/CircleMenuItem.less
@@ -4,4 +4,5 @@
   top: 50%;
   left: 50%;
   margin: -1.3em;
+  pointer-events:all;
 }


### PR DESCRIPTION
This introduces the new `segmentAngles` property.

It allows to restrict the menuitems to appear in a specified segment of the circle:

![localhost_react-geo_build_examples_circlemenu_circlemenu example html 1](https://user-images.githubusercontent.com/1849416/33434318-4338c8ea-d5df-11e7-8640-1a9e59fbf588.png)
