### PR TITLE
Panel - resize prop functions

### DIFF
--- a/src/Panel/Panel/Panel.jsx
+++ b/src/Panel/Panel/Panel.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Rnd from 'react-rnd';
-import { uniqueId, isNumber } from 'lodash';
+import { uniqueId, isNumber, isFunction } from 'lodash';
 
 import Titlebar from '../Titlebar/Titlebar.jsx';
 import SimpleButton from '../../Button/SimpleButton/SimpleButton.jsx';
@@ -83,7 +83,21 @@ export class Panel extends React.Component {
       PropTypes.object,
       PropTypes.bool
     ]),
-
+    /**
+     * Function called when onResize is triggered by react-rnd
+     * @type {Function}
+     */
+    onResize: PropTypes.func,
+    /**
+     * Function called when onResizeStart is triggered by react-rnd
+     * @type {Function}
+     */
+    onResizeStart: PropTypes.func,
+    /**
+     * Function called when onResizeStop is triggered by react-rnd
+     * @type {Function}
+     */
+    onResizeStop: PropTypes.func,
     /**
      * Whether to allow dragging or not.
      * @type {boolean}
@@ -192,6 +206,10 @@ export class Panel extends React.Component {
    * @param {HTMLElement} el The element which gets resized.
    */
   onResize = (evt, direction, el) => {
+    const { onResize } = this.props;
+    if (isFunction(onResize)) {
+      onResize(arguments);
+    }
     this.setState({
       height: el.clientHeight,
       width: el.clientWidth
@@ -202,6 +220,10 @@ export class Panel extends React.Component {
    * Function called when resizing is started.
    */
   onResizeStart = () => {
+    const { onResizeStart } = this.props;
+    if (isFunction(onResizeStart)) {
+      onResizeStart(arguments);
+    }
     this.setState({
       resizing: true
     });
@@ -211,6 +233,10 @@ export class Panel extends React.Component {
    * Function called when resizing is stopped.
    */
   onResizeStop = () => {
+    const { onResizeStop } = this.props;
+    if (isFunction(onResizeStop)) {
+      onResizeStop(arguments);
+    }
     this.setState({
       resizing: false
     });

--- a/src/Panel/Panel/Panel.spec.jsx
+++ b/src/Panel/Panel/Panel.spec.jsx
@@ -51,6 +51,16 @@ describe('<Panel />', () => {
       wrapper.instance().onResize(null, null, {clientHeight: 1337});
       expect(wrapper.state().height).toBe(1337);
     });
+
+    it('calls corresponding function "onResize" of props if defined', () => {
+      const onResizeMock = jest.fn();
+      const wrapperWithMockedFunction = TestUtil.mountComponent(Panel,  {
+        onResize: onResizeMock
+      });
+      expect(wrapperWithMockedFunction.instance().onResizeStop).not.toBeUndefined();
+      wrapperWithMockedFunction.instance().onResize(null, null, {clientHeight: 4711});
+      expect(onResizeMock.mock.calls).toHaveLength(1);
+    });
   });
 
   describe('#onResizeStart', () => {
@@ -65,6 +75,16 @@ describe('<Panel />', () => {
       const state = wrapper.state();
       expect(state.resizing).toBe(true);
     });
+
+    it('calls corresponding function "onResizeStart" of props if defined', () => {
+      const onResizeStartMock = jest.fn();
+      const wrapperWithMockedFunction = TestUtil.mountComponent(Panel,  {
+        onResizeStart: onResizeStartMock
+      });
+      expect(wrapperWithMockedFunction.instance().onResizeStart).not.toBeUndefined();
+      wrapperWithMockedFunction.instance().onResizeStart();
+      expect(onResizeStartMock.mock.calls).toHaveLength(1);
+    });
   });
 
   describe('#onResizeStop', () => {
@@ -78,6 +98,16 @@ describe('<Panel />', () => {
       wrapper.instance().onResizeStop();
       const state = wrapper.state();
       expect(state.resizing).toBe(false);
+    });
+
+    it('calls corresponding function "onResizeStop" of props if defined', () => {
+      const onResizeStopMock = jest.fn();
+      const wrapperWithMockedFunction = TestUtil.mountComponent(Panel,  {
+        onResizeStop: onResizeStopMock
+      });
+      expect(wrapperWithMockedFunction.instance().onResizeStop).not.toBeUndefined();
+      wrapperWithMockedFunction.instance().onResizeStop();
+      expect(onResizeStopMock.mock.calls).toHaveLength(1);
     });
   });
 


### PR DESCRIPTION
This PR adds some prop functions (and tests) which are called as soon as the corresponding ones from react-rnd are called. 
 
This can be useful if width and height of a window are needed (e.g. for charting).

Plz review.