### PR TITLE
Enhance parentId check for Window component

### DIFF
--- a/dist/Container/AddWmsPanel/AddWmsPanel.js
+++ b/dist/Container/AddWmsPanel/AddWmsPanel.js
@@ -37,7 +37,21 @@ var _map2 = _interopRequireDefault(_map);
 
 var _lodash = require('lodash');
 
-var _index = require('../../index');
+var _Panel = require('../../Panel/Panel/Panel');
+
+var _Panel2 = _interopRequireDefault(_Panel);
+
+var _Titlebar = require('../../Panel/Titlebar/Titlebar');
+
+var _Titlebar2 = _interopRequireDefault(_Titlebar);
+
+var _SimpleButton = require('../../Button/SimpleButton/SimpleButton');
+
+var _SimpleButton2 = _interopRequireDefault(_SimpleButton);
+
+var _Logger = require('../../Util/Logger');
+
+var _Logger2 = _interopRequireDefault(_Logger);
 
 require('./AddWmsPanel.less');
 
@@ -107,7 +121,7 @@ var AddWmsPanel = exports.AddWmsPanel = function (_React$Component) {
           }
         });
       } else {
-        _index.Logger.warn('Neither map nor onLayerAddToMap given in props. Will do nothing.');
+        _Logger2.default.warn('Neither map nor onLayerAddToMap given in props. Will do nothing.');
       }
     };
 
@@ -128,7 +142,7 @@ var AddWmsPanel = exports.AddWmsPanel = function (_React$Component) {
           }
         });
       } else {
-        _index.Logger.warn('Neither map nor onLayerAddToMap given in props. Will do nothing.');
+        _Logger2.default.warn('Neither map nor onLayerAddToMap given in props. Will do nothing.');
       }
     };
 
@@ -191,7 +205,7 @@ var AddWmsPanel = exports.AddWmsPanel = function (_React$Component) {
 
 
       return wmsLayers && wmsLayers.length > 0 ? _react2.default.createElement(
-        _index.Panel,
+        _Panel2.default,
         _extends({
           title: titleText,
           bounds: '#main',
@@ -206,8 +220,8 @@ var AddWmsPanel = exports.AddWmsPanel = function (_React$Component) {
               key: idx });
           })
         ),
-        _react2.default.createElement(_index.Titlebar, { tools: [_react2.default.createElement(
-            _index.SimpleButton,
+        _react2.default.createElement(_Titlebar2.default, { tools: [_react2.default.createElement(
+            _SimpleButton2.default,
             {
               size: 'small',
               key: 'useSelectedBtn',
@@ -216,7 +230,7 @@ var AddWmsPanel = exports.AddWmsPanel = function (_React$Component) {
             },
             addSelectedLayersText
           ), _react2.default.createElement(
-            _index.SimpleButton,
+            _SimpleButton2.default,
             {
               size: 'small',
               key: 'useAllBtn',
@@ -224,7 +238,7 @@ var AddWmsPanel = exports.AddWmsPanel = function (_React$Component) {
             },
             addAllLayersText
           ), onCancel ? _react2.default.createElement(
-            _index.SimpleButton,
+            _SimpleButton2.default,
             {
               size: 'small',
               key: 'cancelBtn',

--- a/dist/Field/CoordinateReferenceSystemCombo/CoordinateReferenceSystemCombo.js
+++ b/dist/Field/CoordinateReferenceSystemCombo/CoordinateReferenceSystemCombo.js
@@ -22,7 +22,13 @@ var _propTypes = require('prop-types');
 
 var _propTypes2 = _interopRequireDefault(_propTypes);
 
-var _index = require('../../index.js');
+var _UrlUtil = require('../../Util/UrlUtil/UrlUtil');
+
+var _UrlUtil2 = _interopRequireDefault(_UrlUtil);
+
+var _Logger = require('../../Util/Logger');
+
+var _Logger2 = _interopRequireDefault(_Logger);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -66,7 +72,7 @@ var CoordinateReferenceSystemCombo = function (_React$Component) {
         q: searchVal
       };
 
-      return fetch(crsApiUrl + '?' + _index.UrlUtil.objectToRequestString(queryParameters)).then(function (response) {
+      return fetch(crsApiUrl + '?' + _UrlUtil2.default.objectToRequestString(queryParameters)).then(function (response) {
         return response.json();
       });
     };
@@ -155,7 +161,7 @@ var CoordinateReferenceSystemCombo = function (_React$Component) {
      * @param {String} error The error string.
      */
     value: function onFetchError(error) {
-      _index.Logger.error('Error while requesting in CoordinateReferenceSystemCombo: ' + error);
+      _Logger2.default.error('Error while requesting in CoordinateReferenceSystemCombo: ' + error);
     }
 
     /**

--- a/dist/HigherOrderComponent/MappifiedComponent/MappifiedComponent.js
+++ b/dist/HigherOrderComponent/MappifiedComponent/MappifiedComponent.js
@@ -22,7 +22,9 @@ var _map = require('ol/map');
 
 var _map2 = _interopRequireDefault(_map);
 
-var _index = require('../../index');
+var _Logger = require('../../Util/Logger');
+
+var _Logger2 = _interopRequireDefault(_Logger);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -72,7 +74,7 @@ function mappify(WrappedComponent) {
         if (withRef) {
           return _this.wrappedInstance;
         } else {
-          _index.Logger.warn('No wrapped instance referenced, please call the ' + 'mappify with option withRef = true.');
+          _Logger2.default.warn('No wrapped instance referenced, please call the ' + 'mappify with option withRef = true.');
         }
       };
 
@@ -118,7 +120,7 @@ function mappify(WrappedComponent) {
 
 
         if (!map) {
-          _index.Logger.warn('You trying to mappify a component without any map in the ' + 'context. Did you implement the MapProvider?');
+          _Logger2.default.warn('You trying to mappify a component without any map in the ' + 'context. Did you implement the MapProvider?');
         }
 
         return _react2.default.createElement(WrappedComponent, _extends({

--- a/dist/Window/Window.js
+++ b/dist/Window/Window.js
@@ -25,6 +25,8 @@ var _lodash = require('lodash');
 
 var _index = require('../index.js');
 
+var _index2 = require('../index');
+
 require('./Window.less');
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
@@ -71,6 +73,10 @@ var Window = exports.Window = function (_React$Component) {
 
     _this._parent = document.getElementById(parentId);
 
+    if (!_this._parent) {
+      _index2.Logger.warn('No parent element was found! Please ensure that parentId ' + 'parameter was set correctly (default value is `app`)');
+    }
+
     var div = document.createElement('div');
     div.id = id;
     _this._elementDiv = div;
@@ -104,7 +110,9 @@ var Window = exports.Window = function (_React$Component) {
   _createClass(Window, [{
     key: 'componentDidMount',
     value: function componentDidMount() {
-      this._parent.appendChild(this._elementDiv);
+      if (this._parent) {
+        this._parent.appendChild(this._elementDiv);
+      }
     }
 
     /**
@@ -114,7 +122,9 @@ var Window = exports.Window = function (_React$Component) {
   }, {
     key: 'componentWillUnmount',
     value: function componentWillUnmount() {
-      this._parent.removeChild(this._elementDiv);
+      if (this._parent) {
+        this._parent.removeChild(this._elementDiv);
+      }
     }
 
     /**

--- a/dist/Window/Window.js
+++ b/dist/Window/Window.js
@@ -23,9 +23,9 @@ var _propTypes2 = _interopRequireDefault(_propTypes);
 
 var _lodash = require('lodash');
 
-var _index = require('../index.js');
+var _Panel = require('../Panel/Panel/Panel');
 
-var _index2 = require('../index');
+var _Logger = require('../Util/Logger');
 
 require('./Window.less');
 
@@ -74,7 +74,7 @@ var Window = exports.Window = function (_React$Component) {
     _this._parent = document.getElementById(parentId);
 
     if (!_this._parent) {
-      _index2.Logger.warn('No parent element was found! Please ensure that parentId ' + 'parameter was set correctly (default value is `app`)');
+      _Logger.Logger.warn('No parent element was found! Please ensure that parentId ' + 'parameter was set correctly (default value is `app`)');
     }
 
     var div = document.createElement('div');
@@ -144,7 +144,7 @@ var Window = exports.Window = function (_React$Component) {
       var rndClassName = finalClassName + ' ' + this.state.id;
 
       return _reactDom2.default.createPortal(_react2.default.createElement(
-        _index.Panel,
+        _Panel.Panel,
         _extends({
           closable: true,
           draggable: true,

--- a/src/Container/AddWmsPanel/AddWmsPanel.jsx
+++ b/src/Container/AddWmsPanel/AddWmsPanel.jsx
@@ -6,7 +6,10 @@ import OlLayerImage  from 'ol/layer/image';
 import OlMap from 'ol/map';
 import { isFunction } from 'lodash';
 
-import { Panel, SimpleButton, Titlebar, Logger } from '../../index';
+import Panel from '../../Panel/Panel/Panel.jsx';
+import Titlebar from '../../Panel/Titlebar/Titlebar.jsx';
+import SimpleButton from '../../Button/SimpleButton/SimpleButton.jsx';
+import Logger from '../../Util/Logger';
 
 import './AddWmsPanel.less';
 import AddWmsLayerEntry from './AddWmsLayerEntry/AddWmsLayerEntry.jsx';

--- a/src/Field/CoordinateReferenceSystemCombo/CoordinateReferenceSystemCombo.jsx
+++ b/src/Field/CoordinateReferenceSystemCombo/CoordinateReferenceSystemCombo.jsx
@@ -3,7 +3,8 @@ import PropTypes from 'prop-types';
 import { AutoComplete } from 'antd';
 const Option = AutoComplete.Option;
 
-import { Logger, UrlUtil } from '../../index.js';
+import UrlUtil from '../../Util/UrlUtil/UrlUtil';
+import Logger from '../../Util/Logger';
 
 /**
  * Class representing a combo to choose coordinate projection system via a

--- a/src/HigherOrderComponent/MappifiedComponent/MappifiedComponent.jsx
+++ b/src/HigherOrderComponent/MappifiedComponent/MappifiedComponent.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import OlMap from 'ol/map';
 
-import { Logger } from '../../index';
+import Logger from '../../Util/Logger';
 
 /**
  * The HOC factory function.

--- a/src/Window/Window.jsx
+++ b/src/Window/Window.jsx
@@ -2,9 +2,9 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 import { uniqueId } from 'lodash';
-import { Panel } from  '../index.js';
 
-import { Logger } from '../index';
+import Panel from  '../Panel/Panel/Panel.jsx';
+import Logger from '../Util/Logger';
 
 import './Window.less';
 

--- a/src/Window/Window.jsx
+++ b/src/Window/Window.jsx
@@ -4,6 +4,8 @@ import PropTypes from 'prop-types';
 import { uniqueId } from 'lodash';
 import { Panel } from  '../index.js';
 
+import { Logger } from '../index';
+
 import './Window.less';
 
 /**
@@ -82,6 +84,11 @@ export class Window extends React.Component {
     const { parentId } = this.props;
     this._parent = document.getElementById(parentId);
 
+    if (!this._parent) {
+      Logger.warn('No parent element was found! Please ensure that parentId ' +
+      'parameter was set correctly (default value is `app`)');
+    }
+
     const div = document.createElement('div');
     div.id = id;
     this._elementDiv = div;
@@ -103,14 +110,18 @@ export class Window extends React.Component {
    * is inserted in the DOM tree.
    */
   componentDidMount() {
-    this._parent.appendChild(this._elementDiv);
+    if (this._parent) {
+      this._parent.appendChild(this._elementDiv);
+    }
   }
 
   /**
    * componentWillUnmount - remove child from parent element
    */
   componentWillUnmount() {
-    this._parent.removeChild(this._elementDiv);
+    if (this._parent) {
+      this._parent.removeChild(this._elementDiv);
+    }
   }
 
   /**

--- a/src/Window/Window.spec.jsx
+++ b/src/Window/Window.spec.jsx
@@ -1,5 +1,5 @@
 /*eslint-env jest*/
-import { Window } from '../index';
+import { Window, Logger } from '../index';
 import TestUtil from '../Util/TestUtil';
 
 describe('<Window />', () => {
@@ -17,6 +17,21 @@ describe('<Window />', () => {
       parentId: testIdToMountIn
     });
     expect(wrapper).not.toBeUndefined();
+  });
+
+  it('warns if no parentId is provided', () => {
+
+    const loggerSpy = jest.spyOn(Logger, 'warn');
+
+    TestUtil.mountComponent(Window, {});
+
+    expect(loggerSpy).toHaveBeenCalled();
+    expect(loggerSpy).toHaveBeenCalledWith('No parent element was found! ' +
+      'Please ensure that parentId parameter was set correctly (default ' +
+      'value is `app`)');
+
+    loggerSpy.mockReset();
+    loggerSpy.mockRestore();
   });
 
   it('is completely removed from parent if component is unmounted', () => {


### PR DESCRIPTION
This PR adds warning which will be shown, if no valid `parentId` was provided by Window component instantiation and default value `parentId=app` doesnt' match.

If no valid parent was found, the component won't be rendered.

Please review @terrestris/devs 