### PR TITLE
Make window compatible to other browsers than chrome

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10935,7 +10935,7 @@
     "omit.js": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/omit.js/-/omit.js-1.0.0.tgz",
-      "integrity": "sha1-4BPLhqdRe5z298+w3bQpclapkog=",
+      "integrity": "sha512-O1rwbvEfAdhtonTv+v6IQeMOKTi/wlHcXpI3hehyPDlujkjSBQC6Vtzg0mdy+v2KVDmuPf7hAbHlTBM6q1bUHQ==",
       "dev": true,
       "requires": {
         "babel-runtime": "6.26.0"
@@ -13798,7 +13798,7 @@
     "shallowequal": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.0.2.tgz",
-      "integrity": "sha1-FWHb3vuMAUCBADGQhXZNo/z4P48=",
+      "integrity": "sha512-zlVXeVUKvo+HEv1e2KQF/csyeMKx2oHvatQ9l6XjCUj3agvC8XGf6R9HvIPDSmp8FNPvx7b5kaEJTRi7CqxtEw==",
       "dev": true
     },
     "shebang-command": {

--- a/src/Window/Window.jsx
+++ b/src/Window/Window.jsx
@@ -89,8 +89,13 @@ export class Window extends React.Component {
       'parameter was set correctly (default value is `app`)');
     }
 
+    const finalClassName = props.className
+      ? `${props.className} ${this.className}`
+      : this.className;
+
     const div = document.createElement('div');
     div.id = id;
+    div.className = finalClassName;
     this._elementDiv = div;
 
     this.state = {
@@ -135,16 +140,10 @@ export class Window extends React.Component {
       ...rndOpts
     } = this.props;
 
-    const finalClassName = className
-      ? `${className} ${this.className}`
-      : this.className;
-    const rndClassName = `${finalClassName} ${this.state.id}`;
-
     return ReactDOM.createPortal(
       <Panel
         closable
         draggable
-        className={rndClassName}
         onClose={onClose}
         {...rndOpts}
       >

--- a/src/Window/Window.less
+++ b/src/Window/Window.less
@@ -2,6 +2,7 @@
 
 .react-geo-window-portal {
   z-index: 1000; // see @zindex-modal
+  position: inherit !important;
 
   .react-geo-simplebutton {
     background-color: #fff;


### PR DESCRIPTION
The `Window` component did only work in chrome properly. In other browsers (e.g. firefox) the wrapper div of the window has a `style="position: relative;"` element (which seems to come from the parent component [react-rnd](https://github.com/bokuweb/react-rnd)) and the window appeared below the viewport.

This is fixed by adding a `position: inherit !important;` to the `.react-geo-window-portal` CSS class. On top of that, this class will now correctly be set on the wrapper div (but not on the wrapped panel div as before).