### PR TITLE
Also push master when releasing

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "build:dist": "npm run clean:dist && BABEL_ENV=build babel src --out-dir dist --copy-files --ignore spec.js,example.js,.md",
     "build:all": "npm run build:examples && npm run build:docs && npm run build:dist",
     "build": "npm run test -- --coverage && npm run build:all",
-    "release": "np --no-yarn && git push https://github.com/terrestris/react-geo.git --tags"
+    "release": "np --no-yarn && git push https://github.com/terrestris/react-geo.git master --tags"
   },
   "peerDependencies": {
     "antd": "~3.0",


### PR DESCRIPTION
Until now, when releasing with npm, only the tags were pushed to github, but the master had to be pushed manually.

With this change, the master will also be pushed within this process.

From the git docs:

<pre>
--tags
     All refs under refs/tags are pushed, <b>in addition to refspecs explicitly listed</b> on the command line.
</pre>