### PR TITLE
Simplify map provider

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2575,7 +2575,7 @@
     "circular-json": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
-      "integrity": "sha1-gVyZ6oT2gJUp0vRXkb34JxE1LWY=",
+      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
       "dev": true
     },
     "clap": {
@@ -4358,13 +4358,13 @@
         },
         "ansi-regex": {
           "version": "3.0.0",
-          "resolved": "http://10.133.7.204:4873/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
         },
         "ansi-styles": {
           "version": "3.2.0",
-          "resolved": "http://10.133.7.204:4873/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
           "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
           "dev": true,
           "requires": {
@@ -4399,7 +4399,7 @@
         },
         "strip-ansi": {
           "version": "4.0.0",
-          "resolved": "http://10.133.7.204:4873/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {

--- a/src/HigherOrderComponent/MapProvider/MapProvider.jsx
+++ b/src/HigherOrderComponent/MapProvider/MapProvider.jsx
@@ -54,19 +54,13 @@ class MapProvider extends React.Component {
       ready: false
     };
 
-    if (props.map instanceof OlMap) {
-      this.state = {
-        map: props.map,
+    Promise.resolve(props.map).then((map) => {
+      this.setState({
+        map: map,
         ready: true
-      };
-    } else {
-      props.map.then((map) => {
-        this.setState({
-          map: map,
-          ready: true
-        });
       });
-    }
+    });
+
   }
 
   /**

--- a/src/HigherOrderComponent/MapProvider/MapProvider.spec.jsx
+++ b/src/HigherOrderComponent/MapProvider/MapProvider.spec.jsx
@@ -80,5 +80,27 @@ describe('MapProvider', () => {
         expect(mapFromMock).toBe(map);
       });
     });
+
+    it('Does not render on rejected promise', () => {
+      const errMsg = 'Some message: Humpty';
+      const failingPromise = new Promise((resolve, reject) => {
+        reject(new Error(errMsg));
+      });
+
+      const wrapper = mount(
+        <MapProvider map={failingPromise}> {/* use the failing promise*/}
+          <MappifiedMockComponent />
+        </MapProvider>
+      );
+
+      expect.assertions(3);
+      return failingPromise.catch((err) => {
+        expect(err).toBeInstanceOf(Error);
+        expect(err.message).toBe(errMsg);
+        wrapper.update();
+        const mapFromMock = wrapper.find(MockComponent);
+        expect(mapFromMock.exists()).toBe(false);
+      });
+    });
   });
 });

--- a/src/HigherOrderComponent/MapProvider/MapProvider.spec.jsx
+++ b/src/HigherOrderComponent/MapProvider/MapProvider.spec.jsx
@@ -33,16 +33,32 @@ describe('MapProvider', () => {
 
     it('provides a given map to its children (ol.Map)', () => {
       const map = TestUtil.createMap();
+      // We create the promise only to be able to return it below, we do not
+      // actually use it to instantiate MapProvider
+      const mapPromise = new Promise((resolve) => {
+        resolve(map);
+      });
+
       const wrapper = mount(
-        <MapProvider map={map}>
+        <MapProvider map={map}> {/* See, we use the map, not the promise*/}
           <MappifiedMockComponent />
         </MapProvider>
       );
-      const isReady = wrapper.state('ready');
-      expect(isReady).toBe(true);
 
-      const mapFromMock = wrapper.find(MockComponent).prop('map');
-      expect(mapFromMock).toBe(map);
+      // resolve our promise, so this async behaviour is testable.
+      setTimeout(() => {
+        mapPromise.resolve(map);
+      }, 50);
+
+      expect.assertions(2);
+      return mapPromise.then(() => {
+        const isReady = wrapper.state('ready');
+        expect(isReady).toBe(true);
+        wrapper.update();
+        const mapFromMock = wrapper.find(MockComponent).prop('map');
+        expect(mapFromMock).toBe(map);
+      });
+
     });
 
     it('provides a given map to its children (Promise)', () => {
@@ -51,10 +67,11 @@ describe('MapProvider', () => {
         resolve(map);
       });
       const wrapper = mount(
-        <MapProvider map={mapPromise}>
+        <MapProvider map={mapPromise}> {/* See, we now use the actual promise*/}
           <MappifiedMockComponent />
         </MapProvider>
       );
+      expect.assertions(2);
       return mapPromise.then(() => {
         const isReady = wrapper.state('ready');
         expect(isReady).toBe(true);


### PR DESCRIPTION
## DEVSETUP

### Description:

This makes it easier for people who use `npm link`, where `instanceof` checks sometimes fail.

Also the code is easier to read. I was unsure about how I handle the tests, but this works locally for me. Looking forward to your review.
