### PR TITLE
Refactors Panel, Titlebar and Window

### DIFF
--- a/src/Panel/Panel/Panel.example.jsx
+++ b/src/Panel/Panel/Panel.example.jsx
@@ -15,43 +15,41 @@ render(
       <Panel
         x={0}
         y={20}
-        title="Collapsible"
-        collapsible={true}
+        title="Children"
       >
-        Content
+        <div style={{padding: '5px'}}>
+          Im a div but i can be any node.
+        </div>
       </Panel>
 
       <Panel
-        x={200}
+        x={250}
         y={20}
+        title="Collapsible"
+        collapsible={true}
+      >
+        <div style={{padding: '5px'}}>
+          Content
+        </div>
+      </Panel>
+
+      <Panel
+        x={420}
+        y={20}
+        width={160}
         collapsible={true}
         title="Tooltip"
         collapseTooltip="Einklappen"
       >
-        Content
-      </Panel>
-
-      <Panel
-        x={400}
-        y={20}
-        title="Children"
-      >
-        <div>Im a div but i can be any node.</div>
+        <div style={{padding: '5px'}}>
+          You can set the tooltip for the collapse icon with the prop `collapseTooltip`.
+        </div>
       </Panel>
 
       <Panel
         x={700}
         y={20}
-        title="Resizable"
-        resizeOpts={true}
-      >
-        <img src="http://www.koeln.de/files/images/Karnevalstrikot_Spieler_270.jpg" />
-      </Panel>
-
-      <Panel
-        x={1000}
-        y={20}
-        title="Resizeopts"
+        title="resizeopts (right & bottom)"
         resizeOpts={{
           bottom: true,
           bottomLeft: false,
@@ -62,6 +60,15 @@ render(
           topLeft: false,
           topRight: false,
         }}
+      >
+        <img src="http://www.koeln.de/files/images/Karnevalstrikot_Spieler_270.jpg" />
+      </Panel>
+
+      <Panel
+        x={1000}
+        y={20}
+        title="resizeopts={true}"
+        resizeOpts={true}
       >
         <img src="http://www.koeln.de/files/images/Karnevalstrikot_Spieler_270.jpg" />
       </Panel>

--- a/src/Panel/Panel/Panel.example.jsx
+++ b/src/Panel/Panel/Panel.example.jsx
@@ -12,23 +12,24 @@ render(
     <div className="example-block">
       <span>Panels:</span>
 
-
       <Panel
         x={0}
         y={20}
         title="Collapsible"
         collapsible={true}
-      />
+      >
+        Content
+      </Panel>
 
       <Panel
         x={200}
         y={20}
-        closable={true}
         collapsible={true}
-        title="Tooltips"
-        compressTooltip="Einklappen"
-        closeTooltip="Schließen"
-      />
+        title="Tooltip"
+        collapseTooltip="Einklappen"
+      >
+        Content
+      </Panel>
 
       <Panel
         x={400}
@@ -39,7 +40,7 @@ render(
       </Panel>
 
       <Panel
-        x={600}
+        x={700}
         y={20}
         title="Resizable"
         resizeOpts={true}
@@ -48,7 +49,7 @@ render(
       </Panel>
 
       <Panel
-        x={800}
+        x={1000}
         y={20}
         title="Resizeopts"
         resizeOpts={{
@@ -68,7 +69,8 @@ render(
       <Panel
         x={0}
         y={220}
-        title="Custom size"
+        title="Intial size (673 * 134)"
+        resizeOpts={true}
         width={673}
         height={134}
       />

--- a/src/Panel/Panel/Panel.jsx
+++ b/src/Panel/Panel/Panel.jsx
@@ -1,7 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Rnd from 'react-rnd';
-import { uniqueId, isNumber, isFunction } from 'lodash';
+import {
+  uniqueId,
+  isNumber,
+  isFunction
+} from 'lodash';
 
 import Titlebar from '../Titlebar/Titlebar.jsx';
 import SimpleButton from '../../Button/SimpleButton/SimpleButton.jsx';
@@ -118,15 +122,29 @@ export class Panel extends React.Component {
 
     /**
      * The height of the panel.
-     * @type {number}
+     * @type {number|string}
      */
-    height: PropTypes.number,
+    height: PropTypes.oneOfType([
+      PropTypes.number,
+      PropTypes.oneOf([
+        'inherit',
+        'initial',
+        'auto'
+      ])
+    ]),
 
     /**
      * The width of the panel.
-     * @type {number}
+     * @type {number|string}
      */
-    width: PropTypes.number,
+    width: PropTypes.oneOfType([
+      PropTypes.number,
+      PropTypes.oneOf([
+        'inherit',
+        'initial',
+        'auto'
+      ])
+    ]),
 
     /**
      * The height of the TitleBar.
@@ -157,8 +175,8 @@ export class Panel extends React.Component {
     closable: false,
     resizeOpts: false,
     titleBarHeight: 37.5,
-    height: 100,
-    width: 100,
+    height: 'auto',
+    width: 'auto',
     compressTooltip: 'collapse',
     closeTooltip: 'close',
     onClose: () => {}
@@ -183,16 +201,41 @@ export class Panel extends React.Component {
   }
 
   /**
+   * Calculates the height of the Panel and returns a number.
+   *
+   * @return {number}
+   */
+  calculateHeight() {
+    return this.state.collapsed
+      ? this.state.titleBarHeight
+      : this.state.height;
+  }
+
+  /**
+   * Calculates the height of the Panel body and returns a valid css height
+   * expression.
+   *
+   * @return {string}
+   */
+  calculateBodyHeight() {
+    if (this.state.collapsed) {
+      return '0px';
+    } else {
+      return isNumber(this.state.height)
+        ? this.state.height + 'px'
+        : this.state.height;
+    }
+  }
+
+  /**
    * Toggles the collapse state of the panel.
    */
   toggleCollapse = () => {
     this.setState({
       collapsed: !this.state.collapsed
     }, () => {
-      this.panel.updateSize({
-        height: this.state.collapsed
-          ? this.state.titleBarHeight
-          : this.state.height,
+      this.rnd.updateSize({
+        height: this.calculateHeight(),
         width: this.state.width
       });
     });
@@ -306,14 +349,12 @@ export class Panel extends React.Component {
     return (
       <Rnd
         className={rndClassName}
-        ref={(panel) => { this.panel = panel; }}
+        ref={(rnd) => { this.rnd = rnd; }}
         default={{
           x: isNumber(rndOpts.x) ? rndOpts.x : (window.innerWidth / 2) - 160,
           y: isNumber(rndOpts.y) ? rndOpts.y : (window.innerHeight / 2) - 100,
-          width: rndOpts.width || 160,
-          height: this.state.collapsed
-            ? this.state.titleBarHeight
-            : this.state.height
+          width: this.state.width,
+          height: this.calculateHeight()
         }}
         dragHandleClassName=".drag-handle"
         disableDragging={!draggable}
@@ -339,9 +380,7 @@ export class Panel extends React.Component {
           style={{
             cursor: 'default',
             overflow: 'hidden',
-            height: this.state.collapsed
-              ? '0px'
-              : this.state.height - this.state.titleBarHeight,
+            height: this.calculateBodyHeight(),
             transition: this.state.resizing ? '' : 'height 0.25s',
           }}
         >

--- a/src/Panel/Panel/Panel.jsx
+++ b/src/Panel/Panel/Panel.jsx
@@ -60,13 +60,6 @@ export class Panel extends React.Component {
     title: PropTypes.string,
 
     /**
-     * function called on close
-     *
-     * @type {Function}
-     */
-    onClose: PropTypes.func,
-
-    /**
      * The enableResizing property is used to set the resizable permission of a
      * resizable component.
      * The permission of top, right, bottom, left, topRight, bottomRight,
@@ -153,16 +146,15 @@ export class Panel extends React.Component {
     titleBarHeight: PropTypes.number,
 
     /**
-     * The tooltip of the compress button.
+     * The tooltip of the collapse button.
      * @type {String}
      */
-    compressTooltip: PropTypes.string,
+    collapseTooltip: PropTypes.string,
 
     /**
-     * The tooltip of the close button.
-     * @type {String}
+     *
      */
-    closeTooltip: PropTypes.string
+    tools: PropTypes.arrayOf(PropTypes.node)
   }
 
   /**
@@ -172,14 +164,12 @@ export class Panel extends React.Component {
   static defaultProps = {
     draggable: false,
     collapsible: false,
-    closable: false,
     resizeOpts: false,
     titleBarHeight: 37.5,
+    tools: [],
     height: 'auto',
     width: 'auto',
-    compressTooltip: 'collapse',
-    closeTooltip: 'close',
-    onClose: () => {}
+    collapseTooltip: 'collapse'
   }
 
   /**
@@ -222,7 +212,7 @@ export class Panel extends React.Component {
       return '0px';
     } else {
       return isNumber(this.state.height)
-        ? this.state.height + 'px'
+        ? (this.state.height - this.state.titleBarHeight) + 'px'
         : this.state.height;
     }
   }
@@ -290,14 +280,13 @@ export class Panel extends React.Component {
    */
   render() {
     const {
-      closable,
       collapsible,
+      className,
       draggable,
       resizeOpts,
-      className,
-      onClose,
       ...rndOpts
     } = this.props;
+    let tools = [...this.props.tools];
 
     const finalClassName = className
       ? `${className} ${this.className}`
@@ -306,22 +295,12 @@ export class Panel extends React.Component {
     const rndClassName = `${finalClassName} ${this.state.id}`;
     const enableResizing = resizeOpts === true ? undefined : resizeOpts;
 
-    let tools = [];
     if (collapsible) {
-      tools.push(<SimpleButton
+      tools.unshift(<SimpleButton
         icon="compress"
-        key="compress-tool"
+        key="collapse-tool"
         onClick={this.toggleCollapse}
-        tooltip={this.props.compressTooltip}
-        size="small"
-      />);
-    }
-    if (closable) {
-      tools.push(<SimpleButton
-        icon="times"
-        key="close-tool"
-        onClick={onClose}
-        tooltip={this.props.closeTooltip}
+        tooltip={this.props.collapseTooltip}
         size="small"
       />);
     }
@@ -332,11 +311,6 @@ export class Panel extends React.Component {
 
     const titleBar = this.props.title ? <Titlebar
       className={titleBarClassName}
-      closable={closable}
-      collapsible={collapsible}
-      parent={this}
-      compressTooltip={this.props.compressTooltip}
-      closeTooltip={this.props.closeTooltip}
       tools={tools}
       style={{
         height: this.state.titleBarHeight,
@@ -349,7 +323,7 @@ export class Panel extends React.Component {
     return (
       <Rnd
         className={rndClassName}
-        ref={(rnd) => { this.rnd = rnd; }}
+        ref={rnd => this.rnd = rnd}
         default={{
           x: isNumber(rndOpts.x) ? rndOpts.x : (window.innerWidth / 2) - 160,
           y: isNumber(rndOpts.y) ? rndOpts.y : (window.innerHeight / 2) - 100,

--- a/src/Panel/Titlebar/Titlebar.jsx
+++ b/src/Panel/Titlebar/Titlebar.jsx
@@ -40,43 +40,10 @@ export class Titlebar extends React.Component {
      */
     dispatch: PropTypes.func,
     /**
-     * The object of the parent container of the titlebar class.
-     * @type {object}
-     */
-    parent: PropTypes.object,
-    /**
-     * Additional elements display besides the collapseButton.
+     * Additional elements to show at the right side of the Titlebar.
      * @type {Array<object>}
      */
-    tools: PropTypes.arrayOf(PropTypes.element),
-    /**
-     * Whether to allow collasping or not.
-     * @type {boolean}
-     */
-    collapsible: PropTypes.bool,
-    /**
-     * Whether to allow closing or not.
-     * @type {boolean}
-     */
-    closable: PropTypes.bool,
-    /**
-     * The tooltip of the compress button.
-     * @type {String}
-     */
-    compressTooltip: PropTypes.string,
-    /**
-     * The tooltip of the close button.
-     * @type {String}
-     */
-    closeTooltip: PropTypes.string
-  }
-
-  /**
-   * The default props
-   */
-  static defaultProps = {
-    compressTooltip: 'compress',
-    closeTooltip: 'close'
+    tools: PropTypes.arrayOf(PropTypes.element)
   }
 
   /**
@@ -85,7 +52,9 @@ export class Titlebar extends React.Component {
   render() {
     const {
       className,
-      tools
+      tools,
+      children,
+      ...passThroughProps
     } = this.props;
 
     const finalClassName = className
@@ -93,9 +62,9 @@ export class Titlebar extends React.Component {
       : this.className;
 
     return (
-      <div className={finalClassName}>
+      <div className={finalClassName} {...passThroughProps} >
         <span className="title">
-          {this.props.children}
+          {children}
         </span>
         {
           !isEmpty(tools) ?

--- a/src/Panel/Titlebar/Titlebar.less
+++ b/src/Panel/Titlebar/Titlebar.less
@@ -8,15 +8,15 @@
   color: @primary-color;
   font-weight: bold;
 
-  >span {
-    margin: 5px;
-  }
-
   .title {
+    margin: 5px;
     flex: 1;
   }
 
   .controls {
+    margin: 5px;
+    display: flex;
+
     >button {
       margin-right: 2px;
     }

--- a/src/Panel/Titlebar/Titlebar.spec.jsx
+++ b/src/Panel/Titlebar/Titlebar.spec.jsx
@@ -15,15 +15,12 @@ describe('<Titlebar />', () => {
   });
 
   it('can be rendered', () => {
-    const wrapper = TestUtil.mountComponent(Titlebar, {
-      parent: document.body
-    });
+    const wrapper = TestUtil.mountComponent(Titlebar);
     expect(wrapper).not.toBeUndefined();
   });
 
   it('adds a passed className', () => {
     const wrapper = TestUtil.mountComponent(Titlebar, {
-      parent: document.body,
       className: 'podolski'
     });
     expect(wrapper.instance().props.className).toContain('podolski');

--- a/src/Window/Window.example.jsx
+++ b/src/Window/Window.example.jsx
@@ -26,16 +26,27 @@ const doRender = () => {
 
       <div className="example-block">
         <span>Click to open window:</span>
-        <SimpleButton tooltip="Click me to show/hide a window" onClick={triggerRerenderingWithInvertedVisibility} />
+        <SimpleButton
+          tooltip="Click me to show/hide a window"
+          onClick={triggerRerenderingWithInvertedVisibility}
+        />
 
         {
           windowOpen ?
             <Window
               parentId="exampleContainer"
               title="This is the window title"
-              onClose={triggerRerenderingWithInvertedVisibility}
               width={300}
               height={150}
+              tools={[
+                <SimpleButton
+                  key="closeButton"
+                  icon="close"
+                  size="small"
+                  tooltip="Close"
+                  onClick={triggerRerenderingWithInvertedVisibility}
+                />
+              ]}
             >
               This is the content of the window.
             </Window> :

--- a/src/Window/Window.jsx
+++ b/src/Window/Window.jsx
@@ -11,7 +11,7 @@ import './Window.less';
 /**
  * Window component that creates a React portal that renders children into a DOM
  * node that exists outside the DOM hierarchy of the parent component. By default,
- * Window Component is draggable and closable
+ * Window Component is draggable.
  *
  * @class Window
  * @extends React.Component
@@ -58,19 +58,15 @@ export class Window extends React.Component {
     * The title text to be shown in the window header.
     * @type {string}
     */
-    title: PropTypes.string,
-    /**
-    * Function to be called if window is closed
-    * @type {Function}
-    */
-    onClose: PropTypes.func
+    title: PropTypes.string
   }
 
   static defaultProps = {
     parentId: 'app',
     title: 'Window',
     resizeOpts: true,
-    onClose: () => {} // default: do nothing
+    collapsible: true,
+    draggable: true
   }
 
   /**
@@ -136,17 +132,11 @@ export class Window extends React.Component {
     const {
       className,
       children,
-      onClose,
-      ...rndOpts
+      ...passThroughProps
     } = this.props;
 
     return ReactDOM.createPortal(
-      <Panel
-        closable
-        draggable
-        onClose={onClose}
-        {...rndOpts}
-      >
+      <Panel {...passThroughProps} >
         {children}
       </Panel>,
       this._elementDiv,


### PR DESCRIPTION
<!--- Please choose one of the categories. -->
##  :exclamation: BREAKING CHANGE :exclamation: 

### Description:
<!--- Please describe what this PR is about. -->

This is a breaking change as it removes some props from `Panel`, `Titlebar` and `Window`:

- Removes closable prop from all three classes
  - If you wan't to implement a close button just do it your self and pass it via the `tools` property.
- Removes collapsible prop from Titlebar
  - This prop was not used as the `Panel` passes a CollapseButton if you configure it with `collapsible`
- Removes unused parent property from Titlebar and Panel
- Renames `compress…` props to `collapse…`

It also changes the way the `Panel` component calculates its height and the height of its body.
The old defaults for the props `height` (100) and `width` (100) are replaced with `'auto'` so the Panel will grow with its content, except you specify a specific height and width.

@terrestris/devs plz review (and test)

<!--- CHECKLIST
Fixes Issue?
Examples added?
Tests added?
Docs added?
Would a screenshot be helpful?
Do you want to mention someone?
-->
