### PR TITLE
Digitize tools enhancements

### DIFF
--- a/src/Button/DigitizeButton/DigitizeButton.jsx
+++ b/src/Button/DigitizeButton/DigitizeButton.jsx
@@ -134,6 +134,13 @@ class DigitizeButton extends React.Component {
   static DEFAULT_STROKE_COLOR = 'rgba(154, 26, 56, 0.8)';
 
   /**
+   * Hit detection in pixels used for select interaction.
+   *
+   * @type {Number}
+   */
+   static HIT_TOLERANCE = 5;
+
+  /**
    * Default style for digitized points.
    *
    * @type {OlStyleStyle}
@@ -551,7 +558,7 @@ class DigitizeButton extends React.Component {
     this._selectInteraction = new OlInteractionSelect({
       condition: OlEventsCondition.singleClick,
       style: this.getDigitizeStyleFunction,
-      hitTolerance: 5
+      hitTolerance: DigitizeButton.HIT_TOLERANCE
     });
 
     if (editType === DigitizeButton.DELETE_EDIT_TYPE) {
@@ -715,19 +722,29 @@ class DigitizeButton extends React.Component {
    * a hoverable layer.
    *
    * @param {ol.MapEvent} evt The `pointermove` event.
-   *
-   * @method
    */
   onPointerMove = evt => {
     if (evt.dragging) {
       return;
     }
 
-    const { map } = this.props;
+    const {
+      map,
+      digitizeLayerName
+    } = this.props;
+
     const pixel = map.getEventPixel(evt.originalEvent);
-    const hit = map.hasFeatureAtPixel(pixel);
+
+    const hit = map.hasFeatureAtPixel(pixel, {
+      layerFilter: (l) => {
+        return l.get('name') === digitizeLayerName;
+      },
+      hitTolerance: DigitizeButton.HIT_TOLERANCE
+    });
 
     map.getTargetElement().style.cursor = hit ? 'pointer' : '';
+
+
   }
 
   /**

--- a/src/Util/AnimateUtil/AnimateUtil.spec.js
+++ b/src/Util/AnimateUtil/AnimateUtil.spec.js
@@ -20,7 +20,7 @@ describe('AnimateUtil', () => {
       it('is defined', () => {
         expect(AnimateUtil.moveFeature).toBeDefined();
       });
-      it('registers postcompose listener on the map', () => {
+      it('moves feature to the new position', () => {
 
         const coords = [0, 0];
         const geom = new OlGeomPoint(coords);


### PR DESCRIPTION
## REFACTORING

### Description:
This is a follow-up of #377 covering issues from https://github.com/terrestris/react-geo/issues/380.

Details:

- Introduced `style` property including the whole `ol.style.Style` object for the `DigitizeButton`. Currently this style will be used in the style function of the `digitizeLayer`. For the future it can be assigned to the singly drawn features to be able to manipulate its style e.g. via styler.
- Added `layerFilter` property to match only features of `digitizeLayer` in select/edit mode.

Please review @terrestris/devs 