### PR TITLE
Introduces stripHTMLTags method to StringUtil

### DIFF
--- a/src/Util/StringUtil/StringUtil.js
+++ b/src/Util/StringUtil/StringUtil.js
@@ -60,7 +60,7 @@ class StringUtil {
    * @param {String} spaceReplacer The string to replace spaces with.
    * @return {String} The 'wrapped' string.
    */
-  static stringDivider = (str, width, spaceReplacer)  => {
+  static stringDivider(str, width, spaceReplacer) {
 
     let startIndex = 0;
     let stopIndex = width;
@@ -93,6 +93,19 @@ class StringUtil {
       }
     }
     return str;
+  }
+
+  /**
+   * Returns the displayed text of an string with html text.
+   *
+   * @param {string} htmlString A string containing html.
+   * @return {string} The stripped Text.
+   */
+  static stripHTMLTags(htmlString) {
+    const div = document.createElement('div');
+    div.innerHTML = htmlString;
+    const text = div.textContent || div.innerText || '';
+    return text;
   }
 }
 

--- a/src/Util/StringUtil/StringUtil.spec.js
+++ b/src/Util/StringUtil/StringUtil.spec.js
@@ -99,6 +99,15 @@ describe('StringUtil', () => {
         expect(outputString).toBe(expectedString);
       });
     });
+
+    describe('#stripHTMLTags', () => {
+      it ('returns the text content of an html string', () => {
+        const htmlString = '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap contributors</a> <br>';
+        const got = '© OpenStreetMap contributors ';
+        const result = StringUtil.stripHTMLTags(htmlString);
+        expect(result).toBe(got);
+      });
+    });
   });
 
 });


### PR DESCRIPTION
<!--- Please choose one of the categories and choose the corresponding label, too. -->
## FEATURE

### Description:
This introduces the `stripHTMLTags` method to the `StringUtil`.

It removes the HTML-Tags and returns just the textual content. Compare the spec file.

<!--- Please describe what this PR is about. -->

<!--- CHECKLIST
Fixes Issue?
Examples added?
Tests added?
Docs added?
Would a screenshot be helpful?
Do you want to mention someone?
-->
