### PR TITLE
Remove unused i18n dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,6 @@
     "react": "~16.0"
   },
   "dependencies": {
-    "i18next": "10.4.1",
     "lodash": "4.17.5",
     "loglevel": "1.6.1",
     "moment": "2.20.1",
@@ -78,7 +77,6 @@
     "query-string": "5.1.0",
     "react-dom": "16.2.0",
     "react-fa": "5.0.0",
-    "react-i18next": "7.3.5",
     "react-rnd": "7.3.0",
     "url-parse": "1.2.0",
     "validator": "9.4.1"


### PR DESCRIPTION
<!--- Please choose one of the categories and choose the corresponding label, too. -->
## REFACTORING
### Description:
<!--- Please describe what this PR is about. -->
`i18next` and `react-i18next` weren't is use and in my opinion `react-geo` should only expose all translatable contents as props so the real translation could take place in the application itself (e.g. by using `translate` provided by `react-i18next`).

<!--- CHECKLIST
Fixes Issue?
Examples added?
Tests added?
Docs added?
Would a screenshot be helpful?
Do you want to mention someone?
-->
