### PR TITLE
Only apply pressed state to togglebuttons

### DIFF
--- a/src/Button/ToggleGroup/ToggleGroup.jsx
+++ b/src/Button/ToggleGroup/ToggleGroup.jsx
@@ -2,6 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { isFunction } from 'lodash';
 
+import ToggleButton from '../ToggleButton/ToggleButton.jsx';
+
 import './ToggleGroup.less';
 
 /**
@@ -163,6 +165,10 @@ class ToggleGroup extends React.Component {
       : 'horizontal-toggle-group';
 
     const childrenWithProps = React.Children.map(children, (child) => {
+      // Only set pressed state for ToggleButtons
+      if (!(child.type === ToggleButton)) {
+        return child;
+      }
       return React.cloneElement(child, {
         pressed: this.state.selectedName === child.props.name
       });


### PR DESCRIPTION
<!--- Please choose one of the categories and choose the corresponding label, too. -->
## BUGFIX

### Description:
<!--- Please describe what this PR is about. -->
This adds a check to the togglegroup render method to only apply the pressed state to children which are instances of `ToggleButton`.

<!--- CHECKLIST
Fixes Issue?
Examples added?
Tests added?
Docs added?
Would a screenshot be helpful?
Do you want to mention someone?
-->
Fixes #418 
