### PR TITLE
Add basic .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+build/
+coverage/
+dist/
+
+C:\\nppdf32Log\\debuglog.txt


### PR DESCRIPTION
<!--- Please choose one of the categories and choose the corresponding label, too. -->
## WEBSITE

### Description:

Add a basic `.gitignore`-file so we are able to work on the gh-pages branch locally.
