### PR TITLE
Modifies implementation of featurestyle prop of FeatureGrid

### DIFF
--- a/src/Grid/FeatureGrid/FeatureGrid.jsx
+++ b/src/Grid/FeatureGrid/FeatureGrid.jsx
@@ -307,7 +307,6 @@ export class FeatureGrid extends React.Component {
     const {
       map,
       features,
-      featureStyle,
       selectable
     } = this.props;
 
@@ -320,7 +319,6 @@ export class FeatureGrid extends React.Component {
       if (this._source) {
         this._source.clear();
         this._source.addFeatures(nextProps.features);
-        this._source.forEachFeature(feature => feature.setStyle(featureStyle));
       }
 
       if (nextProps.zoomToExtent) {
@@ -378,10 +376,9 @@ export class FeatureGrid extends React.Component {
 
     const layer = new OlLayerVector({
       name: layerName,
-      source: source
+      source: source,
+      style: featureStyle
     });
-
-    source.forEachFeature(feature => feature.setStyle(featureStyle));
 
     map.addLayer(layer);
 
@@ -421,7 +418,6 @@ export class FeatureGrid extends React.Component {
     const {
       map,
       features,
-      featureStyle,
       highlightStyle,
       selectStyle
     } = this.props;
@@ -444,7 +440,7 @@ export class FeatureGrid extends React.Component {
       if (selectedRowKeys.includes(key)) {
         feature.setStyle(selectStyle);
       } else {
-        feature.setStyle(featureStyle);
+        feature.setStyle(null);
       }
     });
 
@@ -467,7 +463,6 @@ export class FeatureGrid extends React.Component {
   onMapSingleClick = olEvt => {
     const {
       map,
-      featureStyle,
       selectStyle
     } = this.props;
 
@@ -485,7 +480,7 @@ export class FeatureGrid extends React.Component {
       const key = this.props.keyFunction(selectedFeature);
       if (rowKeys.includes(key)) {
         rowKeys = rowKeys.filter(rowKey => rowKey !== key);
-        selectedFeature.setStyle(featureStyle);
+        selectedFeature.setStyle(null);
       } else {
         rowKeys.push(key);
         selectedFeature.setStyle(selectStyle);
@@ -730,7 +725,6 @@ export class FeatureGrid extends React.Component {
   unhighlightFeatures = unhighlightFeatures => {
     const {
       map,
-      featureStyle,
       selectStyle
     } = this.props;
 
@@ -747,7 +741,7 @@ export class FeatureGrid extends React.Component {
       if (selectedRowKeys.includes(key)) {
         feature.setStyle(selectStyle);
       } else {
-        feature.setStyle(featureStyle);
+        feature.setStyle(null);
       }
     });
   }
@@ -776,15 +770,14 @@ export class FeatureGrid extends React.Component {
   resetFeatureStyles = () => {
     const {
       map,
-      features,
-      featureStyle
+      features
     } = this.props;
 
     if (!(map instanceof OlMap)) {
       return;
     }
 
-    features.forEach(feature => feature.setStyle(featureStyle));
+    features.forEach(feature => feature.setStyle(null));
   }
 
   /**

--- a/src/Grid/FeatureGrid/FeatureGrid.spec.jsx
+++ b/src/Grid/FeatureGrid/FeatureGrid.spec.jsx
@@ -64,12 +64,9 @@ describe('<FeatureGrid />', () => {
     expect(wrapper.instance()._layer).toBeInstanceOf(OlLayerVector);
   });
 
-  it('sets the given featureStyle to each feature in the given features array', () => {
+  it('sets the given featureStyle to the featurelayer', () => {
     const wrapper = TestUtil.mountComponent(FeatureGrid, {map, features});
-
-    features.forEach(feature => {
-      expect(feature.getStyle()).toEqual(wrapper.prop('featureStyle'));
-    });
+    expect(wrapper.instance()._layer.getStyle()).toEqual(wrapper.prop('featureStyle'));
   });
 
   it('removes the vector layer from the map on unmount', () => {
@@ -207,7 +204,7 @@ describe('<FeatureGrid />', () => {
       if (feature.ol_uid === selectedFeatureUid) {
         expect(feature.getStyle()).toEqual(wrapper.prop('selectStyle'));
       } else {
-        expect(feature.getStyle()).toEqual(wrapper.prop('featureStyle'));
+        expect(feature.getStyle()).toBe(null);
       }
     });
   });
@@ -228,7 +225,7 @@ describe('<FeatureGrid />', () => {
     wrapper.instance().resetFeatureStyles(features);
 
     features.forEach(feature => {
-      expect(feature.getStyle()).toEqual(wrapper.prop('featureStyle'));
+      expect(feature.getStyle()).toBe(null);
     });
   });
 
@@ -242,7 +239,7 @@ describe('<FeatureGrid />', () => {
       if (selectedRowKeys.includes(feature.ol_uid)) {
         expect(feature.getStyle()).toEqual(wrapper.prop('selectStyle'));
       } else {
-        expect(feature.getStyle()).toEqual(wrapper.prop('featureStyle'));
+        expect(feature.getStyle()).toBe(null);
       }
     });
 
@@ -339,9 +336,6 @@ describe('<FeatureGrid />', () => {
     });
 
     expect(wrapper.instance()._source.getFeatures()).toEqual(features);
-    features.forEach(feature => {
-      expect(feature.getStyle()).toEqual(wrapper.prop('featureStyle'));
-    });
     expect(zoomToFeaturesSpy).toHaveBeenCalled();
 
     zoomToFeaturesSpy.mockReset();
@@ -383,8 +377,8 @@ describe('<FeatureGrid />', () => {
 
     expect(features[0].getStyle()).toEqual(wrapper.prop('highlightStyle'));
 
-    expect(features[1].getStyle()).toEqual(wrapper.prop('featureStyle'));
-    expect(features[2].getStyle()).toEqual(wrapper.prop('featureStyle'));
+    expect(features[1].getStyle()).toEqual(null);
+    expect(features[2].getStyle()).toEqual(null);
 
     getFeaturesAtPixelSpy.mockReset();
     getFeaturesAtPixelSpy.mockRestore();

--- a/src/Grid/FeatureGrid/FeatureGridWfs.example.jsx
+++ b/src/Grid/FeatureGrid/FeatureGridWfs.example.jsx
@@ -167,7 +167,7 @@ class RemoteFeatureGrid extends React.Component {
         color: color
       })),
       text: new OlStyleText({
-        text: feature.get('name'),
+        text: feature ? feature.get('name') : '',
         fill: new OlStyleFill({
           color: 'rgb(0, 0, 0)'
         }),


### PR DESCRIPTION
<!--- Please choose one of the categories and choose the corresponding label, too. -->
## REFACTORING | BUGFIX

### Description:
<!--- Please describe what this PR is about. -->

This modifies the way of how the `featureStyle` prop is applied.
Currently the `featureStyle` is applied to every feature separately.
This PR changes the implementation so that the style is applied to the layer and not to the feature itself.

The advantage is, that you can have the feature in an existing vectorlayer overwriting its style there.

<!--- CHECKLIST
Fixes Issue?
Examples added?
Tests added?
Docs added?
Would a screenshot be helpful?
Do you want to mention someone?
-->
