### PR TITLE
Feature grid: rowClassName as function and CSS key fixes

### DIFF
--- a/src/Grid/FeatureGrid/FeatureGrid.jsx
+++ b/src/Grid/FeatureGrid/FeatureGrid.jsx
@@ -3,7 +3,8 @@ import PropTypes from 'prop-types';
 import { Table } from 'antd';
 import {
   isEqual,
-  isFunction
+  isFunction,
+  kebabCase
 } from 'lodash';
 import OlStyle from 'ol/style/style';
 import OlStyleFill from 'ol/style/fill';
@@ -431,7 +432,7 @@ export class FeatureGrid extends React.Component {
     }) || [];
 
     features.forEach(feature => {
-      const key = this.props.keyFunction(feature);
+      const key = kebabCase(this.props.keyFunction(feature));
       const sel = `.${this._rowClassName}.${this._rowKeyClassNamePrefix}${key}`;
       const el = document.querySelectorAll(sel)[0];
       if (el) {
@@ -445,7 +446,7 @@ export class FeatureGrid extends React.Component {
     });
 
     selectedFeatures.forEach(feature => {
-      const key = this.props.keyFunction(feature);
+      const key = kebabCase(this.props.keyFunction(feature));
       const sel = `.${this._rowClassName}.${this._rowKeyClassNamePrefix}${key}`;
       const el = document.querySelectorAll(sel)[0];
       if (el) {

--- a/src/Grid/FeatureGrid/FeatureGrid.jsx
+++ b/src/Grid/FeatureGrid/FeatureGrid.jsx
@@ -845,7 +845,7 @@ export class FeatureGrid extends React.Component {
 
     let rowClassNameFn;
     if (isFunction(rowClassName)) {
-      rowClassNameFn = rowClassName;
+      rowClassNameFn = record => `${this._rowClassName} ${rowClassName(record)}`;
     } else {
       const finalRowClassName = rowClassName
         ? `${rowClassName} ${this._rowClassName}`

--- a/src/Grid/FeatureGrid/FeatureGrid.jsx
+++ b/src/Grid/FeatureGrid/FeatureGrid.jsx
@@ -83,10 +83,14 @@ export class FeatureGrid extends React.Component {
     className: PropTypes.string,
 
     /**
-     * Optional CSS class to add to each table row.
-     * @type {String}
+     * Optional CSS class to add to each table row or a function that
+     * is evaluated for each record
+     * @type {String|Function}
      */
-    rowClassName: PropTypes.string,
+    rowClassName: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.func
+    ]),
 
     /**
      * The features to show in the grid and the map (if set).
@@ -839,9 +843,15 @@ export class FeatureGrid extends React.Component {
       ? `${className} ${this._className}`
       : this._className;
 
-    const finalRowClassName = rowClassName
-      ? `${rowClassName} ${this._rowClassName}`
-      : this._rowClassName;
+    let rowClassNameFn;
+    if (isFunction(rowClassName)) {
+      rowClassNameFn = rowClassName;
+    } else {
+      const finalRowClassName = rowClassName
+        ? `${rowClassName} ${this._rowClassName}`
+        : this._rowClassName;
+      rowClassNameFn = record => `${finalRowClassName} ${this._rowKeyClassNamePrefix}${kebabCase(record.key)}`;
+    }
 
     return (
       <Table
@@ -853,7 +863,7 @@ export class FeatureGrid extends React.Component {
           onMouseOver: () => this.onRowMouseOver(record),
           onMouseOut: () => this.onRowMouseOut(record)
         })}
-        rowClassName={record => `${finalRowClassName} ${this._rowKeyClassNamePrefix}${record.key}`}
+        rowClassName={rowClassNameFn}
         rowSelection={selectable ? rowSelection : null}
         ref={ref => this._ref = ref}
         {...passThroughProps}


### PR DESCRIPTION
## FEATURE / BUGFIXES

### Description:
* use kebabCase for row keys
  * If not `ol_uid` is used as row key (e.g. by using `keyFunction` prop with `keyFunction={f => f.getId()}` this can lead to errornous row class names that contain irregular characters like `.`. In order to prevent this, keys are [`"kebabCased"`](https://lodash.com/docs/4.17.5#kebabCase).
* enable rowClassName prop being a function as well