### PR TITLE
Render LegendGraphic again when props have changed

### DIFF
--- a/src/Legend/Legend.jsx
+++ b/src/Legend/Legend.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 
 import Logger from '../Util/Logger';
 import MapUtil from '../Util/MapUtil/MapUtil';
+import { isEqual } from 'lodash';
 
 /**
  * Class representing the Legend.
@@ -62,14 +63,19 @@ export class Legend extends React.Component {
    * Calls getLegendUrl.
    */
   componentWillMount() {
-    this.getLegendUrl();
+    let layer = this.props.layer;
+    let extraParams = this.props.extraParams;
+    this.getLegendUrl(layer, extraParams);
   }
 
   /**
    * Calls getLegendUrl for dynamic extraParams like scale
    */
-  componentWillReceiveProps() {
-    this.getLegendUrl();
+  componentWillReceiveProps(nextProps) {
+    if(nextProps.extraParams &&
+      !(isEqual(this.props.extraParams, nextProps.extraParams))) {
+      this.getLegendUrl(nextProps.layer, nextProps.extraParams);
+    }
   }
 
   /**
@@ -78,13 +84,12 @@ export class Legend extends React.Component {
    * will be created by the MapUtil.
    *
    */
-  getLegendUrl() {
-    const {layer} = this.props;
+  getLegendUrl(layer, extraParams) {
     let legendUrl;
     if (layer.get('legendUrl')) {
       legendUrl = layer.get('legendUrl');
     } else {
-      legendUrl = MapUtil.getLegendGraphicUrl(layer, this.props.extraParams);
+      legendUrl = MapUtil.getLegendGraphicUrl(layer, extraParams);
     }
     this.setState({legendUrl});
   }

--- a/src/Legend/Legend.jsx
+++ b/src/Legend/Legend.jsx
@@ -66,6 +66,13 @@ export class Legend extends React.Component {
   }
 
   /**
+   * Calls getLegendUrl for dynamic extraParams like scale
+   */
+  componentWillReceiveProps() {
+    this.getLegendUrl();
+  }
+
+  /**
    * Get the corresponding legendGraphic of a layer. If layer is configured with
    * "legendUrl" this will be used. Otherwise a getLegendGraphic requestString
    * will be created by the MapUtil.


### PR DESCRIPTION
<!--- Please choose one of the categories and choose the corresponding label, too. -->
## FEATURE
Render LegendGraphic again when props have changed

### Description:
If the props of a Legend change, it will now get requested again.
Usecase: passing a dynamic `extraParam` to the legend like the `scale` parameter will now be handled correctly. Before, the legend was only rendered once and never again.

