### PR TITLE
WIP Introduce split by line

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "react": "~16.0"
   },
   "dependencies": {
+    "@turf/turf": "5.1.6",
     "lodash": "4.17.5",
     "loglevel": "1.6.1",
     "moment": "2.21.0",

--- a/src/Util/GeometryUtil/GeometryUtil.js
+++ b/src/Util/GeometryUtil/GeometryUtil.js
@@ -1,0 +1,93 @@
+import OlFormatGeoJSON from 'ol/format/geojson';
+import {
+  polygonToLine,
+  union,
+  polygonize,
+  centroid,
+  booleanPointInPolygon,
+  buffer,
+  segmentEach,
+  multiLineString,
+  getCoords
+} from '@turf/turf';
+
+/**
+ * Helper Class for the geospatial analysis.
+ *
+ * @class GeometryUtil
+ */
+class GeometryUtil {
+
+  /**
+   *
+   * @param {ol.Feature} polygonFeat The feature with a polygon geometry to split.
+   * @param {ol.Feature} lineFeat The feature with a line geometry to split the
+   *                              polygon geometry with.
+   * @param {ol.ProjectionLike} epsg The EPSG code of the input features. Default
+   *                                  is to EPSG:3857.
+   * @param {Number} tolerance The tolerance (in meters) used to find if a line
+   *                           vertex is inside the polygon geometry. Default is
+   *                           to 10.
+   *
+   * @return {ol.Feature[]}
+   */
+  static splitByLine(polygonFeat, lineFeat, epsg = 'EPSG:3857', tolerance = 10) {
+    const format = new OlFormatGeoJSON();
+    const formatOptions = {
+      dataProjection: 'EPSG:4326',
+      featureProjection: epsg
+    };
+
+    // Convert the input features to turf.js/GeoJSON features while
+    // reprojecting them to the internal turf.js projection 'EPSG:4326'.
+    const turfPolygon = format.writeFeatureObject(polygonFeat, formatOptions);
+    const turfLine = format.writeFeatureObject(lineFeat, formatOptions);
+
+    // Union both geometries to a set of MultiLineStrings.
+    const unionGeom = union(polygonToLine(turfPolygon), turfLine);
+
+    // Buffer the input polygon to take great circle (un-)precision
+    // into account.
+    const bufferedTurfPolygon = buffer(turfPolygon, tolerance, {
+      units: 'meters'
+    });
+
+    let filteredSegments = [];
+
+    // Iterate over each segment and remove any segment that is not covered by
+    // the (buffered) input polygon.
+    segmentEach(unionGeom, (currentSegment, featureIndex, multiFeatureIndex) => {
+      const segmentCenter = centroid(currentSegment);
+      const isSegmentInPolygon = booleanPointInPolygon(segmentCenter, bufferedTurfPolygon);
+
+      if (isSegmentInPolygon) {
+        if (!filteredSegments[multiFeatureIndex]) {
+          filteredSegments[multiFeatureIndex] = [];
+        }
+
+        if (filteredSegments[multiFeatureIndex].length === 0) {
+          filteredSegments[multiFeatureIndex].push(
+            getCoords(currentSegment)[0],
+            getCoords(currentSegment)[1]
+          );
+        } else {
+          filteredSegments[multiFeatureIndex].push(
+            getCoords(currentSegment)[1]
+          );
+        }
+      }
+    });
+
+    // Rebuild the unioned geometry based in the filtered segments.
+    const filteredUnionGeom = multiLineString(filteredSegments);
+
+    // Polygonize the lines.
+    const polygonizedUnionGeom = polygonize(filteredUnionGeom);
+
+    // Return as Array of ol.Features.
+    return format.readFeatures(polygonizedUnionGeom, formatOptions);
+  }
+
+}
+
+export default GeometryUtil;

--- a/src/Util/GeometryUtil/GeometryUtil.spec.js
+++ b/src/Util/GeometryUtil/GeometryUtil.spec.js
@@ -1,0 +1,211 @@
+/*eslint-env jest*/
+
+import OlFormatGeoJSON from 'ol/format/geojson';
+import OlFeature from 'ol/feature';
+import OlGeomLineString from 'ol/geom/linestring';
+import OlGeomPolygon from 'ol/geom/polygon';
+
+import {
+  GeometryUtil,
+} from '../../index';
+
+describe('FeatureUtil', () => {
+  let poly;
+  let format;
+
+  beforeEach(() => {
+    format = new OlFormatGeoJSON();
+
+    poly = new OlFeature({
+      geometry: new OlGeomPolygon([[
+        [10, 40],
+        [40, 40],
+        [40, 10],
+        [10, 10],
+        [10, 40]
+      ]])
+    });
+  });
+
+  describe('Basics', () => {
+    it('is defined', () => {
+      expect(GeometryUtil).toBeDefined();
+    });
+  });
+
+  describe('Static methods', () => {
+    describe('#splitByLine', () => {
+      /**
+       *          +
+       *          |
+       *   +-------------+
+       *   |      |      |
+       *   |      |      |
+       *   |      |      |
+       *   |      |      |
+       *   |      |      |
+       *   |      |      |
+       *   +-------------+
+       *          |
+       *          +
+       */
+      it('splits the given convex polygon geometry with a straight line', () => {
+        const line = new OlFeature({
+          geometry: new OlGeomLineString([
+            [25, 50],
+            [25, 0]
+          ])
+        });
+
+        const got = GeometryUtil.splitByLine(poly, line, 'EPSG:4326');
+
+        const exp = [
+          new OlFeature({
+            geometry: new OlGeomPolygon([[
+              [10, 40],
+              [25, 40],
+              [25, 10],
+              [10, 10],
+              [10, 40]
+            ]])
+          }),
+          new OlFeature({
+            geometry: new OlGeomPolygon([[
+              [25, 40],
+              [40, 40],
+              [40, 10],
+              [25, 10],
+              [25, 40]
+            ]])
+          })
+        ];
+
+        expect(format.writeFeatures(got)).toEqual(format.writeFeatures(exp));
+      });
+
+      /**
+       *          +
+       *          |
+       *   +-------------+
+       *   |      |      |
+       *   |      |      |
+       *   |      |      |
+       *   |      +---------+
+       *   |             |
+       *   |             |
+       *   +-------------+
+       */
+      it('splits the given convex polygon geometry with a more complex line', () => {
+        const line = new OlFeature({
+          geometry: new OlGeomLineString([
+            [25, 50],
+            [25, 25],
+            [50, 25]
+          ])
+        });
+
+        const got = GeometryUtil.splitByLine(poly, line, 'EPSG:4326');
+
+        const exp = [
+          new OlFeature({
+            geometry: new OlGeomPolygon([[
+              [10, 40],
+              [25, 40],
+              [25, 25],
+              [40, 25],
+              [40, 10],
+              [10, 10],
+              [10, 40]
+            ]])
+          }),
+          new OlFeature({
+            geometry: new OlGeomPolygon([[
+              [25, 40],
+              [40, 40],
+              [40, 25],
+              [25, 25],
+              [25, 40]
+            ]])
+          })
+        ];
+
+        expect(format.writeFeatures(got)).toEqual(format.writeFeatures(exp));
+      });
+
+      /**
+       *       +----+         +----+
+       *       |    |         |    |
+       *       |    |         |    |
+       * +--------------------------------+
+       *       |    |         |    |
+       *       |    +---------+    |
+       *       |                   |
+       *       |                   |
+       *       |                   |
+       *       |                   |
+       *       +-------------------+
+       *
+       */
+      it('splits the given concave polygon geometry with a straight line', () => {
+        poly = new OlFeature({
+          geometry: new OlGeomPolygon([[
+            [10, 40],
+            [20, 40],
+            [20, 30],
+            [30, 30],
+            [30, 40],
+            [40, 40],
+            [40, 10],
+            [10, 10],
+            [10, 40]
+          ]])
+        });
+
+        const line = new OlFeature({
+          geometry: new OlGeomLineString([
+            [0, 35],
+            [50, 35]
+          ])
+        });
+
+        const got = GeometryUtil.splitByLine(poly, line, 'EPSG:4326');
+
+        const exp = [
+          new OlFeature({
+            geometry: new OlGeomPolygon([[
+              [10, 40],
+              [20, 40],
+              [20, 35],
+              [10, 35],
+              [10, 40]
+            ]])
+          }),
+          new OlFeature({
+            geometry: new OlGeomPolygon([[
+              [20, 35],
+              [20, 30],
+              [30, 30],
+              [30, 35],
+              [40, 35],
+              [40, 10],
+              [10, 10],
+              [10, 35],
+              [20, 35]
+            ]])
+          }),
+          new OlFeature({
+            geometry: new OlGeomPolygon([[
+              [30, 35],
+              [30, 40],
+              [40, 40],
+              [40, 35],
+              [30, 35]
+            ]])
+          })
+        ];
+
+        expect(format.writeFeatures(got)).toEqual(format.writeFeatures(exp));
+      });
+    });
+  });
+});

--- a/src/index.js
+++ b/src/index.js
@@ -29,6 +29,7 @@ import CapabilitiesUtil from './Util/CapabilitiesUtil/CapabilitiesUtil';
 import CsrfUtil from './Util/CsrfUtil/CsrfUtil';
 import AnimateUtil from './Util/AnimateUtil/AnimateUtil';
 import FeatureUtil from './Util/FeatureUtil/FeatureUtil';
+import GeometryUtil from './Util/GeometryUtil/GeometryUtil';
 import MapUtil from './Util/MapUtil/MapUtil';
 import MeasureUtil from './Util/MeasureUtil/MeasureUtil';
 import ObjectUtil from './Util/ObjectUtil/ObjectUtil';
@@ -70,6 +71,7 @@ export {
   CsrfUtil,
   AnimateUtil,
   FeatureUtil,
+  GeometryUtil,
   Logger,
   MapUtil,
   MeasureUtil,


### PR DESCRIPTION
<!--- Please choose one of the categories and choose the corresponding label, too. -->
## FEATURE

### Description:
This introduces the `GeometryUtil` with the method `splitByLine`.

**Note**: This works for convex and concave polygons but not for multipolygons (yet).

<!--- CHECKLIST
Fixes Issue?
Examples added?
Tests added?
Docs added?
Would a screenshot be helpful?
Do you want to mention someone?
-->
