### PR TITLE
Fixes bug in ToggleButton

### DIFF
--- a/src/Button/ToggleButton/ToggleButton.jsx
+++ b/src/Button/ToggleButton/ToggleButton.jsx
@@ -107,7 +107,8 @@ class ToggleButton extends React.Component {
   onClick(evt) {
     if (this.context.toggleGroup && isFunction(this.context.toggleGroup.onChange)) {
       this.context.toggleGroup.onChange(this.props);
-    } else if (this.props.onToggle) {
+    }
+    if (this.props.onToggle) {
       this.props.onToggle(!this.state.pressed, evt);
     }
 


### PR DESCRIPTION
<!--- Please choose one of the categories and choose the corresponding label, too. -->
## BUGFIX

### Description:
<!--- Please describe what this PR is about. -->
The `ToggleButton` didn't execute a passed `onToggle` handler if in a `ToggleGroup`. With this PR he does again.

This should fix the `Digitizebutton` examples.

<!--- CHECKLIST
Fixes Issue?
Examples added?
Tests added?
Docs added?
Would a screenshot be helpful?
Do you want to mention someone?
-->
