### PR TITLE
Adds props for 'onDrawStart' and 'onDrawEnd' listeners to DigitizeButton

### DIFF
--- a/src/Button/DigitizeButton/DigitizeButton.jsx
+++ b/src/Button/DigitizeButton/DigitizeButton.jsx
@@ -286,9 +286,22 @@ class DigitizeButton extends React.Component {
      *
      * @type {OlStyleStyle}
      */
-    style: PropTypes.instanceOf(OlStyleStyle)
-  };
+    style: PropTypes.instanceOf(OlStyleStyle),
 
+    /**
+     * Listener function for the 'drawend' event of an ol.interaction.Draw.
+     * See http://openlayers.org/en/latest/apidoc/ol.interaction.Draw.Event.html
+     * for more information.
+     */
+    onDrawEnd: PropTypes.func,
+
+    /**
+     * Listener function for the 'drawstart' event of an ol.interaction.Draw.
+     * See http://openlayers.org/en/latest/apidoc/ol.interaction.Draw.Event.html
+     * for more information.
+     */
+    onDrawStart: PropTypes.func
+  };
 
   /**
    * The default properties.
@@ -544,7 +557,9 @@ class DigitizeButton extends React.Component {
   createDrawInteraction = pressed => {
     const {
       drawType,
-      map
+      map,
+      onDrawEnd,
+      onDrawStart
     } = this.props;
 
     let geometryFunction;
@@ -565,6 +580,14 @@ class DigitizeButton extends React.Component {
       style: this.getDigitizeStyleFunction,
       freehandCondition: OlEventsCondition.never
     });
+
+    if (onDrawEnd) {
+      drawInteraction.on('drawend', onDrawEnd);
+    }
+
+    if (onDrawStart) {
+      drawInteraction.on('drawstart', onDrawStart);
+    }
 
     map.addInteraction(drawInteraction);
 
@@ -832,6 +855,8 @@ class DigitizeButton extends React.Component {
       modalPromptTitle,
       modalPromptOkButtonText,
       modalPromptCancelButtonText,
+      onDrawEnd,
+      onDrawStart,
       ...passThroughProps
     } = this.props;
 


### PR DESCRIPTION
<!--- Please choose one of the categories and choose the corresponding label, too. -->
## FEATURE

### Description:
<!--- Please describe what this PR is about. -->
This adds new props to the `DigitizeButton`:

- `OnDrawStart`: Optional listener function for the `drawstart` event of the [DrawInteraction](http://openlayers.org/en/latest/apidoc/ol.interaction.Draw.html)
- `OnDrawEnd`: Optional listener function for the `drawend` event of the [DrawInteraction](http://openlayers.org/en/latest/apidoc/ol.interaction.Draw.html)

<!--- CHECKLIST
Fixes Issue?
Examples added?
Tests added?
Docs added?
Would a screenshot be helpful?
Do you want to mention someone?
-->
