### PR TITLE
GeometryUtil - support merge of MultiGeometry

### DIFF
--- a/assets/TestCoords.js
+++ b/assets/TestCoords.js
@@ -274,9 +274,17 @@ export const bufferedHoleCoords = [
 ];
 
 export const pointCoords2 = [37, 13];
+export const pointCoords3 = [47, 11];
+export const pointCoords4 = [11, 47];
 export const mergedPointCoordinates = [
   [13, 37],
   [37, 13]
+];
+export const mergedPointCoordinates2 = [
+  [13, 37],
+  [37, 13],
+  [47, 11],
+  [11, 47]
 ];
 
 export const boxCoords3 = [[
@@ -326,3 +334,42 @@ export const boxCoords4 = [[
   [0, 0],
   [0, 5]
 ]];
+
+export const expectedMultiPolygon = [
+  [
+    [
+      [10, 40],
+      [40, 40],
+      [40, 10],
+      [10, 10],
+      [10, 40]
+    ]
+  ],
+  [
+    [
+      [15, 35],
+      [35, 35],
+      [35, 15],
+      [15, 15],
+      [15, 35]
+    ]
+  ],
+  [
+    [
+      [0, 20],
+      [20, 20],
+      [20, 0],
+      [0, 0],
+      [0, 20]
+    ]
+  ],
+  [
+    [
+      [0, 5],
+      [5, 5],
+      [5, 0],
+      [0, 0],
+      [0, 5]
+    ]
+  ]
+];

--- a/src/Util/GeometryUtil/GeometryUtil.spec.js
+++ b/src/Util/GeometryUtil/GeometryUtil.spec.js
@@ -42,7 +42,11 @@ import {
   unionedBoxCoordinates,
   differenceBoxCoords,
   intersectionCoords,
-  boxCoords4
+  boxCoords4,
+  pointCoords3,
+  pointCoords4,
+  mergedPointCoordinates2,
+  expectedMultiPolygon
 } from '../../../assets/TestCoords';
 
 describe('GeometryUtil', () => {
@@ -321,6 +325,27 @@ describe('GeometryUtil', () => {
         const mergedLineString = GeometryUtil.mergeGeometries([testLineString1, testLineString2]);
         expect(mergedLineString instanceof OlGeomMultiLineString).toBe(true);
         expect(mergedLineString.getCoordinates()).toEqual(mergedLineStringCoordinates);
+      });
+      it('merges multiple instances of ol.geom.MultiPoint into ol.geom.MultiPoint', () => {
+        const testMultiPoint1 = new OlGeomMultiPoint([pointCoords, pointCoords2]);
+        const testMultiPoint2 = new OlGeomMultiPoint([pointCoords3, pointCoords4]);
+        const mergedMultiPoint = GeometryUtil.mergeGeometries([testMultiPoint1, testMultiPoint2]);
+        expect(mergedMultiPoint instanceof OlGeomMultiPoint).toBe(true);
+        expect(mergedMultiPoint.getCoordinates()).toEqual(mergedPointCoordinates2);
+      });
+      it('merges multiple instances of ol.geom.MultiPolygon into ol.geom.MultiPolygon', () => {
+        const testMultiPolygon1 = new OlGeomMultiPolygon([boxCoords, boxCoords2]);
+        const testMultiPolygon2 = new OlGeomMultiPolygon([boxCoords3, boxCoords4]);
+        const mergedMultiPolygon = GeometryUtil.mergeGeometries([testMultiPolygon1, testMultiPolygon2]);
+        expect(mergedMultiPolygon instanceof OlGeomMultiPolygon).toBe(true);
+        expect(mergedMultiPolygon.getCoordinates()).toEqual(expectedMultiPolygon);
+      });
+      it('merges multiple instances of ol.geom.MultiLineString into ol.geom.MultiLineString', () => {
+        const testMultiLineString1 = new OlGeomMultiLineString([lineStringCoords]);
+        const testMultiLineString2 = new OlGeomMultiLineString([lineStringCoords2]);
+        const mergedMultiLineString = GeometryUtil.mergeGeometries([testMultiLineString1, testMultiLineString2]);
+        expect(mergedMultiLineString instanceof OlGeomMultiLineString).toBe(true);
+        expect(mergedMultiLineString.getCoordinates()).toEqual(mergedLineStringCoordinates);
       });
     });
 


### PR DESCRIPTION
<!--- Please choose one of the categories and choose the corresponding label, too. -->
## FEATURE

### Description:
This PR adds support of Multi-Geometries (e.g. `MultiPolygon`)  as input  of `mergeGeometries` in `GeometryUtil`.

<!--- CHECKLIST
Fixes Issue?
Examples added?
Tests added?
Docs added?
Would a screenshot be helpful?
Do you want to mention someone?
-->
