### PR TITLE
Introduces separateGeometries method to GeometryUtil

### DIFF
--- a/src/Util/GeometryUtil/GeometryUtil.js
+++ b/src/Util/GeometryUtil/GeometryUtil.js
@@ -26,12 +26,12 @@ import {
 class GeometryUtil {
 
   /**
-   * The Prefix used to detect multi geometries.
+   * The prefix used to detect multi geometries.
    */
-  static MUTLI_GEOM_PREFIX = 'Multi';
+  static MULTI_GEOM_PREFIX = 'Multi';
 
   /**
-   * Splits a ol.feature with/or ol.geom.Polygon by a ol.feature with/or ol.geom.LineString
+   * Splits an ol.feature with/or ol.geom.Polygon by an ol.feature with/or ol.geom.LineString
    * into an array of instances of ol.feature with/or ol.geom.Polygon.
    * If the target polygon (first param) is of type ol.Feature it will return an
    * array with ol.Feature. If the target polygon (first param) is of type
@@ -171,8 +171,8 @@ class GeometryUtil {
 
     // split all multi-geometries to simple ones if passed geometries are
     // multigeometries
-    if (geomType.startsWith(GeometryUtil.MUTLI_GEOM_PREFIX)) {
-      const multiGeomPartType = geomType.substring(GeometryUtil.MUTLI_GEOM_PREFIX.length);
+    if (geomType.startsWith(GeometryUtil.MULTI_GEOM_PREFIX)) {
+      const multiGeomPartType = geomType.substring(GeometryUtil.MULTI_GEOM_PREFIX.length);
       geometries = GeometryUtil.separateGeometries(geometries);
       geomType = multiGeomPartType;
     }
@@ -200,11 +200,13 @@ class GeometryUtil {
   }
 
   /**
-   * Splits an array of geometries (and multi geometries) or a single MutliGeom
+   * Splits an array of geometries (and multi geometries) or a single MultiGeom
    * into an array of single geometries.
    *
-   * @param {ol.geom.Geometry|ol.geom.Geometry[]} geometries An (array of) ol.geom.geometries;
-   * @returns {ol.geom.Point[]|ol.geom.Polygon[]|ol.geom.Linestring[]} An array of geometries.
+   * Attention: ol.geom.Circle and ol.geom.LinearRing are not supported.
+   *
+   * @param {ol.geom.SimpleGeometry|ol.geom.SimpleGeometry[]} geometries An (array of) ol.geom.geometries;
+   * @returns {ol.geom.Point[]|ol.geom.Polygon[]|ol.geom.LineString[]} An array of geometries.
    */
   static separateGeometries(geometries) {
     const separatedGeometries = [];
@@ -213,8 +215,8 @@ class GeometryUtil {
 
     geometries.forEach(geometry => {
       const geomType = geometry.getType();
-      if (geomType.startsWith(GeometryUtil.MUTLI_GEOM_PREFIX)) {
-        const multiGeomPartType = geomType.substring(GeometryUtil.MUTLI_GEOM_PREFIX.length);
+      if (geomType.startsWith(GeometryUtil.MULTI_GEOM_PREFIX)) {
+        const multiGeomPartType = geomType.substring(GeometryUtil.MULTI_GEOM_PREFIX.length);
         switch (multiGeomPartType) {
           case 'Polygon':
             separatedGeometries.push(...geometry.getPolygons());

--- a/src/Util/GeometryUtil/GeometryUtil.js
+++ b/src/Util/GeometryUtil/GeometryUtil.js
@@ -26,6 +26,11 @@ import {
 class GeometryUtil {
 
   /**
+   * The Prefix used to detect multi geometries.
+   */
+  static MUTLI_GEOM_PREFIX = 'Multi';
+
+  /**
    * Splits a ol.feature with/or ol.geom.Polygon by a ol.feature with/or ol.geom.LineString
    * into an array of instances of ol.feature with/or ol.geom.Polygon.
    * If the target polygon (first param) is of type ol.Feature it will return an
@@ -166,26 +171,9 @@ class GeometryUtil {
 
     // split all multi-geometries to simple ones if passed geometries are
     // multigeometries
-    const multiGeomPrefix = 'Multi';
-    if (geomType.startsWith(multiGeomPrefix)) {
-      const multiGeomPartType = geomType.substring(multiGeomPrefix.length);
-      let subGeometries = [];
-      geometries.forEach(geometry => {
-        switch (multiGeomPartType) {
-          case 'Polygon':
-            subGeometries.push(...geometry.getPolygons());
-            break;
-          case 'LineString':
-            subGeometries.push(...geometry.getLineStrings());
-            break;
-          case 'Point':
-            subGeometries.push(...geometry.getPoints());
-            break;
-          default:
-            break;
-        }
-      });
-      geometries = subGeometries;
+    if (geomType.startsWith(GeometryUtil.MUTLI_GEOM_PREFIX)) {
+      const multiGeomPartType = geomType.substring(GeometryUtil.MUTLI_GEOM_PREFIX.length);
+      geometries = GeometryUtil.separateGeometries(geometries);
       geomType = multiGeomPartType;
     }
 
@@ -209,6 +197,42 @@ class GeometryUtil {
     }
     geometries.forEach(geom => append(geom));
     return multiGeom;
+  }
+
+  /**
+   * Splits an array of geometries (and multi geometries) or a single MutliGeom
+   * into an array of single geometries.
+   *
+   * @param {ol.geom.Geometry|ol.geom.Geometry[]} geometries An (array of) ol.geom.geometries;
+   * @returns {ol.geom.Point[]|ol.geom.Polygon[]|ol.geom.Linestring[]} An array of geometries.
+   */
+  static separateGeometries(geometries) {
+    const separatedGeometries = [];
+
+    geometries = Array.isArray(geometries) ? geometries : [geometries];
+
+    geometries.forEach(geometry => {
+      const geomType = geometry.getType();
+      if (geomType.startsWith(GeometryUtil.MUTLI_GEOM_PREFIX)) {
+        const multiGeomPartType = geomType.substring(GeometryUtil.MUTLI_GEOM_PREFIX.length);
+        switch (multiGeomPartType) {
+          case 'Polygon':
+            separatedGeometries.push(...geometry.getPolygons());
+            break;
+          case 'LineString':
+            separatedGeometries.push(...geometry.getLineStrings());
+            break;
+          case 'Point':
+            separatedGeometries.push(...geometry.getPoints());
+            break;
+          default:
+            break;
+        }
+      } else {
+        separatedGeometries.push(geometry);
+      }
+    });
+    return separatedGeometries;
   }
 
   /**

--- a/src/Util/GeometryUtil/GeometryUtil.spec.js
+++ b/src/Util/GeometryUtil/GeometryUtil.spec.js
@@ -304,6 +304,69 @@ describe('GeometryUtil', () => {
       });
     });
 
+    describe('#separateGeometries', () => {
+      it('can split a single ol.geom.MultiPoint into an array of ol.geom.Points', () => {
+        const testPoint1 = new OlGeomPoint(pointCoords);
+        const testPoint2 = new OlGeomPoint(pointCoords2);
+        const mergedPoint = GeometryUtil.mergeGeometries([testPoint1, testPoint2]);
+        const separatedPoints = GeometryUtil.separateGeometries(mergedPoint);
+        expect(Array.isArray(separatedPoints)).toBe(true);
+        expect(separatedPoints[0].getCoordinates()).toEqual(pointCoords);
+        expect(separatedPoints[1].getCoordinates()).toEqual(pointCoords2);
+      });
+      it('can split a single ol.geom.MultiPolygoin into an array of ol.geom.Polygon', () => {
+        const testPolygon1 = new OlGeomPolygon(boxCoords);
+        const testPolygon2 = new OlGeomPolygon(boxCoords3);
+        const mergedPolygon = GeometryUtil.mergeGeometries([testPolygon1, testPolygon2]);
+        const separatedPolygons = GeometryUtil.separateGeometries(mergedPolygon);
+        expect(Array.isArray(separatedPolygons)).toBe(true);
+        expect(separatedPolygons[0].getCoordinates()).toEqual(boxCoords);
+        expect(separatedPolygons[1].getCoordinates()).toEqual(boxCoords3);
+      });
+      it('can split a single ol.geom.MultiLineString into an array of ol.geom.LineString', () => {
+        const testLineString1 = new OlGeomLineString(lineStringCoords);
+        const testLineString2 = new OlGeomLineString(lineStringCoords2);
+        const mergedLineString = GeometryUtil.mergeGeometries([testLineString1, testLineString2]);
+        const separatedLineStrings = GeometryUtil.separateGeometries(mergedLineString);
+        expect(Array.isArray(separatedLineStrings)).toBe(true);
+        expect(separatedLineStrings[0].getCoordinates()).toEqual(lineStringCoords);
+        expect(separatedLineStrings[1].getCoordinates()).toEqual(lineStringCoords2);
+      });
+      it('can split multiple mixed MultiGeometries into an array of ol.geom.Geomtries', () => {
+        const testPoint1 = new OlGeomPoint(pointCoords);
+        const testPoint2 = new OlGeomPoint(pointCoords2);
+        const mergedPoint = GeometryUtil.mergeGeometries([testPoint1, testPoint2]);
+        const testPolygon1 = new OlGeomPolygon(boxCoords);
+        const testPolygon2 = new OlGeomPolygon(boxCoords3);
+        const mergedPolygon = GeometryUtil.mergeGeometries([testPolygon1, testPolygon2]);
+        const testLineString1 = new OlGeomLineString(lineStringCoords);
+        const testLineString2 = new OlGeomLineString(lineStringCoords2);
+        const mergedLineString = GeometryUtil.mergeGeometries([testLineString1, testLineString2]);
+        const mixedMultiGeoemtries = [mergedPoint, mergedPolygon, mergedLineString];
+        const separatedGeometries = GeometryUtil.separateGeometries(mixedMultiGeoemtries);
+        expect(Array.isArray(separatedGeometries)).toBe(true);
+        expect(separatedGeometries[0].getCoordinates()).toEqual(pointCoords);
+        expect(separatedGeometries[1].getCoordinates()).toEqual(pointCoords2);
+        expect(separatedGeometries[2].getCoordinates()).toEqual(boxCoords);
+        expect(separatedGeometries[3].getCoordinates()).toEqual(boxCoords3);
+        expect(separatedGeometries[4].getCoordinates()).toEqual(lineStringCoords);
+        expect(separatedGeometries[5].getCoordinates()).toEqual(lineStringCoords2);
+      });
+      it('can split multiple mixed MultiGeometries and SingelGeometries into an array of ol.geom.Geomtries', () => {
+        const testPoint1 = new OlGeomPoint(pointCoords);
+        const testPoint2 = new OlGeomPoint(pointCoords2);
+        const mergedPoint = GeometryUtil.mergeGeometries([testPoint1, testPoint2]);
+        const testPolygon1 = new OlGeomPolygon(boxCoords);
+        const testPolygon2 = new OlGeomPolygon(boxCoords3);
+        const mixedMultiGeoemtries = [mergedPoint, testPolygon1, testPolygon2];
+        const separatedGeometries = GeometryUtil.separateGeometries(mixedMultiGeoemtries);
+        expect(Array.isArray(separatedGeometries)).toBe(true);
+        expect(separatedGeometries[0].getCoordinates()).toEqual(pointCoords);
+        expect(separatedGeometries[1].getCoordinates()).toEqual(pointCoords2);
+        expect(separatedGeometries[2].getCoordinates()).toEqual(boxCoords);
+      });
+    });
+
     describe('#mergeGeometries', () => {
       it('merges multiple instances of ol.geom.Point into ol.geom.MultiPoint', () => {
         const testPoint1 = new OlGeomPoint(pointCoords);


### PR DESCRIPTION
<!--- Please choose one of the categories and choose the corresponding label, too. -->
## FEATURE

### Description:
<!--- Please describe what this PR is about. -->
This introduces separateGeoemtries method to GeometryUtil. To split one or many "MultiGeometries".
The methods accepts a single or an Array of Geometries and/or MultiGeometries and returns an array of single Geometries.

<!--- CHECKLIST
Fixes Issue?
Examples added?
Tests added?
Docs added?
Would a screenshot be helpful?
Do you want to mention someone?
-->

Closes #483 