### PR TITLE
Fixes bug in moveFeature method of AnimateUtil

### DIFF
--- a/src/Util/AnimateUtil/AnimateUtil.js
+++ b/src/Util/AnimateUtil/AnimateUtil.js
@@ -47,10 +47,12 @@ class AnimateUtil {
         geometry.translate(deltaX, deltaY);
 
         if (vectorContext.setFillStrokeStyle && vectorContext.setImageStyle &&
-          vectorContext.drawPointGeometry) {
-          vectorContext.setFillStrokeStyle(
-            style.getFill(), style.getStroke());
-          vectorContext.setImageStyle(style.getImage());
+            vectorContext.drawPointGeometry) {
+          if (style) {
+            vectorContext.setFillStrokeStyle(
+              style.getFill(), style.getStroke());
+            vectorContext.setImageStyle(style.getImage());
+          }
           if (geometry instanceof OlGeomPoint) {
             vectorContext.drawPointGeometry(geometry, null);
           } else if (geometry instanceof OlGeomLineString) {
@@ -59,7 +61,9 @@ class AnimateUtil {
             vectorContext.drawPolygonGeometry(geometry, null);
           }
         } else {
-          vectorContext.setStyle(style);
+          if (style) {
+            vectorContext.setStyle(style);
+          }
           vectorContext.drawGeometry(geometry);
         }
 


### PR DESCRIPTION
<!--- Please choose one of the categories and choose the corresponding label, too. -->
## BUGFIX

### Description:
<!--- Please describe what this PR is about. -->
If the style given to the `moveFeature` method was null, an error occured in the animation and it never stoped translating the feature in the given direction.
This introduces two small checks to avoid this.

<!--- CHECKLIST
Fixes Issue?
Examples added?
Tests added?
Docs added?
Would a screenshot be helpful?
Do you want to mention someone?
-->
