### PR TITLE
Remove 'Multi' from geomType comparison in `mergeGeomtries`

### DIFF
--- a/src/Util/GeometryUtil/GeometryUtil.js
+++ b/src/Util/GeometryUtil/GeometryUtil.js
@@ -160,7 +160,7 @@ class GeometryUtil {
     let geomType = geometries[0].getType();
     let mixedGeometryTypes = false;
     geometries.forEach(geometry => {
-      if (geomType !== geometry.getType()) {
+      if (geomType.replace('Multi', '') !== geometry.getType().replace('Multi', '')) {
         mixedGeometryTypes = true;
       }
     });


### PR DESCRIPTION
<!--- Please choose one of the categories and choose the corresponding label, too. -->
## BUGFIX

### Description:
<!--- Please describe what this PR is about. -->
This removes 'Multi' from geomType comparison in `GeometryUtil.mergeGeomtries` to allow merging e.g. `MultiPolygon` with `Polygon`.

<!--- CHECKLIST
Fixes Issue?
Examples added?
Tests added?
Docs added?
Would a screenshot be helpful?
Do you want to mention someone?
-->
