### PR TITLE
Use animations by default when zooming

### DIFF
--- a/src/Button/ZoomInButton/ZoomInButton.example.jsx
+++ b/src/Button/ZoomInButton/ZoomInButton.example.jsx
@@ -23,7 +23,7 @@ const map = new OlMap({
   ],
   view: new OlView({
     center: olProj.fromLonLat([37.40570, 8.81566]),
-    zoom: 19
+    zoom: 10
   })
 });
 
@@ -40,7 +40,15 @@ render(
     <div className="example-block">
       <span>Zoom in button:</span>
       <ZoomInButton map={map}>
-         Zoom in (+)
+         Zoom in (standard, animated)
+      </ZoomInButton>
+      &nbsp;
+      <ZoomInButton map={map} animate={false}>
+         Zoom in (no animation)
+      </ZoomInButton>
+      &nbsp;
+      <ZoomInButton map={map} animateOptions={{duration: 1500}}>
+         Zoom in (1.5 seconds animation)
       </ZoomInButton>
     </div>
 

--- a/src/Button/ZoomInButton/ZoomInButton.jsx
+++ b/src/Button/ZoomInButton/ZoomInButton.jsx
@@ -91,6 +91,8 @@ class ZoomInButton extends React.Component {
   render() {
     const {
       className,
+      animate,
+      animateOptions,
       ...passThroughProps
     } = this.props;
 

--- a/src/Button/ZoomInButton/ZoomInButton.jsx
+++ b/src/Button/ZoomInButton/ZoomInButton.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import OlMap from 'ol/map';
+import easing from 'ol/easing';
 
 import  {
   SimpleButton
@@ -35,6 +36,31 @@ class ZoomInButton extends React.Component {
      * @type {OlMap}
      */
     map: PropTypes.instanceOf(OlMap).isRequired,
+
+    /**
+     * Whether the zoom in shall be animated. Defaults to `true`.
+     * 
+     * @type {Boolean}
+     */
+    animate: PropTypes.bool,
+
+    /**
+     * The options for the zoom in animation. By default zooming in will take
+     * 1000 milliseconds and an in-and-out easing (which starts slow, speeds up,
+     * and then slows down again) will be used.
+     */
+    animateOptions: PropTypes.shape({
+      duration: PropTypes.number,
+      easing: PropTypes.function
+    })
+  }
+
+  static defaultProps = {
+    animate: true,
+    animateOptions: {
+      duration: 1000,
+      easing: easing.inAndOut
+    }
   }
 
   /**
@@ -42,12 +68,21 @@ class ZoomInButton extends React.Component {
    *
    * @method
    */
-  onClick = () => {
-    const map = this.props.map;
+  onClick() {
+    const {map, animate, animateOptions: {duration, easing}} = this.props;
     const view = map.getView();
     const currentZoom = view.getZoom();
-
-    view.setZoom(currentZoom + 1);
+    const zoom = currentZoom + 1;
+    if (animate) {
+      const finalOptions = {
+        zoom,
+        duration,
+        easing
+      };
+      view.animate(finalOptions);
+    } else {
+      view.setZoom(zoom);
+    }
   }
 
   /**
@@ -66,7 +101,7 @@ class ZoomInButton extends React.Component {
     return (
       <SimpleButton
         className={finalClassName}
-        onClick={this.onClick}
+        onClick={this.onClick.bind(this)}
         {...passThroughProps}
       />
     );

--- a/src/Button/ZoomInButton/ZoomInButton.jsx
+++ b/src/Button/ZoomInButton/ZoomInButton.jsx
@@ -51,7 +51,7 @@ class ZoomInButton extends React.Component {
      */
     animateOptions: PropTypes.shape({
       duration: PropTypes.number,
-      easing: PropTypes.function
+      easing: PropTypes.func
     })
   }
 
@@ -69,7 +69,14 @@ class ZoomInButton extends React.Component {
    * @method
    */
   onClick() {
-    const {map, animate, animateOptions: {duration, easing}} = this.props;
+    const {
+      map,
+      animate,
+      animateOptions: {
+        duration,
+        easing
+      }
+    } = this.props;
     const view = map.getView();
     const currentZoom = view.getZoom();
     const zoom = currentZoom + 1;

--- a/src/Button/ZoomInButton/ZoomInButton.spec.jsx
+++ b/src/Button/ZoomInButton/ZoomInButton.spec.jsx
@@ -17,7 +17,7 @@ describe('<ZoomInButton />', () => {
   });
 
   it('can be rendered', () => {
-    const wrapper = TestUtil.mountComponent(ZoomInButton);
+    const wrapper = TestUtil.mountComponent(ZoomInButton, {map});
     expect(wrapper).not.toBeUndefined();
   });
 
@@ -28,16 +28,15 @@ describe('<ZoomInButton />', () => {
 
     wrapper.instance().onClick();
 
+    const promise = new Promise(resolve => {
+      setTimeout(resolve, 1200);
+    });
+
     expect.assertions(1);
-    const promise = new Promise((resolve) => {resolve();});
-    promise.then(() => {
+    return promise.then(() => {
       const newZoom = map.getView().getZoom();
       expect(newZoom).toBe(initialZoom + 1);
     });
-
-    setTimeout(() => {promise.resolve();}, 1200);
-
-    return promise;
   });
 
 });

--- a/src/Button/ZoomInButton/ZoomInButton.spec.jsx
+++ b/src/Button/ZoomInButton/ZoomInButton.spec.jsx
@@ -28,9 +28,16 @@ describe('<ZoomInButton />', () => {
 
     wrapper.instance().onClick();
 
-    const newZoom = map.getView().getZoom();
+    expect.assertions(1);
+    const promise = new Promise((resolve) => {resolve();});
+    promise.then(() => {
+      const newZoom = map.getView().getZoom();
+      expect(newZoom).toBe(initialZoom + 1);
+    });
 
-    expect(newZoom).toBe(initialZoom + 1);
+    setTimeout(() => {promise.resolve();}, 1200);
+
+    return promise;
   });
 
 });

--- a/src/Button/ZoomOutButton/ZoomOutButton.example.jsx
+++ b/src/Button/ZoomOutButton/ZoomOutButton.example.jsx
@@ -40,7 +40,15 @@ render(
     <div className="example-block">
       <span>Zoom out button:</span>
       <ZoomOutButton map={map}>
-         Zoom out (-)
+         Zoom out (standard, animated)
+      </ZoomOutButton>
+      &nbsp;
+      <ZoomOutButton map={map} animate={false}>
+         Zoom out (no animation)
+      </ZoomOutButton>
+      &nbsp;
+      <ZoomOutButton map={map} animateOptions={{duration: 1500}}>
+         Zoom out (1.5 seconds animation)
       </ZoomOutButton>
     </div>
 

--- a/src/Button/ZoomOutButton/ZoomOutButton.jsx
+++ b/src/Button/ZoomOutButton/ZoomOutButton.jsx
@@ -51,7 +51,7 @@ class ZoomOutButton extends React.Component {
      */
     animateOptions: PropTypes.shape({
       duration: PropTypes.number,
-      easing: PropTypes.function
+      easing: PropTypes.func
     })
   }
 
@@ -69,7 +69,14 @@ class ZoomOutButton extends React.Component {
    * @method
    */
   onClick() {
-    const {map, animate, animateOptions: {duration, easing}} = this.props;
+    const {
+      map,
+      animate,
+      animateOptions: {
+        duration,
+        easing
+      }
+    } = this.props;
     const view = map.getView();
     const currentZoom = view.getZoom();
     const zoom = currentZoom - 1;

--- a/src/Button/ZoomOutButton/ZoomOutButton.jsx
+++ b/src/Button/ZoomOutButton/ZoomOutButton.jsx
@@ -91,6 +91,8 @@ class ZoomOutButton extends React.Component {
   render() {
     const {
       className,
+      animate,
+      animateOptions,
       ...passThroughProps
     } = this.props;
 

--- a/src/Button/ZoomOutButton/ZoomOutButton.jsx
+++ b/src/Button/ZoomOutButton/ZoomOutButton.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import OlMap from 'ol/map';
+import easing from 'ol/easing';
 
 import  {
   SimpleButton
@@ -35,6 +36,31 @@ class ZoomOutButton extends React.Component {
      * @type {OlMap}
      */
     map: PropTypes.instanceOf(OlMap).isRequired,
+
+    /**
+     * Whether the zoom out shall be animated. Defaults to `true`.
+     * 
+     * @type {Boolean}
+     */
+    animate: PropTypes.bool,
+
+    /**
+     * The options for the zoom out animation. By default zooming out will take
+     * 1000 milliseconds and an in-and-out easing (which starts slow, speeds up,
+     * and then slows down again) will be used.
+     */
+    animateOptions: PropTypes.shape({
+      duration: PropTypes.number,
+      easing: PropTypes.function
+    })
+  }
+
+  static defaultProps = {
+    animate: true,
+    animateOptions: {
+      duration: 1000,
+      easing: easing.inAndOut
+    }
   }
 
   /**
@@ -42,12 +68,21 @@ class ZoomOutButton extends React.Component {
    *
    * @method
    */
-  onClick = () => {
-    const map = this.props.map;
+  onClick() {
+    const {map, animate, animateOptions: {duration, easing}} = this.props;
     const view = map.getView();
     const currentZoom = view.getZoom();
-
-    view.setZoom(currentZoom - 1);
+    const zoom = currentZoom - 1;
+    if (animate) {
+      const finalOptions = {
+        zoom,
+        duration,
+        easing
+      };
+      view.animate(finalOptions);
+    } else {
+      view.setZoom(zoom);
+    }
   }
 
   /**
@@ -66,7 +101,7 @@ class ZoomOutButton extends React.Component {
     return (
       <SimpleButton
         className={finalClassName}
-        onClick={this.onClick}
+        onClick={this.onClick.bind(this)}
         {...passThroughProps}
       />
     );

--- a/src/Button/ZoomOutButton/ZoomOutButton.spec.jsx
+++ b/src/Button/ZoomOutButton/ZoomOutButton.spec.jsx
@@ -17,7 +17,7 @@ describe('<ZoomOutButton />', () => {
   });
 
   it('can be rendered', () => {
-    const wrapper = TestUtil.mountComponent(ZoomOutButton);
+    const wrapper = TestUtil.mountComponent(ZoomOutButton, {map});
     expect(wrapper).not.toBeUndefined();
   });
 
@@ -28,15 +28,15 @@ describe('<ZoomOutButton />', () => {
 
     wrapper.instance().onClick();
 
+    const promise = new Promise(resolve => {
+      setTimeout(resolve, 1200);
+    });
+
     expect.assertions(1);
-    const promise = new Promise((resolve) => {resolve();});
-    promise.then(() => {
+    return promise.then(() => {
       const newZoom = map.getView().getZoom();
       expect(newZoom).toBe(initialZoom - 1);
     });
-
-    setTimeout(() => {promise.resolve();}, 1200);
-
   });
 
 });

--- a/src/Button/ZoomOutButton/ZoomOutButton.spec.jsx
+++ b/src/Button/ZoomOutButton/ZoomOutButton.spec.jsx
@@ -28,9 +28,15 @@ describe('<ZoomOutButton />', () => {
 
     wrapper.instance().onClick();
 
-    const newZoom = map.getView().getZoom();
+    expect.assertions(1);
+    const promise = new Promise((resolve) => {resolve();});
+    promise.then(() => {
+      const newZoom = map.getView().getZoom();
+      expect(newZoom).toBe(initialZoom - 1);
+    });
 
-    expect(newZoom).toBe(initialZoom - 1);
+    setTimeout(() => {promise.resolve();}, 1200);
+
   });
 
 });

--- a/src/Button/ZoomToExtentButton/ZoomToExtentButton.example.jsx
+++ b/src/Button/ZoomToExtentButton/ZoomToExtentButton.example.jsx
@@ -6,6 +6,7 @@ import OlView from 'ol/view';
 import OlLayerTile from 'ol/layer/tile';
 import OlSourceOsm from 'ol/source/osm';
 import olProj from 'ol/proj';
+import easing from 'ol/easing';
 
 import {
   ZoomToExtentButton
@@ -23,13 +24,15 @@ const map = new OlMap({
   ],
   view: new OlView({
     center: olProj.fromLonLat([37.40570, 8.81566]),
-    zoom: 19
+    zoom: 10
   })
 });
 
 //
 // ***************************** SETUP END *************************************
 //
+
+const extent = [588947.9928934451,6584461.475575979,1053685.1248673166,6829059.966088544];
 
 render(
   <div>
@@ -39,10 +42,23 @@ render(
 
     <div className="example-block">
       <span>Zoom to extent button:</span>
-      <ZoomToExtentButton map={map} extent={
-        [588947.9928934451,6584461.475575979,1053685.1248673166,6829059.966088544]
-      }>
-         Zoom to extent
+      <ZoomToExtentButton map={map} extent={extent}>
+         Zoom to extent (standard, animated)
+      </ZoomToExtentButton>
+      &nbsp;
+      <ZoomToExtentButton map={map} extent={extent} fitOptions={{
+        duration: 0
+      }}
+      >
+        Zoom to extent (no animation)
+      </ZoomToExtentButton>
+      &nbsp;
+      <ZoomToExtentButton map={map} extent={extent} fitOptions={{
+        duration: 3000,
+        easing: easing.inAndOut
+      }}
+      >
+        Zoom to extent (slow animation)
       </ZoomToExtentButton>
     </div>
 

--- a/src/Button/ZoomToExtentButton/ZoomToExtentButton.example.jsx
+++ b/src/Button/ZoomToExtentButton/ZoomToExtentButton.example.jsx
@@ -6,7 +6,6 @@ import OlView from 'ol/view';
 import OlLayerTile from 'ol/layer/tile';
 import OlSourceOsm from 'ol/source/osm';
 import olProj from 'ol/proj';
-import easing from 'ol/easing';
 
 import {
   ZoomToExtentButton
@@ -54,8 +53,7 @@ render(
       </ZoomToExtentButton>
       &nbsp;
       <ZoomToExtentButton map={map} extent={extent} fitOptions={{
-        duration: 3000,
-        easing: easing.inAndOut
+        duration: 3000
       }}
       >
         Zoom to extent (slow animation)

--- a/src/Button/ZoomToExtentButton/ZoomToExtentButton.example.jsx
+++ b/src/Button/ZoomToExtentButton/ZoomToExtentButton.example.jsx
@@ -31,7 +31,9 @@ const map = new OlMap({
 // ***************************** SETUP END *************************************
 //
 
-const extent = [588947.9928934451,6584461.475575979,1053685.1248673166,6829059.966088544];
+const extent1 = [588948, 6584461, 1053685, 6829060];
+const extent2 = [608948, 6484461, 1253685, 6629060];
+const extent3 = [628948, 6384461, 1453685, 6429060];
 
 render(
   <div>
@@ -41,18 +43,18 @@ render(
 
     <div className="example-block">
       <span>Zoom to extent button:</span>
-      <ZoomToExtentButton map={map} extent={extent}>
+      <ZoomToExtentButton map={map} extent={extent1}>
          Zoom to extent (standard, animated)
       </ZoomToExtentButton>
       &nbsp;
-      <ZoomToExtentButton map={map} extent={extent} fitOptions={{
+      <ZoomToExtentButton map={map} extent={extent2} fitOptions={{
         duration: 0
       }}
       >
         Zoom to extent (no animation)
       </ZoomToExtentButton>
       &nbsp;
-      <ZoomToExtentButton map={map} extent={extent} fitOptions={{
+      <ZoomToExtentButton map={map} extent={extent3} fitOptions={{
         duration: 3000
       }}
       >

--- a/src/Button/ZoomToExtentButton/ZoomToExtentButton.jsx
+++ b/src/Button/ZoomToExtentButton/ZoomToExtentButton.jsx
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types';
 
 import OlMap from 'ol/map';
 import OlSimpleGeometry from 'ol/geom/simplegeometry';
+import easing from 'ol/easing';
+
 import {
   SimpleButton
 } from '../../index';
@@ -46,10 +48,16 @@ class ZoomToExtentButton extends React.Component {
     ]).isRequired,
 
     /**
-     * Options for fitting to the given extent.
+     * Options for fitting to the given extent. See http://openlayers.org/en/latest/apidoc/ol.View.html#fit
      * @type {Object}
      */
-    fitOptions: PropTypes.object
+    fitOptions: PropTypes.shape({
+      constrainResolution: PropTypes.bool,
+      duration: PropTypes.number,
+      easing: PropTypes.function,
+      padding: PropTypes.arrayOf(PropTypes.number),
+      nearest: PropTypes.bool
+    })
     
   }
 
@@ -58,7 +66,11 @@ class ZoomToExtentButton extends React.Component {
    * @type {Object}
    */
   static defaultProps = {
-    fitOptions: {'constrainResolution': false}
+    fitOptions: {
+      constrainResolution: false,
+      duration: 1000,
+      easing: easing.inAndOut
+    }
   }
 
   /**
@@ -66,13 +78,18 @@ class ZoomToExtentButton extends React.Component {
    *
    * @method
    */
-  onClick = (fitProp) => {
+  onClick = (fitProp = {}) => {
     const{
       map, 
       extent 
     } = this.props;
     const view = map.getView();
-    view.fit(extent,fitProp);
+
+    if (fitProp.constrainResolution === undefined) {
+      fitProp.constrainResolution = false; // TODO access defaultProps?
+    }
+
+    view.fit(extent, fitProp);
   }
 
   /**

--- a/src/Button/ZoomToExtentButton/ZoomToExtentButton.jsx
+++ b/src/Button/ZoomToExtentButton/ZoomToExtentButton.jsx
@@ -78,18 +78,22 @@ class ZoomToExtentButton extends React.Component {
    *
    * @method
    */
-  onClick = (fitProp = {}) => {
+  onClick() {
     const{
       map, 
-      extent 
+      extent,
+      fitOptions
     } = this.props;
     const view = map.getView();
 
-    if (fitProp.constrainResolution === undefined) {
-      fitProp.constrainResolution = false; // TODO access defaultProps?
-    }
+    const {fitOptions: defaultFitOptions} = ZoomToExtentButton.defaultProps;
 
-    view.fit(extent, fitProp);
+    const finalFitOptions = {
+      ...defaultFitOptions,
+      ...fitOptions
+    };
+
+    view.fit(extent, finalFitOptions);
   }
 
   /**
@@ -106,12 +110,10 @@ class ZoomToExtentButton extends React.Component {
       this.className;
 
     return ( 
-      <SimpleButton className = {
-        finalClassName
-      }
-      onClick = {
-        ()=>this.onClick(fitOptions)
-      } { ...passThroughProps}
+      <SimpleButton
+        className = {finalClassName}
+        onClick = {this.onClick.bind(this)}
+        { ...passThroughProps}
       />
     );
   }

--- a/src/Button/ZoomToExtentButton/ZoomToExtentButton.jsx
+++ b/src/Button/ZoomToExtentButton/ZoomToExtentButton.jsx
@@ -54,7 +54,7 @@ class ZoomToExtentButton extends React.Component {
     fitOptions: PropTypes.shape({
       constrainResolution: PropTypes.bool,
       duration: PropTypes.number,
-      easing: PropTypes.function,
+      easing: PropTypes.func,
       padding: PropTypes.arrayOf(PropTypes.number),
       nearest: PropTypes.bool
     })

--- a/src/Button/ZoomToExtentButton/ZoomToExtentButton.spec.jsx
+++ b/src/Button/ZoomToExtentButton/ZoomToExtentButton.spec.jsx
@@ -2,6 +2,7 @@
 
 import TestUtil from '../../Util/TestUtil';
 import OlExtent from 'ol/extent';
+import OlGeomPolygon from 'ol/geom/polygon';
 
 import {
   ZoomToExtentButton
@@ -10,13 +11,15 @@ import {
 describe('<ZoomToExtentButton />', () => {
 
   let map;
-  let mockGeometry;
-  let mockExtent;
+  const mockGeometry = new OlGeomPolygon([
+    [[5000, 0], [0, 5000], [5000, 10000], [10000, 5000], [5000, 0]]
+  ]);
+  const mockGeometryCenter = [5000, 5000];
+  const mockExtent = [0, 0, 10000, 10000];
+  const mockExtentCenter = [5000, 5000];
 
   beforeEach(() => {
     map = TestUtil.createMap();
-    mockExtent = TestUtil.generateExtent();
-    mockGeometry = TestUtil.generatePolygonGeometry();
   });
 
   it('is defined', () => {
@@ -24,7 +27,10 @@ describe('<ZoomToExtentButton />', () => {
   });
 
   it('can be rendered', () => {
-    const wrapper = TestUtil.mountComponent(ZoomToExtentButton);
+    const wrapper = TestUtil.mountComponent(ZoomToExtentButton, {
+      map,
+      extent: mockExtent
+    });
     expect(wrapper).not.toBeUndefined();
   });
 
@@ -34,14 +40,18 @@ describe('<ZoomToExtentButton />', () => {
       extent: mockExtent
     });
     wrapper.instance().onClick();
-    const newExtent = map.getView().calculateExtent();
-    const newSize = OlExtent.getSize(newExtent);
-    const mockSize = OlExtent.getSize(mockExtent);
-    const newCenter = OlExtent.getCenter(newExtent);
-    const mockCenter = OlExtent.getCenter(mockExtent);
-    expect(newCenter).toEqual(mockCenter);
-    if (!(mockSize[1] < newSize[1]))     expect(newSize[1]).toEqual(mockSize[1]);
-    if (!(mockSize[0] < newSize[0]))     expect(newSize[0]).toEqual(mockSize[0]);
+
+    const promise = new Promise(resolve => {
+      setTimeout(resolve, 1200);
+    });
+
+    expect.assertions(2);
+    return promise.then(() => {
+      const newExtent = map.getView().calculateExtent();
+      const newCenter = OlExtent.getCenter(newExtent);
+      expect(newCenter).toEqual(mockExtentCenter);
+      expect(OlExtent.containsExtent(newExtent, mockExtent)).toBe(true);
+    });
   });
 
   it('zooms to polygon\'s geometry extent when clicked', () => {
@@ -49,14 +59,20 @@ describe('<ZoomToExtentButton />', () => {
       map,
       extent: mockGeometry
     });
+
     wrapper.instance().onClick();
-    const newExtent = map.getView().calculateExtent();
-    const newSize = OlExtent.getSize(newExtent);
-    const mockSize = OlExtent.getSize(mockGeometry.getExtent());
-    const newCenter = OlExtent.getCenter(newExtent);
-    const mockCenter = OlExtent.getCenter(mockGeometry.getExtent());
-    expect(newCenter).toEqual(mockCenter);
-    if (!(mockSize[1] < newSize[1]))     expect(newSize[1]).toEqual(mockSize[1]);
-    if (!(mockSize[0] < newSize[0]))     expect(newSize[0]).toEqual(mockSize[0]);
+
+    const promise = new Promise(resolve => {
+      setTimeout(resolve, 1200);
+    });
+
+    expect.assertions(2);
+    return promise.then(() => {
+      const newExtent = map.getView().calculateExtent();
+      const newCenter = OlExtent.getCenter(newExtent);
+      expect(newCenter).toEqual(mockGeometryCenter);
+      expect(OlExtent.containsExtent(newExtent, mockExtent)).toBe(true);
+    });
+
   });
 });

--- a/src/Util/TestUtil.js
+++ b/src/Util/TestUtil.js
@@ -4,10 +4,8 @@ import OlView from 'ol/view';
 import OlMap from 'ol/map';
 import OlSourceVector from 'ol/source/vector';
 import OlLayerVector from 'ol/layer/vector';
-import OlExtent from 'ol/extent';
 import OlFeature from 'ol/feature';
 import OlGeomPoint from 'ol/geom/point';
-import OlGeomPolygon from 'ol/geom/polygon';
 import OlPointerPointerEvent from 'ol/pointer/pointerevent';
 import OlMapBrowserPointerEvent from 'ol/mapbrowserpointerevent';
 
@@ -171,40 +169,6 @@ export class TestUtil {
     return feat;
   })
 
-  /**
-   * Returns a polygon feature with a random position.
-   * @type {Object}
-   */
-  static generatePolygonGeometry = (vertices = 4) => {
-    const polyCoords = [];
-    for (let i = 0; i <= vertices; i++){
-      const coords = [
-        Math.floor(Math.random() * 180) - 180,
-        Math.floor(Math.random() * 90) - 90
-      ];
-      polyCoords.push(coords);
-    }
-    const extent = OlExtent.boundingExtent(polyCoords);
-    const geom = new OlGeomPolygon.fromExtent(extent); 
-    return geom;
-  }
-
-  /**
-   * Returns a random extent .
-   * @type {array}
-   */
-  static generateExtent = () => {
-    const polyCoords = [];
-    for (let i = 0; i < 5; i++){
-      const coords = [
-        Math.floor(Math.random() * 180) - 180,
-        Math.floor(Math.random() * 90) - 90
-      ];
-      polyCoords.push(coords);
-    }
-    const extent = OlExtent.boundingExtent(polyCoords);
-    return extent;
-  }
 }
 
 export default TestUtil;


### PR DESCRIPTION
## Feature

This PR suggests to change the `ZoomInButton`, `ZoomOutButton` and `ZoomToExtentButton` to animate the view when zomming / fiting the extent by default.

One can still configure each component to not animate at all. The existing tests and examples have been updated to reflect these changes.

The `ZoomToExtentButton` class, test and example have been cleaned up. 

Some uneeded TestUtil functions have been removed. 

A future enhancement should factor out common code in a shared class. 

Fixes #516 
