### PR TITLE
Fixup broken labels in MultiLayerSlider

### DIFF
--- a/src/Slider/MultiLayerSlider/MultiLayerSlider.jsx
+++ b/src/Slider/MultiLayerSlider/MultiLayerSlider.jsx
@@ -158,7 +158,7 @@ class MultiLayerSlider extends React.Component {
     return (
       <Slider
         className={finalClassName}
-        marks={this.getMarks.bind(this)}
+        marks={this.getMarks()}
         defaultValue={defaultValue}
         min={0}
         max={100}


### PR DESCRIPTION
<!--- Please choose one of the categories and choose the corresponding label, too. -->
## BUGFIX

### Description:
This fixes the labels of the MultiLayerSlider, as the `marks` property does expect an object and not a function.