### PR TITLE
Less specific selector for titlebar

### DIFF
--- a/src/Panel/Titlebar/Titlebar.less
+++ b/src/Panel/Titlebar/Titlebar.less
@@ -1,6 +1,6 @@
 @import '../../style/variables.less';
 
-.ant-modal-header.react-geo-titlebar {
+.react-geo-titlebar {
   display: flex;
   align-items: center;
   background-color: darken(@component-background, 10);


### PR DESCRIPTION
<!--- Please choose one of the categories and choose the corresponding label, too. -->
##  BUGFIX

### Description:
This one is actually a revert of e410bde8.
`Titilebar` can be used not only inside of component header but also like its footer (e.g. to place some action buttons there) we need to make selector for titlebar less specific.

We probably need a more common name for the `Titlebar` component as well --> https://github.com/terrestris/react-geo/issues/537

Please review @terrestris/devs 