### PR TITLE
Use fixed version instead of repo-url for html-webpack-plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "eslint-plugin-markdown": "1.0.0-beta.7",
     "eslint-plugin-react": "7.7.0",
     "file-loader": "1.1.11",
-    "html-webpack-plugin": "webpack-contrib/html-webpack-plugin#master",
+    "html-webpack-plugin": "3.1.0",
     "jest": "22.4.2",
     "less": "3.0.1",
     "less-loader": "4.1.0",


### PR DESCRIPTION
<!--- Please choose one of the categories and choose the corresponding label, too. -->
## BUGFIX | DEVSETUP

### Description:
<!--- Please describe what this PR is about. -->
This replaces the repository url with a fixed version (3.1.0) for the `html-webpack-plugin`.
The previous repo does not longer exist which leads to failing builds.

<!--- CHECKLIST
Fixes Issue?
Examples added?
Tests added?
Docs added?
Would a screenshot be helpful?
Do you want to mention someone?
-->
