### PR TITLE
Faster & less error-prone zooming

### DIFF
--- a/src/Button/ZoomButton/ZoomButton.jsx
+++ b/src/Button/ZoomButton/ZoomButton.jsx
@@ -45,15 +45,15 @@ class ZoomButton extends React.Component {
 
     /**
      * Whether the zoom in shall be animated. Defaults to `true`.
-     * 
+     *
      * @type {Boolean}
      */
     animate: PropTypes.bool,
 
     /**
      * The options for the zoom in animation. By default zooming in will take
-     * 1000 milliseconds and an in-and-out easing (which starts slow, speeds up,
-     * and then slows down again) will be used.
+     * 250 milliseconds and an easing which starts fast and then slows down
+     * will be used.
      */
     animateOptions: PropTypes.shape({
       duration: PropTypes.number,
@@ -65,8 +65,8 @@ class ZoomButton extends React.Component {
     delta: 1,
     animate: true,
     animateOptions: {
-      duration: 1000,
-      easing: easing.inAndOut
+      duration: 250,
+      easing: easing.easeOut
     }
   }
 
@@ -86,6 +86,9 @@ class ZoomButton extends React.Component {
       delta
     } = this.props;
     const view = map.getView();
+    if (!view) { // no view, no zooming
+      return;
+    }
     const currentZoom = view.getZoom();
     const zoom = currentZoom + delta;
     if (animate) {
@@ -94,6 +97,9 @@ class ZoomButton extends React.Component {
         duration,
         easing
       };
+      if (view.getAnimating()) {
+        view.cancelAnimations();
+      }
       view.animate(finalOptions);
     } else {
       view.setZoom(zoom);

--- a/src/Button/ZoomButton/ZoomButton.spec.jsx
+++ b/src/Button/ZoomButton/ZoomButton.spec.jsx
@@ -1,6 +1,7 @@
 /*eslint-env jest*/
 
 import TestUtil from '../../Util/TestUtil';
+import OlMap from 'ol/map';
 
 import { ZoomButton } from '../../index';
 
@@ -29,7 +30,7 @@ describe('<ZoomButton />', () => {
     wrapper.instance().onClick();
 
     const promise = new Promise(resolve => {
-      setTimeout(resolve, 1200);
+      setTimeout(resolve, 300);
     });
 
     expect.assertions(1);
@@ -47,7 +48,7 @@ describe('<ZoomButton />', () => {
     wrapper.instance().onClick();
 
     const promise = new Promise(resolve => {
-      setTimeout(resolve, 1200);
+      setTimeout(resolve, 300);
     });
 
     expect.assertions(1);
@@ -55,6 +56,24 @@ describe('<ZoomButton />', () => {
       const newZoom = map.getView().getZoom();
       expect(newZoom).toBe(initialZoom - 1);
     });
+  });
+
+  it('does not belch when map has no view', () => {
+    const wrapper = TestUtil.mountComponent(ZoomButton, {map: new OlMap()});
+    expect(() => {wrapper.instance().onClick();}).not.toThrow();
+  });
+
+  it('cancels already running animations', () => {
+    const wrapper = TestUtil.mountComponent(ZoomButton, {map, duration: 250});
+    const view = map.getView();
+
+    view.cancelAnimations = jest.fn();
+
+    wrapper.instance().onClick();
+    wrapper.instance().onClick();
+    wrapper.instance().onClick();
+
+    expect(view.cancelAnimations.mock.calls.length).toBe(2);
   });
 
 });


### PR DESCRIPTION
<!--- Please choose one of the categories and choose the corresponding label, too. -->
## BUGFIX

### Description:

This fixes two bugs with the `ZoomButton`:

* Multiple fast clicks on a `ZoomButton` could mess up the animation, because already running animations would not be canceled
* If you configured the `ZoomButton` with a map that did not have a view (yet), clicking the button would throw an exception 

Also zooming now uses the same defaults for animations as the standard OpenLayers controls (`easeOut` animation an the duration is `250ms`)

Please review.