### PR TITLE
Changes to WfsSearch

### DIFF
--- a/src/Field/WfsSearch/WfsSearch.example.md
+++ b/src/Field/WfsSearch/WfsSearch.example.md
@@ -43,7 +43,9 @@ class WfsSearchExample extends React.Component {
               placeholder="Type a countryname in its own language…"
               baseUrl='http://ows.terrestris.de/geoserver/osm/wfs'
               featureTypes={['osm:osm-country-borders']}
-              searchAttributes={['name']}
+              searchAttributes={{
+                'osm:osm-country-borders': ['name']
+              }}
               map={this.map}
               style={{
                 width: '80%'

--- a/src/Field/WfsSearch/WfsSearch.jsx
+++ b/src/Field/WfsSearch/WfsSearch.jsx
@@ -134,8 +134,14 @@ export class WfsSearch extends React.Component {
     /**
      * Options which are passed to the constructor of the ol.format.WFS.
      * compare: http://openlayers.org/en/latest/apidoc/ol.format.WFS.html
+     * @type {object}
      */
-    wfsFormatOptions: PropTypes.object
+    wfsFormatOptions: PropTypes.object,
+    /**
+     * Which prop value of option will render as content of select.
+     * @type {string}
+     */
+    optionLabelProp: PropTypes.string
   }
 
   static defaultProps = {
@@ -143,6 +149,7 @@ export class WfsSearch extends React.Component {
     outputFormat: 'application/json',
     minChars: 3,
     additionalFetchOptions: {},
+    optionLabelProp: 'title',
     /**
      * Create an AutoComplete.Option from the given data.
      *
@@ -151,12 +158,14 @@ export class WfsSearch extends React.Component {
      * rendered for each feature.
      */
     renderOption: feature => {
+      const display = feature.properties.name ? feature.properties.name : feature.id;
       return (
-        <Option key={feature.id}>
-          {feature.properties.name ? feature.properties.name : feature.id}
+        <Option key={feature.id} title={display}>
+          {display}
         </Option>
       );
     },
+
     /**
      * The default onSelect method if no onSelect prop is given. It zooms to the
      * selected item.
@@ -354,6 +363,7 @@ export class WfsSearch extends React.Component {
       map,
       maxFeatures,
       minChars,
+      optionLabelProp,
       outputFormat,
       onSelect,
       propertyNames,
@@ -377,7 +387,7 @@ export class WfsSearch extends React.Component {
         onChange={this.onUpdateInput}
         onSelect={this.onMenuItemSelected}
         notFoundContent={fetching ? <Spin size="small" /> : null}
-        optionLabelProp='children'
+        optionLabelProp={optionLabelProp}
         filterOption={false}
         showArrow={false}
         {...passThroughProps}


### PR DESCRIPTION
<!--- Please choose one of the categories and choose the corresponding label, too. -->
## FEATURE | BREAKING-CHANGE :exclamation: 

### Description:
<!--- Please describe what this PR is about. -->
This makes adds the `optionLabelProp` to be more flexible. Although it is an antd prop we have to introduce it as a prop because we set a default for it.
The default for the `renderOption` prop has been adapted to the changes.

Breaking change:
Modifies the `searchAttributes` to be receive an object instead of an array. To be more precise doing the WFS-GetFeature request. 

<!--- CHECKLIST
Fixes Issue?
Examples added?
Tests added?
Docs added?
Would a screenshot be helpful?
Do you want to mention someone?
-->

Thx for support @hwbllmnn 