### PR TITLE
Less HTTP, more HTTPS

### DIFF
--- a/src/Button/DigitizeButton/DigitizeButton.jsx
+++ b/src/Button/DigitizeButton/DigitizeButton.jsx
@@ -291,14 +291,14 @@ class DigitizeButton extends React.Component {
 
     /**
      * Listener function for the 'drawend' event of an ol.interaction.Draw.
-     * See http://openlayers.org/en/latest/apidoc/ol.interaction.Draw.Event.html
+     * See https://openlayers.org/en/latest/apidoc/ol.interaction.Draw.Event.html
      * for more information.
      */
     onDrawEnd: PropTypes.func,
 
     /**
      * Listener function for the 'drawstart' event of an ol.interaction.Draw.
-     * See http://openlayers.org/en/latest/apidoc/ol.interaction.Draw.Event.html
+     * See https://openlayers.org/en/latest/apidoc/ol.interaction.Draw.Event.html
      * for more information.
      */
     onDrawStart: PropTypes.func

--- a/src/Button/ZoomToExtentButton/ZoomToExtentButton.jsx
+++ b/src/Button/ZoomToExtentButton/ZoomToExtentButton.jsx
@@ -49,7 +49,7 @@ class ZoomToExtentButton extends React.Component {
     ]).isRequired,
 
     /**
-     * Options for fitting to the given extent. See http://openlayers.org/en/latest/apidoc/ol.View.html#fit
+     * Options for fitting to the given extent. See https://openlayers.org/en/latest/apidoc/ol.View.html#fit
      * @type {Object}
      */
     fitOptions: PropTypes.shape({

--- a/src/Container/AddWmsPanel/AddWmsLayerEntry/AddWmsLayerEntry.spec.jsx
+++ b/src/Container/AddWmsPanel/AddWmsLayerEntry/AddWmsLayerEntry.spec.jsx
@@ -12,7 +12,7 @@ describe('<AddWmsLayerEntry />', () => {
     visible: false,
     title: testLayerTitle,
     source: new OlSourceTileWMS({
-      url: 'http://ows.terrestris.de/osm/service?',
+      url: 'https://ows.terrestris.de/osm/service?',
       params: {
         'LAYERS': testLayerName,
         'TILED': true

--- a/src/Container/AddWmsPanel/AddWmsPanel.spec.jsx
+++ b/src/Container/AddWmsPanel/AddWmsPanel.spec.jsx
@@ -12,7 +12,7 @@ describe('<AddWmsPanel />', () => {
     visible: false,
     title: testLayerTitle,
     source: new OlSourceTileWMS({
-      url: 'http://ows.terrestris.de/osm/service?',
+      url: 'https://ows.terrestris.de/osm/service?',
       params: {
         'LAYERS': testLayerName,
         'TILED': true
@@ -26,7 +26,7 @@ describe('<AddWmsPanel />', () => {
     visible: false,
     title: testLayerTitle2,
     source: new OlSourceTileWMS({
-      url: 'http://ows.terrestris.de/osm/service?',
+      url: 'https://ows.terrestris.de/osm/service?',
       params: {
         'LAYERS': testLayerName2,
         'TILED': true

--- a/src/Field/CoordinateReferenceSystemCombo/CoordinateReferenceSystemCombo.example.md
+++ b/src/Field/CoordinateReferenceSystemCombo/CoordinateReferenceSystemCombo.example.md
@@ -100,7 +100,7 @@ class CoordinateReferenceSystemComboExample extends React.Component {
         <div className="example-block">
           <span>
             A <code>CoordinateReferenceSystemCombo</code> with autocomplete mode
-            where CRS are fetched from <a href="http://epsg.io/">epsg.io/</a>.
+            where CRS are fetched from <a href="https://epsg.io/">epsg.io/</a>.
             If a CRS is selected (prop <code>onSelect</code>), the projection is
             used to perform client-side raster reprojection of OSM layer in map.
           </span>

--- a/src/Field/CoordinateReferenceSystemCombo/CoordinateReferenceSystemCombo.jsx
+++ b/src/Field/CoordinateReferenceSystemCombo/CoordinateReferenceSystemCombo.jsx
@@ -32,7 +32,7 @@ class CoordinateReferenceSystemCombo extends React.Component {
     className: PropTypes.string,
     /**
      * The API to query for CRS definitions
-     * default: http://epsg.io
+     * default: https://epsg.io
      * @type {String}
      */
     crsApiUrl: PropTypes.string,

--- a/src/Field/NominatimSearch/NominatimSearch.jsx
+++ b/src/Field/NominatimSearch/NominatimSearch.jsx
@@ -33,7 +33,7 @@ export class NominatimSearch extends React.Component {
      */
     className: PropTypes.string,
     /**
-     * The Nominatim Base URL. See http://wiki.openstreetmap.org/wiki/Nominatim
+     * The Nominatim Base URL. See https://wiki.openstreetmap.org/wiki/Nominatim
      * @type {String}
      */
     nominatimBaseUrl: PropTypes.string,

--- a/src/Field/WfsSearch/WfsSearch.example.md
+++ b/src/Field/WfsSearch/WfsSearch.example.md
@@ -41,7 +41,7 @@ class WfsSearchExample extends React.Component {
           <label>WFS Search:<br />
             <WfsSearch
               placeholder="Type a countryname in its own language…"
-              baseUrl='http://ows.terrestris.de/geoserver/osm/wfs'
+              baseUrl='https://ows.terrestris.de/geoserver/osm/wfs'
               featureTypes={['osm:osm-country-borders']}
               searchAttributes={{
                 'osm:osm-country-borders': ['name']

--- a/src/Field/WfsSearch/WfsSearch.jsx
+++ b/src/Field/WfsSearch/WfsSearch.jsx
@@ -20,7 +20,7 @@ import OlFormatWFS from 'ol/format/wfs';
  *
  * The GetFeature request is created with `ol.format.WFS.writeGetFeature`
  * so most of the WFS specific options work like document in the corresponding
- * API-docs: http://openlayers.org/en/latest/apidoc/ol.format.WFS.html#writeGetFeature
+ * API-docs: https://openlayers.org/en/latest/apidoc/ol.format.WFS.html#writeGetFeature
  *
  * @class WfsSearch
  * @extends React.Component
@@ -92,7 +92,7 @@ export class WfsSearch extends React.Component {
      */
     propertyNames: PropTypes.arrayOf(PropTypes.string),
     /**
-     * Filter condition. See http://openlayers.org/en/latest/apidoc/ol.format.filter.html
+     * Filter condition. See https://openlayers.org/en/latest/apidoc/ol.format.filter.html
      * for more information.
      * @type {object}
      */
@@ -136,7 +136,7 @@ export class WfsSearch extends React.Component {
     additionalFetchOptions: PropTypes.object,
     /**
      * Options which are passed to the constructor of the ol.format.WFS.
-     * compare: http://openlayers.org/en/latest/apidoc/ol.format.WFS.html
+     * compare: https://openlayers.org/en/latest/apidoc/ol.format.WFS.html
      * @type {object}
      */
     wfsFormatOptions: PropTypes.object,

--- a/src/Field/WfsSearch/WfsSearch.spec.jsx
+++ b/src/Field/WfsSearch/WfsSearch.spec.jsx
@@ -38,7 +38,7 @@ describe('<WfsSearch />', () => {
       // expect.assertions(1);
       const wrapper = TestUtil.mountComponent(WfsSearch, {
         placeholder: 'Type a countryname in its own language…',
-        baseUrl: 'http://ows.terrestris.de/geoserver/osm/wfs',
+        baseUrl: 'https://ows.terrestris.de/geoserver/osm/wfs',
         featureTypes: ['osm:osm-country-borders'],
         searchAttributes: ['name']
       });

--- a/src/Legend/Legend.spec.jsx
+++ b/src/Legend/Legend.spec.jsx
@@ -26,7 +26,7 @@ describe('<Legend />', () => {
       })
     });
     layer2 = new OlLayerTile({
-      legendUrl: 'http://www.koeln.de/files/images/Karnevalstrikot_Spieler_270.jpg',
+      legendUrl: 'https://www.koeln.de/files/images/Karnevalstrikot_Spieler_270.jpg',
       name: 'Food insecurity',
       source: new OlSourceTileJson({
         url: 'https://api.tiles.mapbox.com/v3/mapbox.20110804-hoa-foodinsecurity-3month.json?secure',

--- a/src/Panel/Panel/Panel.example.md
+++ b/src/Panel/Panel/Panel.example.md
@@ -60,7 +60,7 @@ This example demonstrates the use of Panels
     topRight: false,
   }}
 >
-  <img src="http://www.koeln.de/files/images/Karnevalstrikot_Spieler_270.jpg" />
+  <img src="https://www.koeln.de/files/images/Karnevalstrikot_Spieler_270.jpg" />
 </Panel>
 ```
 
@@ -72,7 +72,7 @@ This example demonstrates the use of Panels
   title="resizeopts={true}"
   resizeOpts={true}
 >
-  <img src="http://www.koeln.de/files/images/Karnevalstrikot_Spieler_270.jpg" />
+  <img src="https://www.koeln.de/files/images/Karnevalstrikot_Spieler_270.jpg" />
 </Panel>
 ```
 

--- a/src/Util/FeatureUtil/FeatureUtil.spec.js
+++ b/src/Util/FeatureUtil/FeatureUtil.spec.js
@@ -24,7 +24,7 @@ describe('FeatureUtil', () => {
       name: 'Shinji Kagawa',
       address: 'Borsigplatz 9',
       city: 'Dortmund',
-      homepage: 'http://www.bvb.de/'
+      homepage: 'https://www.bvb.de/'
     };
     feat = new OlFeature({
       geometry: geom

--- a/src/Util/MapUtil/MapUtil.spec.js
+++ b/src/Util/MapUtil/MapUtil.spec.js
@@ -210,7 +210,7 @@ describe('MapUtil', () => {
       const layer = new OlLayerTile({
         visible: false,
         source: new OlSourceTileWMS({
-          url: 'http://ows.terrestris.de/osm/service?',
+          url: 'https://ows.terrestris.de/osm/service?',
           params: {
             'LAYERS': layerName,
             'TILED': true
@@ -250,7 +250,7 @@ describe('MapUtil', () => {
       let layer = new OlLayerTile({
         visible: false,
         source: new OlSourceTileWMS({
-          url: 'http://ows.terrestris.de/osm/service?',
+          url: 'https://ows.terrestris.de/osm/service?',
           params: {
             'LAYERS': qualifiedLayerName,
             'TILED': true
@@ -280,7 +280,7 @@ describe('MapUtil', () => {
       let layer = new OlLayerTile({
         visible: false,
         source: new OlSourceTileWMS({
-          url: 'http://ows.terrestris.de/osm/service?',
+          url: 'https://ows.terrestris.de/osm/service?',
           params: {
             'LAYERS': qualifiedLayerName,
             'TILED': true

--- a/src/Util/MeasureUtil/MeasureUtil.js
+++ b/src/Util/MeasureUtil/MeasureUtil.js
@@ -93,7 +93,7 @@ class MeasureUtil {
    * -180° and 180°, with 0° being in the east. The angle will increase
    * counter-clockwise.
    *
-   * Inspired by http://stackoverflow.com/a/31136507
+   * Inspired by https://stackoverflow.com/a/31136507
    *
    * @param {Array<Number>} start The start coordinates of the line with the
    *     x-coordinate being at index `0` and y-coordinate being at index `1`.
@@ -117,7 +117,7 @@ class MeasureUtil {
    * 0° and 360°, with 0° being in the east. The angle will increase
    * counter-clockwise.
    *
-   * Inspired by http://stackoverflow.com/a/31136507
+   * Inspired by https://stackoverflow.com/a/31136507
    *
    * @param {Array<Number>} start The start coordinates of the line with the
    *     x-coordinate being at index `0` and y-coordinate being at index `1`.

--- a/src/Util/StringUtil/StringUtil.js
+++ b/src/Util/StringUtil/StringUtil.js
@@ -53,7 +53,7 @@ class StringUtil {
    * Returns a string that is wrapped: every ~`width` chars a space is
    * replaced with the passed `spaceReplacer`.
    *
-   * See http://stackoverflow.com/questions/14484787/wrap-text-in-javascript
+   * See https://stackoverflow.com/questions/14484787/wrap-text-in-javascript
    *
    * @param {String} str The string to wrap.
    * @param {Number} width The width of a line (number of characters).

--- a/src/Util/StringUtil/StringUtil.spec.js
+++ b/src/Util/StringUtil/StringUtil.spec.js
@@ -102,7 +102,7 @@ describe('StringUtil', () => {
 
     describe('#stripHTMLTags', () => {
       it ('returns the text content of an html string', () => {
-        const htmlString = '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap contributors</a> <br>';
+        const htmlString = '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap contributors</a> <br>';
         const got = '© OpenStreetMap contributors ';
         const result = StringUtil.stripHTMLTags(htmlString);
         expect(result).toBe(got);

--- a/src/Util/UrlUtil/UrlUtil.js
+++ b/src/Util/UrlUtil/UrlUtil.js
@@ -146,12 +146,12 @@ export class UrlUtil {
    * This joins/bundles a given set of (typically WMS GetFeatureInfo) requests
    * by the base URL. E.g. it merges the following two requests:
    *
-   * http://maps.bvb.de?SERVICE=WMS&REQUEST=GetFeatureInfo&LAYERS=Shinji
-   * http://maps.bvb.de?SERVICE=WMS&REQUEST=GetFeatureInfo&LAYERS=Kagawa
+   * https://maps.bvb.de?SERVICE=WMS&REQUEST=GetFeatureInfo&LAYERS=Shinji
+   * https://maps.bvb.de?SERVICE=WMS&REQUEST=GetFeatureInfo&LAYERS=Kagawa
    *
    * to
    *
-   * http://maps.bvb.de?SERVICE=WMS&REQUEST=GetFeatureInfo&LAYERS=Shinji,Kagawa
+   * https://maps.bvb.de?SERVICE=WMS&REQUEST=GetFeatureInfo&LAYERS=Shinji,Kagawa
    *
    * @param {Array} featureInfoUrls An array of requests to bundle.
    * @param {Boolean} stringify Whether to stringify the output or not. If set


### PR DESCRIPTION
<!-- Please choose one of the categories and choose the corresponding label, too. -->
## BUGFIX | DOCUMENTATION

### Description:

This replaces 'http'-URLs with 'https'-ones where possible and useful.

This also fixes the online examples like the WFS search which wouldn't work on the hosted HTTPS page as it tried to load content from a HTTP resource.

Please review.