### PR TITLE
Fixes buggy behaviour when toggleButton is pressed

### DIFF
--- a/src/Button/ToggleButton/ToggleButton.jsx
+++ b/src/Button/ToggleButton/ToggleButton.jsx
@@ -93,7 +93,8 @@ class ToggleButton extends React.Component {
    * @param {Object} nextProps The received properties.
    */
   componentWillReceiveProps(nextProps) {
-    if (this.state.pressed !== nextProps.pressed) {
+    // Checks if the pressed property has changed before checking its match with the current state 
+    if (this.props.pressed !== nextProps.pressed && this.state.pressed !== nextProps.pressed) {
       this.props.onToggle(nextProps.pressed);
       this.setState({
         pressed: nextProps.pressed


### PR DESCRIPTION
<!-- Please choose one of the categories and choose the corresponding label, too. -->
## BUGFIX | 

### Description:
This fixes a buggy behaviour of the `ToggleButton`.
The bug appears when the component's pressed property has not changed but the pressed state has changed and the `componentWillReceiveProps` function uses the initial props to trigger the button.
With this fix we will check if the props have changed at all before we check the new props against the current state.

Plz review.

<!--- CHECKLIST
Fixes Issue?
Examples added?
Tests added?
Docs added?
Would a screenshot be helpful?
Do you want to mention someone?
-->
