### PR TITLE
Fix test debugging command for vscode

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,13 +5,15 @@
         "name": "Debug Jest Tests",
         "type": "node",
         "request": "launch",
+        "port": 9230,
         "runtimeArgs": [
-          "--inspect-brk",
+          "--inspect-brk=9230",
           "${workspaceRoot}/node_modules/.bin/jest",
-          "--runInBand"
+          "--runInBand",
+          "--watch"
         ],
-        "console": "integratedTerminal",
-        "internalConsoleOptions": "neverOpen"
+        "runtimeExecutable": null,
+        "console": "externalTerminal"
       }
     ]
   }


### PR DESCRIPTION
<!-- Please choose one of the categories and choose the corresponding label, too. -->
## BUGFIX | DEVSETUP

### Description:
<!-- Please describe what this PR is about. -->
This fixes the `Debug Jest Tests` script for vscode by adding a port.
Test will now also run in an external terminal and in watchmode.

<!--- CHECKLIST
Fixes Issue?
Examples added?
Tests added?
Docs added?
Would a screenshot be helpful?
Do you want to mention someone?
-->
