### PR TITLE
Use `jest.DoneCallback` in test of WfsSearch

### DIFF
--- a/src/Field/WfsSearch/WfsSearch.spec.jsx
+++ b/src/Field/WfsSearch/WfsSearch.spec.jsx
@@ -113,7 +113,7 @@ describe('<WfsSearch />', () => {
   });
 
   describe('default #onSelect', () => {
-    it('zooms to the selected feature', () => {
+    it('zooms to the selected feature', (done) => {
       expect.assertions(3);
       jest.useFakeTimers();
       //SETUP
@@ -145,6 +145,7 @@ describe('<WfsSearch />', () => {
       setTimeout(() => {
         expect(map.getView().getCenter()).toEqual([25, 25]);
         expect(map.getView().getZoom()).toEqual(2);
+        done();
       }, 501);
       jest.runAllTimers();
       fitSpy.mockReset();


### PR DESCRIPTION
<!-- Please choose one of the categories and choose the corresponding label, too. -->
## BUGFIX

### Description:
<!-- Please describe what this PR is about. -->
If this is not included local tests for `WfsSearch` run into an error
```
Ran 100000 timers, and there are still more! Assuming we've hit an infinite
recursion and bailing out...
```
 Using this fix, Jest will wait until the `done` callback is called before finishing the test.

<!--- CHECKLIST
Fixes Issue?
Examples added?
Tests added?
Docs added?
Would a screenshot be helpful?
Do you want to mention someone?
-->
