### PR TITLE
Increase timeout in onSelect test of WfsSearch

### DIFF
--- a/src/Field/WfsSearch/WfsSearch.spec.jsx
+++ b/src/Field/WfsSearch/WfsSearch.spec.jsx
@@ -146,7 +146,7 @@ describe('<WfsSearch />', () => {
         expect(map.getView().getCenter()).toEqual([25, 25]);
         expect(map.getView().getZoom()).toEqual(2);
         done();
-      }, 501);
+      }, 510);
       jest.runAllTimers();
       fitSpy.mockReset();
       fitSpy.mockRestore();


### PR DESCRIPTION
<!-- Please choose one of the categories and choose the corresponding label, too. -->
## BUGFIX

### Description:
<!-- Please describe what this PR is about. -->
This PR increases the timeout used in test of `onSelect` (`WfsSearch`) to 500ms + 10ms (as in test of CircleMenu)

<!--- CHECKLIST
Fixes Issue?
Examples added?
Tests added?
Docs added?
Would a screenshot be helpful?
Do you want to mention someone?
-->
