### PR TITLE
Fix searching number fields

### DIFF
--- a/src/Field/WfsSearch/WfsSearch.jsx
+++ b/src/Field/WfsSearch/WfsSearch.jsx
@@ -54,7 +54,13 @@ export class WfsSearch extends React.Component {
      * An object mapping feature types to an array of attribute details.
      * @type {Object}
      */
-    attributeDetails: PropTypes.object,
+    attributeDetails: PropTypes.objectOf(PropTypes.arrayOf(
+      PropTypes.objectOf(PropTypes.shape({
+        matchCase: PropTypes.bool,
+        type: PropTypes.string,
+        exactSearch: PropTypes.bool
+      }))
+    )),
     /**
      * The namespace URI used for features.
      * @type {String}


### PR DESCRIPTION
<!-- Please choose one of the categories and choose the corresponding label, too. -->
## FEATURE

### Description:
<!-- Please describe what this PR is about. -->
This PR fixes searching number fields via WFS. This is still far from perfect. You can configure the WFS search now with attribute details, which allows you to control how filters are created. `matchCase` can be used to control the corresponding filter attribute, `exactSearch` will make the code check for attributes of type `number` and `int` and skip the filter completely if the search term contains non numeric characters.

We should really think about doing a solr or elastic search backend in order to get better results.

<!--- CHECKLIST
Fixes Issue?
Examples added?
Tests added?
Docs added?
Would a screenshot be helpful?
Do you want to mention someone?
-->

@terrestris/devs Please review.