### PR TITLE
Fixes titlebar style

### DIFF
--- a/src/Panel/Titlebar/Titlebar.less
+++ b/src/Panel/Titlebar/Titlebar.less
@@ -1,6 +1,7 @@
 @import '../../style/variables.less';
 
 .react-geo-titlebar {
+  padding: 0;
   display: flex;
   align-items: center;
   background-color: darken(@component-background, 10);


### PR DESCRIPTION
<!-- Please choose one of the categories and choose the corresponding label, too. -->
## BUGFIX

### Description:
<!-- Please describe what this PR is about. -->
This fixes the styling of the `Titelbar` as an update of Ant Design added a default padding to the ant-modal-header.

<!--- CHECKLIST
Fixes Issue?
Examples added?
Tests added?
Docs added?
Would a screenshot be helpful?
Do you want to mention someone?
-->

Before:
![terrestris github io_react-geo_docs_latest_index html 1](https://user-images.githubusercontent.com/1849416/39693025-edc20cca-51e2-11e8-961d-3882727b2a01.png)

After:
![terrestris github io_react-geo_docs_latest_index html 2](https://user-images.githubusercontent.com/1849416/39693031-f1582702-51e2-11e8-9c1a-98c1a145533c.png)



