### PR TITLE
Collect coverage from src directory only

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -21,5 +21,8 @@ module.exports = {
     '<rootDir>/jest/setup.js'
   ],
   collectCoverage: false,
+  collectCoverageFrom: [
+    'src/**/*.jsx'
+  ],
   coverageDirectory: '<rootDir>/coverage'
 };


### PR DESCRIPTION
<!-- Please choose one of the categories and choose the corresponding label, too. -->
## DEVSETUP 

### Description:

Previously we would collect coverage information from the `assets/`- and `jest/`- directories, which should not matter to us. I belive this will bring down coverage a bit, but the then reported value is a bit closer to the reality.

Update: as expected coverage went down quite a bit (`-6.8 %`).