### PR TITLE
Better configuration for coverage collection

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -22,7 +22,9 @@ module.exports = {
   ],
   collectCoverage: false,
   collectCoverageFrom: [
-    'src/**/*.jsx'
+    'src/**/*.jsx',
+    'src/**/*.js',
+    '!src/**/*example*.*'
   ],
   coverageDirectory: '<rootDir>/coverage'
 };


### PR DESCRIPTION
## DEVSETUP

### Description:
A better configuration for coverage collection. The previous configuration excluded `*.js` files (and only kept `*.jsx`) and erroneously included at least one example.

The [last build](https://coveralls.io/builds/16880847) had coverage for 40 files, the [current one](https://coveralls.io/builds/16883356) has coverage for 56 files (see all those with the small pluss sign for those that we previously missed).
