### PR TITLE
Resolutions filter for scale combo

### DIFF
--- a/src/Field/ScaleCombo/ScaleCombo.jsx
+++ b/src/Field/ScaleCombo/ScaleCombo.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Select } from 'antd';
 const Option = Select.Option;
+import OlMap from 'ol/map';
 import {
   isInteger,
   isEmpty,
@@ -79,7 +80,7 @@ class ScaleCombo extends React.Component {
      * The map
      * @type {Ol.Map}
      */
-    map: PropTypes.object.isRequired,
+    map: PropTypes.instanceOf(OlMap).isRequired,
 
     /**
      * Set to false to not listen to the map moveend event.

--- a/src/Field/ScaleCombo/ScaleCombo.jsx
+++ b/src/Field/ScaleCombo/ScaleCombo.jsx
@@ -94,6 +94,7 @@ class ScaleCombo extends React.Component {
    * The default props
    */
   static defaultProps = {
+    resolutionsFilter: () => true,
     style: {
       width: 100
     },
@@ -220,18 +221,14 @@ class ScaleCombo extends React.Component {
     if (isEmpty(resolutions)) {
       for (let currentZoomLevel = mv.getMaxZoom(); currentZoomLevel >= mv.getMinZoom(); currentZoomLevel--) {
         let resolution = mv.getResolutionForZoom(currentZoomLevel);
-        if (isFunction(resolutionsFilter)) {
-          if (resolutionsFilter(resolution)) {
-            this.pushScale(resolution, mv);
-          }
-        } else {
+        if (resolutionsFilter(resolution)) {
           this.pushScale(resolution, mv);
         }
       }
     } else {
       let reversedResolutions = reverse(clone(resolutions));
       reversedResolutions
-        .filter(isFunction(resolutionsFilter) ? resolutionsFilter : f => f)
+        .filter(resolutionsFilter)
         .forEach((resolution) => {
           this.pushScale(resolution, mv);
         });

--- a/src/Field/ScaleCombo/ScaleCombo.jsx
+++ b/src/Field/ScaleCombo/ScaleCombo.jsx
@@ -64,6 +64,12 @@ class ScaleCombo extends React.Component {
     scales: PropTypes.arrayOf(PropTypes.shape),
 
     /**
+     * A filter function to filter resolutions no options should be created
+     * @type {Function}
+     */
+    resolutionsFilter: PropTypes.func,
+
+    /**
      * The style object
      * @type {Object}
      */
@@ -107,8 +113,8 @@ class ScaleCombo extends React.Component {
      *
      * @param  {Number} selectedScale The selectedScale.
      */
-    const defaultOnZoomLevelSelect = (selectedScale) => {
-      const mapView = this.props.map.getView();
+    const defaultOnZoomLevelSelect = selectedScale => {
+      const mapView = props.map.getView();
       const calculatedResolution = MapUtil.getResolutionForScale(
         selectedScale, mapView.getProjection().getUnits()
       );
@@ -116,13 +122,13 @@ class ScaleCombo extends React.Component {
     };
 
     this.state = {
-      zoomLevel: props.zoomLevel || this.props.map.getView().getZoom(),
+      zoomLevel: props.zoomLevel || props.map.getView().getZoom(),
       onZoomLevelSelect: props.onZoomLevelSelect || defaultOnZoomLevelSelect,
       scales: props.scales
     };
 
     if (props.syncWithMap) {
-      this.props.map.on('moveend', this.zoomListener);
+      props.map.on('moveend', this.zoomListener);
     }
   }
 
@@ -193,29 +199,41 @@ class ScaleCombo extends React.Component {
    * based on an existing instance of {@link Ol.Map}
    */
   getOptionsFromMap = () => {
+    const {
+      map,
+      resolutionsFilter
+    } = this.props;
+
     if (!isEmpty(this.state.scales)) {
       Logger.debug('Array with scales found. Returning');
       return;
     }
-    if (!this.props.map) {
+    if (!map) {
       Logger.warn('Map component not found. Could not initialize options array.');
       return;
     }
 
-    let map = this.props.map;
     let mv = map.getView();
     // use existing resolutions array if exists
     let resolutions = mv.getResolutions();
     if (isEmpty(resolutions)) {
       for (let currentZoomLevel = mv.getMaxZoom(); currentZoomLevel >= mv.getMinZoom(); currentZoomLevel--) {
         let resolution = mv.getResolutionForZoom(currentZoomLevel);
-        this.pushScale(resolution, mv);
+        if (isFunction(resolutionsFilter)) {
+          if (resolutionsFilter(resolution)) {
+            this.pushScale(resolution, mv);
+          }
+        } else {
+          this.pushScale(resolution, mv);
+        }
       }
     } else {
       let reversedResolutions = reverse(clone(resolutions));
-      reversedResolutions.forEach((resolution) => {
-        this.pushScale(resolution, mv);
-      });
+      reversedResolutions
+        .filter(isFunction(resolutionsFilter) ? resolutionsFilter : f => f)
+        .forEach((resolution) => {
+          this.pushScale(resolution, mv);
+        });
     }
   };
 
@@ -251,11 +269,17 @@ class ScaleCombo extends React.Component {
       className
     } = this.props;
 
+    const {
+      onZoomLevelSelect,
+      scales,
+      zoomLevel
+    } = this.state;
+
     const finalClassName = className
       ? `${className} ${this.className}`
       : this.className;
 
-    const options = this.state.scales.map((roundScale) => {
+    const options = scales.map(roundScale => {
       return <Option
         key={roundScale}
         value={roundScale.toString()}
@@ -267,9 +291,9 @@ class ScaleCombo extends React.Component {
     return (
       <Select
         showSearch
-        onChange={this.state.onZoomLevelSelect}
+        onChange={onZoomLevelSelect}
         filterOption={(input, option) => option.key.startsWith(input)}
-        value={this.determineOptionKeyForZoomLevel(this.state.zoomLevel)}
+        value={this.determineOptionKeyForZoomLevel(zoomLevel)}
         size="small"
         style={style}
         className={finalClassName}

--- a/src/Field/ScaleCombo/ScaleCombo.spec.jsx
+++ b/src/Field/ScaleCombo/ScaleCombo.spec.jsx
@@ -99,6 +99,36 @@ describe('<ScaleCombo />', () => {
 
       TestUtil.removeMap(map);
     });
+
+    it('creates options array from given map with filtered resolutions and updates scales prop', () => {
+      const testResolutions = [560, 280, 140, 70, 28, 19, 15, 14, 13, 9];
+      const map = TestUtil.createMap({
+        resolutions: testResolutions
+      });
+
+      // eslint-disable-next-line
+      const resolutionsFilter = res => {
+        return res >= 19 || res <= 13;
+      }
+
+      const expectedLength = testResolutions.filter(resolutionsFilter).length;
+
+      const wrapper = TestUtil.mountComponent(ScaleCombo, {
+        map: map,
+        scales: [],
+        resolutionsFilter
+      });
+      wrapper.instance().getOptionsFromMap();
+      expect(wrapper.props().scales).toBeInstanceOf(Array);
+      expect(wrapper.props().scales).toHaveLength(expectedLength);
+
+      let roundScale = MapUtil.roundScale(MapUtil.getScaleForResolution(
+        testResolutions[testResolutions.length - 2] ,'m'));
+
+      expect(wrapper.props().scales[1]).toBe(roundScale);
+
+      TestUtil.removeMap(map);
+    });
   });
 
   describe('#determineOptionKeyForZoomLevel', () => {

--- a/src/Field/ScaleCombo/ScaleCombo.spec.jsx
+++ b/src/Field/ScaleCombo/ScaleCombo.spec.jsx
@@ -109,7 +109,7 @@ describe('<ScaleCombo />', () => {
       // eslint-disable-next-line
       const resolutionsFilter = res => {
         return res >= 19 || res <= 13;
-      }
+      };
 
       const expectedLength = testResolutions.filter(resolutionsFilter).length;
 


### PR DESCRIPTION
<!-- Please choose one of the categories and choose the corresponding label, too. -->
## FEATURE

### Description:
<!-- Please describe what this PR is about. -->
This PR adds a prop `resolutionsFilter` to `ScaleCombo` in order to filter resolutions for which no `Select.Option` items will be created in the combo.

<!--- CHECKLIST
Fixes Issue?
Examples added?
Tests added?
Docs added?
Would a screenshot be helpful?
Do you want to mention someone?
-->
