### PR TITLE
Remove unneeded info wrt the non-existant vulnerability

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Known Vulnerabilities](https://snyk.io/test/github/terrestris/react-geo/badge.svg)](https://snyk.io/test/github/terrestris/react-geo)
 [![Greenkeeper badge](https://badges.greenkeeper.io/terrestris/react-geo.svg)](https://greenkeeper.io/)
 [![devDependencies Status](https://david-dm.org/terrestris/react-geo/dev-status.svg)](https://david-dm.org/terrestris/react-geo?type=dev)
-[![dependencies Status](https://david-dm.org/terrestris/react-geo/status.svg)](https://david-dm.org/terrestris/react-geo) <sup title="Worried? Don't be! Please see the explanation in the footnote…">[&nbsp;1&nbsp;](#footnote-1)</sup> <a name="jumpback-footnote-1">&nbsp;</a>
+[![dependencies Status](https://david-dm.org/terrestris/react-geo/status.svg)](https://david-dm.org/terrestris/react-geo)
 
 A set of geo related modules. To use in combination with [react](https://github.com/facebook/react), [antd](https://github.com/ant-design/ant-design) and [ol](https://github.com/openlayers/openlayers).
 
@@ -84,21 +84,3 @@ In your project:
 ```javascript static
 npm link @terrestris/react-geo
 ```
-
-## Footnotes
-
-<dl>
-  <dt>
-    <a name="footnote-1">1:</a>
-  </dt>
-  <dd>
-    The autodetected vulnerability is not applicable for
-    <code>react-geo</code>s use of the <code>ag-grid</code>-component,
-    see <a href="https://nodesecurity.io/advisories/327">Nodesecurity</a>,
-    which states 'if AngularJS is used in combination with ag-grid'.
-    This is clearly not the case for this react library. As long as
-    <a href="https://david-dm.org/terrestris/react-geo">the overview
-    page</a> only lists this specific warning, you should be fine.
-    <a title="Jump back to the origin of the footnote" href="#jumpback-footnote-1">↥ back</a>
-  </dd>
-</dl>


### PR DESCRIPTION
## DOCUMENTATION

### Description:

We are no longer erroneously flagged as having a vulnerable transitive dependency by david-dm. We can therefor remove the footnote with more information that clarified this to readers.

This effectively reverts the relevant parts of commit 9b0c7c801785c4777e4561851f22554257c6f2f9 introduced in #618.

Please review.
