### PR TITLE
Extract createWfsFilter method to WfsFilterUtil

### DIFF
--- a/src/Field/WfsSearch/WfsSearch.jsx
+++ b/src/Field/WfsSearch/WfsSearch.jsx
@@ -51,10 +51,30 @@ export class WfsSearch extends React.Component {
      */
     searchAttributes: PropTypes.object.isRequired,
     /**
-     * An object mapping feature types to an array of attribute details.
+     * A nested object mapping feature types to an object of attribute details,
+     * which are also mapped by search attribute name.
+     *
+     * Example:
+     *   ```
+     *   searchAttributes: {
+     *    featType1: {
+     *      attr1: {
+     *        matchCase: true,
+     *        type: 'number',
+     *        exactSearch: false
+     *      },
+     *      attr2: {
+     *        matchCase: false,
+     *        type: 'string',
+     *        exactSearch: true
+     *      }
+     *    },
+     *    featType2: {...}
+     *   }
+     *   ```
      * @type {Object}
      */
-    attributeDetails: PropTypes.objectOf(PropTypes.arrayOf(
+    attributeDetails: PropTypes.objectOf(PropTypes.objectOf(
       PropTypes.objectOf(PropTypes.shape({
         matchCase: PropTypes.bool,
         type: PropTypes.string,

--- a/src/Util/WfsFilterUtil/WfsFilterUtil.js
+++ b/src/Util/WfsFilterUtil/WfsFilterUtil.js
@@ -1,0 +1,51 @@
+import OlFormatFilter from 'ol/format/filter';
+
+/**
+ * Helper Class for building filters to be used with WFS GetFeature requests.
+ *
+ * @class WfsFilterUtil
+ */
+class WfsFilterUtil {
+
+  /**
+   * Creates a filter for a given feature type considering configured
+   * search attributes, mapped features types to an array of attribute details and the
+   * current search term.
+   * Currently supports EQUALTO and LIKE filters only, which can be combined with
+   * OR filter if searchAttributes array contains multiple values though.
+   *
+   * @param {String} featureType Name of feature type to be used in filter.
+   * @param {String} searchTerm Search value.
+   * @param {Object} searchAttributes An object mapping feature types to an array of
+   *   attributes that should be searched through.
+   * @param {Object} attributeDetails An object mapping feature types to an
+   *   array of attribute details.
+   * @return {OlFormatFilter} Filter to be used with WFS GetFeature requests.
+   * @private
+   */
+  static createWfsFilter(featureType, searchTerm, searchAttributes, attributeDetails) {
+
+    const attributes = searchAttributes[featureType];
+    const details = attributeDetails[featureType];
+
+    const propertyFilters = attributes.map(attribute => {
+      if (details && details[attribute] && details[attribute].exactSearch) {
+        const type = details && details[attribute].type || 'int';
+        if ((type === 'int' || type === 'number') && searchTerm.match(/[^.\d]/)) {
+          return undefined;
+        }
+        return OlFormatFilter.equalTo(attribute, searchTerm, details[attribute].exactSearch);
+      } else {
+        return OlFormatFilter.like(attribute, `*${searchTerm}*`, '*', '.', '!', details && details[attribute].matchCase);
+      }
+    })
+      .filter(filter => filter !== undefined);
+    if (attributes.length > 1 && Object.keys(propertyFilters).length > 1) {
+      return OlFormatFilter.or(...propertyFilters);
+    } else {
+      return propertyFilters[0];
+    }
+  }
+}
+
+export default WfsFilterUtil;

--- a/src/Util/WfsFilterUtil/WfsFilterUtil.js
+++ b/src/Util/WfsFilterUtil/WfsFilterUtil.js
@@ -26,8 +26,12 @@ class WfsFilterUtil {
   static createWfsFilter(featureType, searchTerm, searchAttributes, attributeDetails) {
 
     const attributes = searchAttributes[featureType];
-    const details = attributeDetails[featureType];
 
+    if (!attributes) {
+      return null;
+    }
+
+    const details = attributeDetails[featureType];
     const propertyFilters = attributes.map(attribute => {
       if (details && details[attribute] && details[attribute].exactSearch) {
         const type = details && details[attribute].type || 'int';

--- a/src/Util/WfsFilterUtil/WfsFilterUtil.spec.js
+++ b/src/Util/WfsFilterUtil/WfsFilterUtil.spec.js
@@ -1,0 +1,99 @@
+/*eslint-env jest*/
+
+import {
+  WfsFilterUtil,
+} from '../../index';
+
+describe('WfsFilterUtil', () => {
+
+  const featureType = 'featureType';
+  const stringSearchTerm = 'searchMe';
+  const digitSearchTerm = '123';
+  let searchAttributes = {
+    featureType: []
+  };
+  let attributeDetails = {
+    featureType: {}
+  };
+
+  const stringAttr1 = {
+    matchCase: false,
+    type: 'string',
+    exactSearch: false
+  };
+
+  const stringAttr2 = {
+    matchCase: true,
+    type: 'string',
+    exactSearch: false
+  };
+
+  const numberAttr = {
+    matchCase: true,
+    type: 'int',
+    exactSearch: true
+  };
+
+  describe('Basics', () => {
+    it('is defined', () => {
+      expect(WfsFilterUtil).not.toBeUndefined();
+    });
+  });
+
+  describe('Static methods', () => {
+
+    afterEach(() => {
+      searchAttributes = {
+        'featureType': []
+      };
+      Object.keys(attributeDetails[featureType]).forEach(prop => {
+        delete attributeDetails[featureType][prop];
+      });
+    });
+
+    describe('#createWfsFilter', () => {
+
+      it('is defined', () => {
+        expect(WfsFilterUtil.createWfsFilter).toBeDefined();
+      });
+
+      it ('returns simple LIKE filter if only one attribute is provided and exactSearch flag is false', () => {
+        searchAttributes[featureType].push('stringAttr1');
+        attributeDetails['featureType']['stringAttr1'] = stringAttr1;
+
+        const got = WfsFilterUtil.createWfsFilter(featureType, stringSearchTerm, searchAttributes, attributeDetails);
+
+        expect(got.getTagName()).toBe('PropertyIsLike');
+        expect(got.pattern).toEqual(`*${stringSearchTerm}*`);
+        expect(got.propertyName).toEqual(searchAttributes[featureType][0]);
+      });
+
+      it ('returns simple EQUALTO filter if only one attribute is provided and exactSearch flag is true', () => {
+        searchAttributes[featureType].push('numberAttr');
+        attributeDetails['featureType']['numberAttr'] = numberAttr;
+
+        const got = WfsFilterUtil.createWfsFilter(featureType, digitSearchTerm, searchAttributes, attributeDetails);
+
+        expect(got.getTagName()).toBe('PropertyIsEqualTo');
+        expect(got.expression).toEqual(digitSearchTerm);
+        expect(got.propertyName).toEqual(searchAttributes[featureType][0]);
+      });
+
+      it ('returns combined OR filter if more than one search attributes are provided', () => {
+
+        searchAttributes[featureType].push(...['stringAttr1', 'stringAttr2']);
+        attributeDetails = {
+          'featureType': {
+            'stringAttr1': stringAttr1,
+            'stringAttr2': stringAttr2
+          }
+        };
+
+        const got = WfsFilterUtil.createWfsFilter(featureType, stringSearchTerm, searchAttributes, attributeDetails);
+
+        expect(got.getTagName()).toBe('Or');
+        expect(got.conditions.length).toEqual(searchAttributes[featureType].length);
+      });
+    });
+  });
+});

--- a/src/Util/WfsFilterUtil/WfsFilterUtil.spec.js
+++ b/src/Util/WfsFilterUtil/WfsFilterUtil.spec.js
@@ -57,6 +57,17 @@ describe('WfsFilterUtil', () => {
         expect(WfsFilterUtil.createWfsFilter).toBeDefined();
       });
 
+      it ('returns null if no search attributes for the provided feature type are found', () => {
+        searchAttributes = {
+          'someAnotherFeatureType': []
+        };
+        attributeDetails['featureType']['stringAttr1'] = stringAttr1;
+
+        const got = WfsFilterUtil.createWfsFilter(featureType, stringSearchTerm, searchAttributes, attributeDetails);
+
+        expect(got).toBeNull();
+      });
+
       it ('returns simple LIKE filter if only one attribute is provided and exactSearch flag is false', () => {
         searchAttributes[featureType].push('stringAttr1');
         attributeDetails['featureType']['stringAttr1'] = stringAttr1;
@@ -80,7 +91,6 @@ describe('WfsFilterUtil', () => {
       });
 
       it ('returns combined OR filter if more than one search attributes are provided', () => {
-
         searchAttributes[featureType].push(...['stringAttr1', 'stringAttr2']);
         attributeDetails = {
           'featureType': {

--- a/src/index.js
+++ b/src/index.js
@@ -45,6 +45,7 @@ import ProjectionUtil from './Util/ProjectionUtil/ProjectionUtil';
 import StringUtil from './Util/StringUtil/StringUtil';
 import UndoUtil from './Util/UndoUtil/UndoUtil';
 import UrlUtil from './Util/UrlUtil/UrlUtil';
+import WfsFilterUtil from './Util/WfsFilterUtil/WfsFilterUtil';
 import Logger from './Util/Logger';
 
 import MapProvider from './Provider/MapProvider/MapProvider.jsx';
@@ -101,6 +102,7 @@ export {
   MultiLayerSlider,
   UndoUtil,
   UrlUtil,
+  WfsFilterUtil,
   MapProvider,
   MapComponent,
   mappify,


### PR DESCRIPTION
<!-- Please choose one of the categories and choose the corresponding label, too. -->
## FEATURE | REFACTORING 

### Description:
Extracted `createWfsFilter` method from `WfsSearch` class and moved it to the new utility class `WfsFilterUtil` to make it reusable in other projects.

Please review @terrestris/devs 
