### PR TITLE
Get smarter by `attributeDetails` object access in `WfsFilterUtil`

### DIFF
--- a/src/Util/WfsFilterUtil/WfsFilterUtil.js
+++ b/src/Util/WfsFilterUtil/WfsFilterUtil.js
@@ -25,22 +25,26 @@ class WfsFilterUtil {
    */
   static createWfsFilter(featureType, searchTerm, searchAttributes, attributeDetails) {
 
-    const attributes = searchAttributes[featureType];
+    const attributes = searchAttributes && searchAttributes[featureType];
 
     if (!attributes) {
       return null;
     }
 
-    const details = attributeDetails[featureType];
+    const details = attributeDetails && attributeDetails[featureType];
     const propertyFilters = attributes.map(attribute => {
-      if (details && details[attribute] && details[attribute].exactSearch) {
-        const type = details && details[attribute].type || 'int';
-        if ((type === 'int' || type === 'number') && searchTerm.match(/[^.\d]/)) {
+      if (details && details[attribute]) {
+        const type = details[attribute].type;
+        if (type && (type === 'int' || type === 'number') && searchTerm.match(/[^.\d]/)) {
           return undefined;
         }
-        return OlFormatFilter.equalTo(attribute, searchTerm, details[attribute].exactSearch);
+        if (details[attribute].exactSearch) {
+          return OlFormatFilter.equalTo(attribute, searchTerm, details[attribute].exactSearch);
+        } else {
+          return OlFormatFilter.like(attribute, `*${searchTerm}*`, '*', '.', '!', details[attribute].matchCase || false);
+        }
       } else {
-        return OlFormatFilter.like(attribute, `*${searchTerm}*`, '*', '.', '!', details && details[attribute].matchCase);
+        return OlFormatFilter.like(attribute, `*${searchTerm}*`, '*', '.', '!', false);
       }
     })
       .filter(filter => filter !== undefined);

--- a/src/Util/WfsFilterUtil/WfsFilterUtil.spec.js
+++ b/src/Util/WfsFilterUtil/WfsFilterUtil.spec.js
@@ -68,15 +68,27 @@ describe('WfsFilterUtil', () => {
         expect(got).toBeNull();
       });
 
-      it ('returns simple LIKE filter if only one attribute is provided and exactSearch flag is false', () => {
-        searchAttributes[featureType].push('stringAttr1');
-        attributeDetails['featureType']['stringAttr1'] = stringAttr1;
+      it ('returns simple LIKE filter if only one attribute is provided and exactSearch flag is false or not given', () => {
+        searchAttributes[featureType].push('stringAttr2');
+        attributeDetails['featureType']['stringAttr2'] = stringAttr2;
 
         const got = WfsFilterUtil.createWfsFilter(featureType, stringSearchTerm, searchAttributes, attributeDetails);
 
         expect(got.getTagName()).toBe('PropertyIsLike');
         expect(got.pattern).toEqual(`*${stringSearchTerm}*`);
         expect(got.propertyName).toEqual(searchAttributes[featureType][0]);
+        expect(got.matchCase).toEqual(stringAttr2.matchCase);
+      });
+
+      it ('returns simple LIKE filter if only one attribute is provided and attributeDetails argument is omitted', () => {
+        searchAttributes[featureType].push('stringAttr1');
+
+        const got = WfsFilterUtil.createWfsFilter(featureType, stringSearchTerm, searchAttributes);
+
+        expect(got.getTagName()).toBe('PropertyIsLike');
+        expect(got.pattern).toEqual(`*${stringSearchTerm}*`);
+        expect(got.propertyName).toEqual(searchAttributes[featureType][0]);
+        expect(got.matchCase).toBeFalsy();
       });
 
       it ('returns simple EQUALTO filter if only one attribute is provided and exactSearch flag is true', () => {


### PR DESCRIPTION
<!-- Please choose one of the categories and choose the corresponding label, too. -->
## BUGFIX 

### Description:
Follow-up of #662 

* Added some more additional checks to ensure that `attributeDetails` object is provided and has expected keys (e.g. `type`, `exactSearch` or `matchCase`)
* Enhanced fallback return value if no `attributeDetails` is given.

Please review @terrestris/devs 


