### PR TITLE
Changed find to filter to support IE

### DIFF
--- a/src/Util/MapUtil/MapUtil.js
+++ b/src/Util/MapUtil/MapUtil.js
@@ -168,9 +168,9 @@ export class MapUtil {
    */
   static getLayerByName(map, name) {
     const layers = MapUtil.getAllLayers(map);
-    return layers.find((layer) => {
+    return layers.filter((layer) => {
       return layer.get('name') === name;
-    });
+    })[0];
   }
 
   /**

--- a/src/Util/UrlUtil/UrlUtil.js
+++ b/src/Util/UrlUtil/UrlUtil.js
@@ -64,7 +64,7 @@ export class UrlUtil {
    */
   static getQueryParam(url, key) {
     const queryParamsObj = UrlUtil.getQueryParams(url);
-    const foundKey = Object.keys(queryParamsObj).find(k => k.toLowerCase() === key.toLowerCase());
+    const foundKey = Object.keys(queryParamsObj).filter(k => k.toLowerCase() === key.toLowerCase())[0];
 
     return queryParamsObj[foundKey];
   }


### PR DESCRIPTION
## BUGFIX

### Description:
Internet explorer does not support .find without polyfills, switching to .filter()[0] produces the same result for the function getLayerByName in MapUtil.js
