### PR TITLE
Removes static broken `optionLabelProp` from NominatimSearch

### DIFF
--- a/src/Field/NominatimSearch/NominatimSearch.jsx
+++ b/src/Field/NominatimSearch/NominatimSearch.jsx
@@ -41,7 +41,7 @@ export class NominatimSearch extends React.Component {
      */
     format: PropTypes.string,
     /**
-     * The preferred area to find search results in <left>,<top>,<right>,<bottom>.
+     * The preferred area to find search results in [left],[top],[right],[bottom].
      * @type {String}
      */
     viewbox: PropTypes.string,
@@ -71,7 +71,7 @@ export class NominatimSearch extends React.Component {
     limit: PropTypes.number,
     /**
      * Limit search results to a specific country (or a list of countries).
-     * <countrycode> should be the ISO 3166-1alpha2 code, e.g. gb for the United
+     * [countrycode] should be the ISO 3166-1alpha2 code, e.g. gb for the United
      * Kingdom, de for Germany, etc.
      * @type {String}
      */
@@ -286,7 +286,6 @@ export class NominatimSearch extends React.Component {
         allowClear={true}
         placeholder="Ortsname, Straßenname, Stadtteilname, POI usw."
         dataSource={this.state.dataSource.map(renderOption.bind(this))}
-        optionLabelProp="display_name"
         onChange={this.onUpdateInput}
         onSelect={this.onMenuItemSelected}
         {...passThroughProps}


### PR DESCRIPTION
<!-- Please choose one of the categories and choose the corresponding label, too. -->
## BUGFIX

### Description:
<!-- Please describe what this PR is about. -->
This removes the wrong configured `optionLabelProp` from the NominatimSearch. It uses the default value (the children of the select option) as display value now.

It also includes some minor changes to the docs as these causes some warnings from react-dom.

<!--- CHECKLIST
Fixes Issue?
Examples added?
Tests added?
Docs added?
Would a screenshot be helpful?
Do you want to mention someone?
-->
