### PR TITLE
Several updates for the WfsSearch

### DIFF
--- a/src/Field/WfsSearch/WfsSearch.jsx
+++ b/src/Field/WfsSearch/WfsSearch.jsx
@@ -181,7 +181,7 @@ export class WfsSearch extends React.Component {
      * Which prop value of option will render as content of select.
      * @type {string}
      */
-    optionLabelProp: PropTypes.string,
+    displayValue: PropTypes.string,
     /**
      * Delay in ms before actually sending requests.
      * @type {number}
@@ -194,20 +194,31 @@ export class WfsSearch extends React.Component {
     outputFormat: 'application/json',
     minChars: 3,
     additionalFetchOptions: {},
-    optionLabelProp: 'title',
+    displayValue: 'name',
     attributeDetails: {},
     delay: 300,
     /**
      * Create an AutoComplete.Option from the given data.
      *
      * @param {Object} feature The feature as returned by the server.
+     * @param {Object} props The current props of the component.
      * @return {AutoComplete.Option} The AutoComplete.Option that will be
      * rendered for each feature.
      */
-    renderOption: feature => {
-      const display = feature.properties.name ? feature.properties.name : feature.id;
+    renderOption: (feature, props) => {
+      const {
+        displayValue
+      } = props;
+
+      const display = feature.properties[displayValue] ?
+        feature.properties[displayValue] : feature.id;
+
       return (
-        <Option key={feature.id} title={display}>
+        <Option
+          value={display}
+          key={feature.id}
+          title={display}
+        >
           {display}
         </Option>
       );
@@ -415,12 +426,14 @@ export class WfsSearch extends React.Component {
    * The function describes what to do when an item is selected.
    *
    * @param {String|number} value The value of the selected option.
+   * @param {Node} option The selected option.
    */
-  onMenuItemSelected(value) {
+  onMenuItemSelected(value, option) {
     const {
       map
     } = this.props;
-    const selectedFeature = this.state.data.filter(i => i.id === value)[0];
+
+    const selectedFeature = this.state.data.filter(feat => feat.id === option.key)[0];
     this.props.onSelect(selectedFeature, map);
   }
 
@@ -445,7 +458,6 @@ export class WfsSearch extends React.Component {
       map,
       maxFeatures,
       minChars,
-      optionLabelProp,
       outputFormat,
       onChange,
       onSelect,
@@ -470,12 +482,15 @@ export class WfsSearch extends React.Component {
         onChange={this.onUpdateInput}
         onSelect={this.onMenuItemSelected}
         notFoundContent={fetching ? <Spin size="small" /> : null}
-        optionLabelProp={optionLabelProp}
         filterOption={false}
         showArrow={false}
         {...passThroughProps}
       >
-        {data.map(renderOption.bind(this))}
+        {
+          data.map(d => {
+            return renderOption(d, this.props);
+          })
+        }
       </Select>
     );
   }

--- a/src/Field/WfsSearch/WfsSearch.jsx
+++ b/src/Field/WfsSearch/WfsSearch.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {  Select,  Spin } from 'antd';
+import { Select, Spin } from 'antd';
 const Option = Select.Option;
 
 import Logger from '../../Util/Logger';
@@ -53,7 +53,7 @@ export class WfsSearch extends React.Component {
      *
      * Example:
      *   ```
-     *   searchAttributes: {
+     *   attributeDetails: {
      *    featType1: {
      *      attr1: {
      *        matchCase: true,
@@ -71,13 +71,15 @@ export class WfsSearch extends React.Component {
      *   ```
      * @type {Object}
      */
-    attributeDetails: PropTypes.objectOf(PropTypes.objectOf(
-      PropTypes.objectOf(PropTypes.shape({
-        matchCase: PropTypes.bool,
-        type: PropTypes.string,
-        exactSearch: PropTypes.bool
-      }))
-    )),
+    attributeDetails: PropTypes.objectOf(
+      PropTypes.objectOf(
+        PropTypes.shape({
+          matchCase: PropTypes.bool,
+          type: PropTypes.string,
+          exactSearch: PropTypes.bool
+        })
+      )
+    ),
     /**
      * The namespace URI used for features.
      * @type {String}

--- a/src/Field/WfsSearch/WfsSearch.jsx
+++ b/src/Field/WfsSearch/WfsSearch.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Select, Spin } from 'antd';
 const Option = Select.Option;
+import isFunction from 'lodash/isFunction.js';
 
 import Logger from '../../Util/Logger';
 import WfsFilterUtil from '../../Util/WfsFilterUtil/WfsFilterUtil';
@@ -158,6 +159,12 @@ export class WfsSearch extends React.Component {
      */
     onSelect: PropTypes.func,
     /**
+     * An onChange function which gets called with the current value of the
+     * field.
+     * @type {function}
+     */
+    onChange: PropTypes.func,
+    /**
      * Options which are added to the fetch-POST-request. credentials is set to
      * 'same-origin' as default but can be overwritten. See also
      * https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch
@@ -258,6 +265,11 @@ export class WfsSearch extends React.Component {
    *                                      is pressed.
    */
   onUpdateInput(value) {
+    const {
+      minChars,
+      onChange
+    } = this.props;
+
     this.setState({
       data: []
     });
@@ -266,10 +278,14 @@ export class WfsSearch extends React.Component {
       this.setState({
         searchTerm: value
       }, () => {
-        if (this.state.searchTerm.length >= this.props.minChars) {
+        if (this.state.searchTerm.length >= minChars) {
           this.doSearch();
         }
       });
+    }
+
+    if (isFunction(onChange)) {
+      onChange(value);
     }
   }
 
@@ -431,6 +447,7 @@ export class WfsSearch extends React.Component {
       minChars,
       optionLabelProp,
       outputFormat,
+      onChange,
       onSelect,
       propertyNames,
       renderOption,

--- a/src/Field/WfsSearch/WfsSearch.spec.jsx
+++ b/src/Field/WfsSearch/WfsSearch.spec.jsx
@@ -40,7 +40,9 @@ describe('<WfsSearch />', () => {
         placeholder: 'Type a countryname in its own language…',
         baseUrl: 'https://ows.terrestris.de/geoserver/osm/wfs',
         featureTypes: ['osm:osm-country-borders'],
-        searchAttributes: ['name']
+        searchAttributes: {
+          'osm:osm-country-borders': ['name']
+        }
       });
       wrapper.instance().doSearch = jest.fn();
       const inputValue = 'Deutsch';

--- a/src/Field/WfsSearch/WfsSearch.spec.jsx
+++ b/src/Field/WfsSearch/WfsSearch.spec.jsx
@@ -116,9 +116,7 @@ describe('<WfsSearch />', () => {
   });
 
   describe('default #onSelect', () => {
-    it('zooms to the selected feature', (done) => {
-      expect.assertions(3);
-      jest.useFakeTimers();
+    it('zooms to the selected feature', () => {
       //SETUP
       const feature = {
         type: 'Feature',
@@ -144,15 +142,20 @@ describe('<WfsSearch />', () => {
       const wrapper = TestUtil.mountComponent(WfsSearch, {map});
       const fitSpy = jest.spyOn(map.getView(), 'fit');
       wrapper.props().onSelect(feature, map);
+
+      expect.assertions(3);
+
       expect(fitSpy).toHaveBeenCalled();
-      setTimeout(() => {
-        expect(map.getView().getCenter()).toEqual([25, 25]);
-        expect(map.getView().getZoom()).toEqual(2);
-        done();
-      }, 510);
-      jest.runAllTimers();
-      fitSpy.mockReset();
-      fitSpy.mockRestore();
+
+      return new Promise(resolve => {
+        setTimeout(resolve, 510);
+      })
+        .then(() => {
+          expect(map.getView().getCenter()).toEqual([25, 25]);
+          expect(map.getView().getZoom()).toEqual(2);
+          fitSpy.mockReset();
+          fitSpy.mockRestore();
+        });
     });
   });
 

--- a/src/Field/WfsSearch/WfsSearch.spec.jsx
+++ b/src/Field/WfsSearch/WfsSearch.spec.jsx
@@ -104,7 +104,7 @@ describe('<WfsSearch />', () => {
       wrapper.setState({
         data: data
       });
-      wrapper.instance().onMenuItemSelected('752526');
+      wrapper.instance().onMenuItemSelected('Deutschland', {key: '752526'});
       expect(selectSpy).toHaveBeenCalled();
       expect(selectSpy).toHaveBeenCalledWith(data[0], map);
 
@@ -163,7 +163,9 @@ describe('<WfsSearch />', () => {
           name: 'Deutschland'
         }
       };
-      const option = wrapper.props().renderOption(feature);
+      const option = wrapper.props().renderOption(feature, {
+        displayValue: 'name'
+      });
       expect(option.key).toBe(feature.id);
       expect(option.props.children).toBe(feature.properties.name);
     });


### PR DESCRIPTION
<!-- Please choose one of the categories and choose the corresponding label, too. -->
## BUGFIX

### Description:
<!-- Please describe what this PR is about. -->

This applies some updates to the `WfsSearch` component:
  * Fix prop validation for `attributeDetails`.
  * Don't override component's `onChange` prop.
  * Don't use `optionLabelProp`, introduce `displayValue` instead.
  * Update the default `renderOption`function to include the newly introduced `displayValue` prop.
  * Fix async test to return a `Promise`.

<!--- CHECKLIST
Fixes Issue?
Examples added?
Tests added?
Docs added?
Would a screenshot be helpful?
Do you want to mention someone?
-->
