### PR TITLE
Add getPathByKeyValue to ObjectUtil

### DIFF
--- a/src/Util/ObjectUtil/ObjectUtil.js
+++ b/src/Util/ObjectUtil/ObjectUtil.js
@@ -12,6 +12,43 @@ import Logger from '../Logger';
 class ObjectUtil {
 
   /**
+   * Returns the dot delimited path of a given object by the given
+   * key-value pair. Example:
+   *
+   * ```
+   * const obj = {
+   *   level: 'first',
+   *   nested: {
+   *     level: 'second'
+   *   }
+   * };
+   * const key = 'level';
+   * const value = 'second';
+   *
+   * ObjectUtil.getPathByKeyValue(obj, key, value); // 'nested.level'
+   * ```
+   *
+   * Note: It will return the first available match!
+   *
+   * @param {Object} obj The object to obtain the path from.
+   * @param {String} key The key to look for.
+   * @param {String|Number|Boolean} value The value to look for.
+   * @param {String} [currentPath=''] The currentPath (if called in a recursion)
+   *                                  or the custom root path (default is to '').
+   */
+  static getPathByKeyValue(obj, key, value, currentPath = '') {
+    currentPath = currentPath ? `${currentPath}.` : currentPath;
+
+    for (let k in obj) {
+      if (k === key && obj[k] === value) {
+        return `${currentPath}${k}`;
+      } else if (typeof obj[k] === 'object') {
+        return ObjectUtil.getPathByKeyValue(obj[k], key, value, `${currentPath}${k}`);
+      }
+    }
+  }
+
+  /**
    * Method may be used to return a value of a given input object by a
    * provided query key. The query key can be used in two ways:
    *   * Single-value: Find the first matching key in the provided object

--- a/src/Util/ObjectUtil/ObjectUtil.spec.js
+++ b/src/Util/ObjectUtil/ObjectUtil.spec.js
@@ -1,6 +1,5 @@
 /*eslint-env jest*/
 
-
 import {
   ObjectUtil,
 } from '../../index';
@@ -8,6 +7,55 @@ import {
 describe('ObjectUtil', () => {
   it('is defined', () => {
     expect(ObjectUtil).not.toBeUndefined();
+  });
+
+  describe('#getPathByKeyValue', () => {
+    it('is defined', () => {
+      expect(ObjectUtil.getPathByKeyValue).toBeDefined();
+    });
+
+    it('returns the path of an object by the given key-value pair', () => {
+      const obj = {
+        level: 'first',
+        firstLevel: true,
+        levelNumber: 1,
+        firstNested: {
+          level: 'second',
+          secondLevel: true,
+          levelNumber: 2,
+          deeper: {
+            evenDeeper: {
+              deepest: 'you could go deeper of course'
+            }
+          }
+        }
+      };
+
+      // Check for primitive data types.
+      let res = ObjectUtil.getPathByKeyValue(obj, 'level', 'first');
+      expect(res).toBe('level');
+
+      res = ObjectUtil.getPathByKeyValue(obj, 'firstLevel', true);
+      expect(res).toBe('firstLevel');
+
+      res = ObjectUtil.getPathByKeyValue(obj, 'levelNumber', 1);
+      expect(res).toBe('levelNumber');
+
+      // Check for nested key-value.
+      res = ObjectUtil.getPathByKeyValue(obj, 'level', 'second');
+      expect(res).toBe('firstNested.level');
+
+      res = ObjectUtil.getPathByKeyValue(obj, 'deepest', 'you could go deeper of course');
+      expect(res).toBe('firstNested.deeper.evenDeeper.deepest');
+
+      // Returns undefined if not found.
+      res = ObjectUtil.getPathByKeyValue(obj, 'marco', 'polo');
+      expect(res).toBeUndefined();
+
+      // Appends the given root path if given.
+      res = ObjectUtil.getPathByKeyValue(obj, 'level', 'second', 'myroot');
+      expect(res).toBe('myroot.firstNested.level');
+    });
   });
 
   describe('getValue', () => {


### PR DESCRIPTION
<!-- Please choose one of the categories and choose the corresponding label, too. -->
## FEATURE

### Description:
<!-- Please describe what this PR is about. -->
This adds the `getPathByKeyValue` method to the `ObjectUtil`, that may be used to returns the dot delimited path of a given object by the given key-value pair.

<!--- CHECKLIST
Fixes Issue?
Examples added?
Tests added?
Docs added?
Would a screenshot be helpful?
Do you want to mention someone?
-->
