### PR TITLE
Fix getPathByKeyValue to check for plain objects in recursion

### DIFF
--- a/src/Util/ObjectUtil/ObjectUtil.js
+++ b/src/Util/ObjectUtil/ObjectUtil.js
@@ -1,4 +1,5 @@
 import isObject from 'lodash/isObject.js';
+import isPlainObject from 'lodash/isPlainObject.js';
 import isString from 'lodash/isString.js';
 import isArray from 'lodash/isArray.js';
 import Logger from '../Logger';
@@ -42,8 +43,13 @@ class ObjectUtil {
     for (let k in obj) {
       if (k === key && obj[k] === value) {
         return `${currentPath}${k}`;
-      } else if (typeof obj[k] === 'object') {
-        return ObjectUtil.getPathByKeyValue(obj[k], key, value, `${currentPath}${k}`);
+      } else if (isPlainObject(obj[k])) {
+        const path = ObjectUtil.getPathByKeyValue(obj[k], key, value, `${currentPath}${k}`);
+        if (path) {
+          return path;
+        } else {
+          continue;
+        }
       }
     }
   }

--- a/src/Util/ObjectUtil/ObjectUtil.spec.js
+++ b/src/Util/ObjectUtil/ObjectUtil.spec.js
@@ -19,13 +19,23 @@ describe('ObjectUtil', () => {
         level: 'first',
         firstLevel: true,
         levelNumber: 1,
+        isNull: null,
+        isObject: {},
+        isArray: [],
         firstNested: {
           level: 'second',
           secondLevel: true,
           levelNumber: 2,
+          isObject: {
+            notOfInterestKey: true,
+            anotherKey: 'here'
+          },
+          isArray: [],
           deeper: {
             evenDeeper: {
-              deepest: 'you could go deeper of course'
+              isObject: {},
+              deepest: 'you could go deeper of course',
+              isAnotherObject: {}
             }
           }
         }
@@ -40,6 +50,9 @@ describe('ObjectUtil', () => {
 
       res = ObjectUtil.getPathByKeyValue(obj, 'levelNumber', 1);
       expect(res).toBe('levelNumber');
+
+      res = ObjectUtil.getPathByKeyValue(obj, 'isNull', null);
+      expect(res).toBe('isNull');
 
       // Check for nested key-value.
       res = ObjectUtil.getPathByKeyValue(obj, 'level', 'second');


### PR DESCRIPTION
<!-- Please choose one of the categories and choose the corresponding label, too. -->
## BUGFIX

### Description:
This fixes the newly introduced `getPathByKeyValue()` to only start the recursion if the given key is a plain object. It also updates the tests.

<!--- CHECKLIST
Fixes Issue?
Examples added?
Tests added?
Docs added?
Would a screenshot be helpful?
Do you want to mention someone?
-->
