### PR TITLE
Introduces convertMarks method

### DIFF
--- a/src/Slider/TimeSlider.jsx
+++ b/src/Slider/TimeSlider.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import moment from 'moment';
 import isArray from 'lodash/isArray.js';
+import isObject from 'lodash/isObject.js';
 
 import { Slider } from 'antd';
 
@@ -43,6 +44,12 @@ class TimeSlider extends React.Component {
      * @type {String}
      */
     max: PropTypes.string,
+
+    /**
+     * Tick mark of Slider, type of key must be TimeStamp ISOString, and must in
+     * closed interval min, max，each mark can declare its own style.
+     */
+    marks: PropTypes.object,
 
     /**
      * Called when the value changes.
@@ -112,6 +119,24 @@ class TimeSlider extends React.Component {
   }
 
   /**
+   * Convert the keys of mark values to unix timestamps.
+   *
+   * @param {Object} marks The marks prop.
+   * @return {Object} The marks prop with converted keys.
+   */
+  convertMarks(marks) {
+    let convertedMarks;
+    if (isObject(marks)) {
+      convertedMarks = {};
+      Object.keys(marks).forEach(key => {
+        const convertedKey = this.convert(key);
+        convertedMarks[convertedKey] = marks[key];
+      });
+    }
+    return convertedMarks;
+  }
+
+  /**
    * Formats a timestamp for user display.
    * @param  {Number} unix unix timestamps
    * @return {String}      the formatted timestamps
@@ -136,16 +161,37 @@ class TimeSlider extends React.Component {
    * The render function.
    */
   render() {
+    const {
+      className,
+      defaultValue,
+      formatString,
+      min,
+      max,
+      value,
+      marks,
+      onChange,
+      useRange,
+      ...passThroughProps
+    } = this.props;
+
+    const finalClassName = className
+      ? `${className} ${this.className}`
+      : this.className;
+
+    const convertedMarks = this.convertMarks(marks);
+
     return (
       <Slider
-        className={this.props.className}
-        defaultValue={this.convert(this.props.defaultValue)}
-        range={this.props.useRange}
-        min={moment(this.props.min).unix()}
-        max={moment(this.props.max).unix()}
+        className={finalClassName}
+        defaultValue={this.convert(defaultValue)}
+        range={useRange}
+        min={moment(min).unix()}
+        max={moment(max).unix()}
         tipFormatter={this.formatTimestamp.bind(this)}
         onChange={this.valueUpdated.bind(this)}
-        value={this.convert(this.props.value)}
+        value={this.convert(value)}
+        marks={convertedMarks}
+        {...passThroughProps}
       />
     );
   }

--- a/src/Slider/TimeSlider.spec.jsx
+++ b/src/Slider/TimeSlider.spec.jsx
@@ -62,6 +62,28 @@ describe('<TimeSlider />', () => {
     expect(got2).toEqual(expected2);
   });
 
+  describe('convertMarks', () => {
+    it('converts the Keys of the marks prop', () => {
+      const format = 'YYYY-MM-DD hh:mm:ss';
+      const val1 = moment('2000-01-01 12:00:00', format);
+      const val2 = moment('2001-01-01 12:00:00', format);
+      const marks = {};
+      marks[val1] = val1;
+      marks[val2] = val2;
+
+      const expected1 = val1.unix();
+      const expected2 = val2.unix();
+
+      const slider = TestUtil.mountComponent(TimeSlider, {}).instance();
+      const gotMarks = slider.convertMarks(marks);
+      const gotKeys = Object.keys(gotMarks);
+
+      expect(gotKeys).toEqual(expect.arrayContaining([expected1.toString(), expected2.toString()]));
+      expect(gotMarks[expected1]).toEqual(val1);
+      expect(gotMarks[expected2]).toEqual(val2);
+    });
+  });
+
   it('#formatTimestamp', () => {
     const format = 'YYYY-MM-DD hh:mm:ss';
     const formatted = '2000-01-01 12:00:00';


### PR DESCRIPTION
<!-- Please choose one of the categories and choose the corresponding label, too. -->
## FEATURE

### Description:
<!-- Please describe what this PR is about. -->
This introduces the `convertMarks` method to the `TimeSlider`.
It is needed to support the `marks` property of the antd `Slider`.


<!--- CHECKLIST
Fixes Issue?
Examples added?
Tests added?
Docs added?
Would a screenshot be helpful?
Do you want to mention someone?
-->
