### PR TITLE
Fixes the LayerTree rerendering on layerGroup update

### DIFF
--- a/src/LayerTree/LayerTree.jsx
+++ b/src/LayerTree/LayerTree.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import isBoolean from 'lodash/isBoolean.js';
 import isFunction from 'lodash/isFunction.js';
-import isEqual from 'lodash/isEqual.js';       
+import isEqual from 'lodash/isEqual.js';
 import { Tree } from 'antd';
 import OlMap from 'ol/map';
 import OlLayerBase from 'ol/layer/base';
@@ -162,6 +162,9 @@ class LayerTree extends React.Component {
         this.olListenerKeys = [];
 
         this.registerAddRemoveListeners(layerGroup);
+        this.rebuildTreeNodes();
+      }
+      else if (!isEqual(prevState.layerGroupRevision, layerGroup.getRevision())) {
         this.rebuildTreeNodes();
       }
     }

--- a/src/LayerTree/LayerTree.spec.jsx
+++ b/src/LayerTree/LayerTree.spec.jsx
@@ -380,7 +380,7 @@ describe('<LayerTree />', () => {
       const unregisterSpy = jest.spyOn(wrapper.instance(), 'unregisterEventsByLayer');
 
       layerGroup.getLayers().remove(nestedLayerGroup);
-      expect(rebuildSpy).toHaveBeenCalledTimes(1);
+      expect(rebuildSpy).toHaveBeenCalledTimes(2);
       expect(unregisterSpy).toHaveBeenCalledTimes(3);
 
       rebuildSpy.mockReset();


### PR DESCRIPTION
<!-- Please choose one of the categories and choose the corresponding label, too. -->
## BUGFIX

### Description:
<!-- Please describe what this PR is about. -->
This PR makes sure that the `LayerTree` component rerenderes when the layers in the the `layerGroup` property have changed. 
<!--- CHECKLIST
Fixes Issue?
Examples added?
Tests added?
Docs added?
Would a screenshot be helpful?
Do you want to mention someone?
-->
@terrestris/devs  please review.
