### PR TITLE
Fixup ToggleGroup and Buttons

### DIFF
--- a/src/Button/ToggleButton/ToggleButton.jsx
+++ b/src/Button/ToggleButton/ToggleButton.jsx
@@ -105,6 +105,18 @@ class ToggleButton extends React.Component {
   }
 
   /**
+   * We will handle the initial state of the button here.
+   * If it is pressed, we will have to call its `onToggle`
+   * method, if it exists, in order to reflect the initial
+   * state correctly (e.g. activating ol.Controls)
+   */
+  componentDidMount() {
+    if (this.props.onToggle && this.props.pressed === true) {
+      this.props.onToggle(true, null);
+    }
+  }
+
+  /**
    * Invoked immediately after updating occurs. This method is not called 
    * for the initial render.
    * @method

--- a/src/Button/ToggleGroup/ToggleGroup.jsx
+++ b/src/Button/ToggleGroup/ToggleGroup.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import isFunction from 'lodash/isFunction.js';
+import isUndefined from 'lodash/isUndefined.js';
 
 import { CSS_PREFIX } from '../../constants';
 
@@ -158,8 +159,16 @@ class ToggleGroup extends React.Component {
       : 'horizontal-toggle-group';
     const childrenWithProps = React.Children.map(children, (child) => {
       // pass the press state through to child components
+      // if a pressed prop is given, it has priority over
+      // the selectedName
+      let pressed = false;
+      if (!isUndefined(child.props.pressed)) {
+        pressed = child.props.pressed;
+      } else {
+        pressed = this.state.selectedName === child.props.name;
+      }
       return React.cloneElement(child, {
-        pressed: this.state.selectedName === child.props.name
+        pressed: pressed
       });
     });
 


### PR DESCRIPTION
<!-- Please choose one of the categories and choose the corresponding label, too. -->
## BUGFIX 

### Description:
This fixes 2 things:
1.) The initial behaviour of a ToggleButton, when it was given a prop `pressed=true` was not handled correctly. We now call the belonging `onToggle` method to correctly initialize the button

2.) The `pressed` property of a ToggleButton now gets passed through, if it exists
