### PR TITLE
Adds extra check for WfsSeach Component 

### DIFF
--- a/src/Field/WfsSearch/WfsSearch.jsx
+++ b/src/Field/WfsSearch/WfsSearch.jsx
@@ -368,25 +368,29 @@ export class WfsSearch extends React.Component {
 
     const request = this.getCombinedRequests();
     const fetchTime = new Date();
+    if (request) {
+      this.timeoutHandle = setTimeout(() => {
+        this.setState({
+          fetching: true,
+          latestRequestTime: fetchTime.getTime()
+        }, () => {
+          fetch(`${baseUrl}`, {
+            method: 'POST',
+            credentials: additionalFetchOptions.credentials
+              ? additionalFetchOptions.credentials
+              : 'same-origin',
+            body: new XMLSerializer().serializeToString(request),
+            ...additionalFetchOptions
+          })
+            .then(response => response.json())
+            .then(this.onFetchSuccess.bind(this, fetchTime.getTime()))
+            .catch(this.onFetchError.bind(this));
+        });
+      }, this.props.delay);
+    } else {
+      this.onFetchError('Missing GetFeature request parameters');
+    }
 
-    this.timeoutHandle = setTimeout(() => {
-      this.setState({
-        fetching: true,
-        latestRequestTime: fetchTime.getTime()
-      }, () => {
-        fetch(`${baseUrl}`, {
-          method: 'POST',
-          credentials: additionalFetchOptions.credentials
-            ? additionalFetchOptions.credentials
-            : 'same-origin',
-          body: new XMLSerializer().serializeToString(request),
-          ...additionalFetchOptions
-        })
-          .then(response => response.json())
-          .then(this.onFetchSuccess.bind(this, fetchTime.getTime()))
-          .catch(this.onFetchError.bind(this));
-      });
-    }, this.props.delay);
   }
 
   /**


### PR DESCRIPTION
<!-- Please choose one of the categories and choose the corresponding label, too. -->
## BUGFIX 
This prevents the crash of the `WfsSeach` component when no request parameters exists. 
When an empty array is passed to the `featureType` property of the `WfsSeach` component it will cause it to crash since the request will be undefined and can not be stringified.
### Description:
<!-- Please describe what this PR is about. -->
 @terrestris/devs please review.