### PR TITLE
[ToggleGroup] Revert pressed prop priority handling

### DIFF
--- a/src/Button/ToggleGroup/ToggleGroup.jsx
+++ b/src/Button/ToggleGroup/ToggleGroup.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import isFunction from 'lodash/isFunction.js';
-import isUndefined from 'lodash/isUndefined.js';
 
 import { CSS_PREFIX } from '../../constants';
 
@@ -128,7 +127,7 @@ class ToggleGroup extends React.Component {
       }
     };
   }
-  
+
   /**
    * The onChange handler.
    *
@@ -157,18 +156,11 @@ class ToggleGroup extends React.Component {
     const orientationClass = (orientation === 'vertical')
       ? 'vertical-toggle-group'
       : 'horizontal-toggle-group';
+
     const childrenWithProps = React.Children.map(children, (child) => {
       // pass the press state through to child components
-      // if a pressed prop is given, it has priority over
-      // the selectedName
-      let pressed = false;
-      if (!isUndefined(child.props.pressed)) {
-        pressed = child.props.pressed;
-      } else {
-        pressed = this.state.selectedName === child.props.name;
-      }
       return React.cloneElement(child, {
-        pressed: pressed
+        pressed: this.state.selectedName === child.props.name
       });
     });
 


### PR DESCRIPTION
<!-- Please choose one of the categories and choose the corresponding label, too. -->
## BUGFIX

### Description:
<!-- Please describe what this PR is about. -->
This fixes the `ToggleGroup` (what a classy).

For clarification:
The pressed-state of a `ToggleButton` is determined by its `pressed` prop. Which is `false` per default.
The current concept of the `ToggleGroup` is to set this via the `selectedName` which matches the `name` property of a `ToggleButton`.
  ->> As this concept doesn't seem to be very intuitive we should change it.

So the old line 165 was always true and the `ToggleButtons` never changed their state… Compare broken example.

<!--- CHECKLIST
Fixes Issue?
Examples added?
Tests added?
Docs added?
Would a screenshot be helpful?
Do you want to mention someone?
-->
