### PR TITLE
Set style function with current draw style if pressed

### DIFF
--- a/src/Button/DigitizeButton/DigitizeButton.jsx
+++ b/src/Button/DigitizeButton/DigitizeButton.jsx
@@ -470,7 +470,8 @@ class DigitizeButton extends React.Component {
     const {
       map,
       drawType,
-      editType
+      editType,
+      drawStyle
     } = this.props;
 
     const {
@@ -481,6 +482,9 @@ class DigitizeButton extends React.Component {
     this._digitizeFeatures = digitizeLayer.getSource().getFeaturesCollection();
 
     if (pressed) {
+      if (drawStyle) {
+        digitizeLayer.setStyle(this.getDigitizeStyleFunction);
+      }
       if (drawType) {
         this.createDrawInteraction(pressed);
       } else if (editType) {


### PR DESCRIPTION
<!-- Please choose one of the categories and choose the corresponding label, too. -->
## FEATURE

### Description:
<!-- Please describe what this PR is about. -->
By this PR, the `getDigitizeStyleFunction` function will be applied to the `digitizeLayer` of the `DigitizeButton` is toggled. Herewith, the current set `drawStyle` is always used to draw vector features.

<!--- CHECKLIST
Fixes Issue?
Examples added?
Tests added?
Docs added?
Would a screenshot be helpful?
Do you want to mention someone?
-->

Plz review
