### PR TITLE
Add tooltipProps prop to pass any valid antd tooltip prop

### DIFF
--- a/src/Button/SimpleButton/SimpleButton.jsx
+++ b/src/Button/SimpleButton/SimpleButton.jsx
@@ -60,7 +60,15 @@ class SimpleButton extends React.Component {
       'leftBottom',
       'rightTop',
       'rightBottom'
-    ])
+    ]),
+    /**
+     * Additional [antd tooltip](https://ant.design/components/tooltip/)
+     * properties to pass to the tooltip component. Note: The props `title`
+     * and `placement` will override the props `tooltip` and `tooltipPlacement`
+     * of this component!
+     * @type {Object}
+     */
+    tooltipProps: PropTypes.object
   };
 
   /**
@@ -68,7 +76,10 @@ class SimpleButton extends React.Component {
    * @type {Object}
    */
   static defaultProps = {
-    type: 'primary'
+    type: 'primary',
+    tooltipProps: {
+      mouseEnterDelay: 1.5
+    }
   }
 
   /**
@@ -90,6 +101,7 @@ class SimpleButton extends React.Component {
       fontIcon,
       tooltip,
       tooltipPlacement,
+      tooltipProps,
       ...antBtnProps
     } = this.props;
 
@@ -101,6 +113,7 @@ class SimpleButton extends React.Component {
       <Tooltip
         title={tooltip}
         placement={tooltipPlacement}
+        {...tooltipProps}
       >
         <Button
           className={finalClassName}

--- a/src/Button/ToggleButton/ToggleButton.jsx
+++ b/src/Button/ToggleButton/ToggleButton.jsx
@@ -45,6 +45,14 @@ class ToggleButton extends React.Component {
     onToggle: PropTypes.func,
     tooltip: PropTypes.string,
     tooltipPlacement: PropTypes.string,
+    /**
+     * Additional [antd tooltip](https://ant.design/components/tooltip/)
+     * properties to pass to the tooltip component. Note: The props `title`
+     * and `placement` will override the props `tooltip` and `tooltipPlacement`
+     * of this component!
+     * @type {Object}
+     */
+    tooltipProps: PropTypes.object,
     className: PropTypes.string
   };
 
@@ -55,7 +63,10 @@ class ToggleButton extends React.Component {
   static defaultProps = {
     type: 'primary',
     icon: '',
-    pressed: false
+    pressed: false,
+    tooltipProps: {
+      mouseEnterDelay: 1.5
+    }
   }
 
   /**
@@ -117,7 +128,7 @@ class ToggleButton extends React.Component {
   }
 
   /**
-   * Invoked immediately after updating occurs. This method is not called 
+   * Invoked immediately after updating occurs. This method is not called
    * for the initial render.
    * @method
    */
@@ -207,6 +218,7 @@ class ToggleButton extends React.Component {
       onToggle,
       tooltip,
       tooltipPlacement,
+      tooltipProps,
       ...antBtnProps
     } = this.props;
 
@@ -229,6 +241,7 @@ class ToggleButton extends React.Component {
       <Tooltip
         title={tooltip}
         placement={tooltipPlacement}
+        {...tooltipProps}
       >
         <Button
           className={`${finalClassName}${pressedClass}`}


### PR DESCRIPTION
<!-- Please choose one of the categories and choose the corresponding label, too. -->
## FEATURE

### Description:
<!-- Please describe what this PR is about. -->
This adds the prop `tooltipProps` to the button base classes, that can be used to pass [any valid](https://ant.design/components/tooltip/) `Tooltip` props to them.

<!--- CHECKLIST
Fixes Issue?
Examples added?
Tests added?
Docs added?
Would a screenshot be helpful?
Do you want to mention someone?
-->
