### PR TITLE
Set testURL in jest config

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,5 @@
 module.exports = {
+  testURL: 'http://localhost/',
   moduleFileExtensions: [
     'js',
     'jsx'


### PR DESCRIPTION
<!-- Please choose one of the categories and choose the corresponding label, too. -->
## DEVSETUP

### Description:
This sets the `testURL` in the jest config to a non-default value to prevent the error
```
SecurityError: localStorage is not available for opaque origins
```
See facebook/jest#6766.

<!--- CHECKLIST
Fixes Issue?
Examples added?
Tests added?
Docs added?
Would a screenshot be helpful?
Do you want to mention someone?
-->
