### PR TITLE
Allow passing `columnDefs` and `rowData` to `AgFeatureGrid` component as arrays

### DIFF
--- a/src/Grid/AgFeatureGrid/AgFeatureGrid.jsx
+++ b/src/Grid/AgFeatureGrid/AgFeatureGrid.jsx
@@ -19,6 +19,8 @@ import OlGeomGeometryCollection from 'ol/geom/geometrycollection';
 import { MapUtil } from '../../index';
 import { CSS_PREFIX } from '../../constants';
 
+import isArray from 'lodash/isArray.js';
+
 import 'ag-grid/dist/styles/ag-grid.css';
 import 'ag-grid/dist/styles/ag-theme-balham.css';
 
@@ -211,9 +213,22 @@ export class AgFeatureGrid extends React.Component {
      * See https://ant.design/components/table/#Column. You can either specify
      * an index property on every column definition to get an exact order, or
      * get a somewhat random order by not specifying an index property at all.
-     * @type {Object}
+     * If provided as array, #getColumnDefs won't be called.
+     * @type {Object|Array}
      */
-    columnDefs: PropTypes.object,
+    columnDefs: PropTypes.oneOfType([
+      PropTypes.object,
+      PropTypes.arrayOf(PropTypes.object)
+    ]),
+
+    /**
+     * Custom row data to be shown in feature grid. This might be helpful if
+     * original feature properties should be manipulated in some way before they
+     * are represented in grid.
+     * If provided, #getRowData method won't be called.
+     * @type {Array}
+     */
+    rowData: PropTypes.arrayOf(PropTypes.object),
 
     /**
      * The children to render.
@@ -1003,6 +1018,7 @@ export class AgFeatureGrid extends React.Component {
       layerName,
       columnDefs,
       children,
+      rowData,
       ...passThroughProps
     } = this.props;
 
@@ -1034,8 +1050,8 @@ export class AgFeatureGrid extends React.Component {
         }}
       >
         <AgGridReact
-          columnDefs={this.getColumnDefs()}
-          rowData={this.getRowData()}
+          columnDefs={columnDefs && isArray(columnDefs) ? columnDefs : this.getColumnDefs()}
+          rowData={rowData && isArray(rowData) ? rowData : this.getRowData()}
           onGridReady={this.onGridReady.bind(this)}
           rowSelection='multiple'
           suppressRowClickSelection={true}

--- a/src/Grid/AgFeatureGrid/AgFeatureGrid.jsx
+++ b/src/Grid/AgFeatureGrid/AgFeatureGrid.jsx
@@ -23,6 +23,7 @@ import isArray from 'lodash/isArray.js';
 
 import 'ag-grid/dist/styles/ag-grid.css';
 import 'ag-grid/dist/styles/ag-theme-balham.css';
+import 'ag-grid/dist/styles/ag-theme-fresh.css';
 
 /**
  * The AgFeatureGrid.


### PR DESCRIPTION
<!-- Please choose one of the categories and choose the corresponding label, too. -->
## FEATURE

### Description:
Allow user to pass `columnDefs` and `rowData` properties as arrays (like they are expected by `AgGridReact` which `AgFeatureGrid` inherits).

This can be useful to manipulate feature's properties before these will be shown in grid (e.g. represent each feature property in one new row) like this:

![image](https://user-images.githubusercontent.com/3939355/43958664-7c81d288-9cac-11e8-95df-bf283236f746.png)

Additionally `ag-theme-fresh` theme from `ag-grid` was imported.

Please review @terrestris/devs 
