### PR TITLE
Add onToggle as prop for DigitizeButton and MeasureButton

### DIFF
--- a/src/Button/DigitizeButton/DigitizeButton.jsx
+++ b/src/Button/DigitizeButton/DigitizeButton.jsx
@@ -393,7 +393,15 @@ class DigitizeButton extends React.Component {
      * Note: The key feature is handled internally and shouldn't be overwritten
      *       without any specific cause.
      */
-    translateInteractionConfig: PropTypes.object
+    translateInteractionConfig: PropTypes.object,
+
+    /**
+     * A custom onToogle function that will be called
+     * if button is toggled
+     *
+     * @type {Function} onToggle
+     */
+    onToggle: PropTypes.func
   };
 
   /**
@@ -410,7 +418,8 @@ class DigitizeButton extends React.Component {
     drawInteractionConfig: {},
     selectInteractionConfig: {},
     modifyInteractionConfig: {},
-    translateInteractionConfig: {}
+    translateInteractionConfig: {},
+    onToggle: () => {}
   }
 
   /**
@@ -419,7 +428,6 @@ class DigitizeButton extends React.Component {
    * @constructs DigitizeButton
    */
   constructor(props) {
-
     super(props);
 
     if (!this.props.drawType && !this.props.editType) {
@@ -478,6 +486,8 @@ class DigitizeButton extends React.Component {
       digitizeLayer,
       interactions
     } = this.state;
+
+    this.props.onToggle(pressed);
 
     this._digitizeFeatures = digitizeLayer.getSource().getFeaturesCollection();
 
@@ -1031,6 +1041,7 @@ class DigitizeButton extends React.Component {
       selectInteractionConfig,
       modifyInteractionConfig,
       translateInteractionConfig,
+      onToggle,
       ...passThroughProps
     } = this.props;
 

--- a/src/Button/DigitizeButton/DigitizeButton.spec.jsx
+++ b/src/Button/DigitizeButton/DigitizeButton.spec.jsx
@@ -128,6 +128,18 @@ describe('<DigitizeButton />', () => {
   describe('#Private methods', () => {
 
     describe('#onToggle', () => {
+      it('calls passed onToggle in props it was provided', () => {
+        expect.assertions(1);
+        const wrapper = setupWrapper();
+        const onToggle = jest.fn();
+
+        wrapper.setProps({
+          onToggle
+        }, () => {
+          wrapper.instance().onToggle(true);
+          expect(onToggle).toHaveBeenCalledTimes(1);
+        });
+      });
 
       it ('calls a createDrawInteraction method if button was pressed and valid drawType was provided', () => {
         const wrapper = setupWrapper();

--- a/src/Button/MeasureButton/MeasureButton.jsx
+++ b/src/Button/MeasureButton/MeasureButton.jsx
@@ -250,7 +250,15 @@ class MeasureButton extends React.Component {
      *
      * @type {Boolean} pressed
      */
-    pressed: PropTypes.bool
+    pressed: PropTypes.bool,
+
+    /**
+     * A custom onToogle function that will be called
+     * if button is toggled
+     *
+     * @type {Function} onToggle
+     */
+    onToggle: PropTypes.func
   };
 
   /**
@@ -274,7 +282,8 @@ class MeasureButton extends React.Component {
       tooltipDynamic: `${CSS_PREFIX}measure-tooltip-dynamic`,
       tooltipStatic: `${CSS_PREFIX}measure-tooltip-static`
     },
-    pressed: false
+    pressed: false,
+    onToggle: () => {}
   }
 
   /**
@@ -310,6 +319,8 @@ class MeasureButton extends React.Component {
    */
   onToggle = (pressed) => {
     this.cleanup();
+
+    this.props.onToggle(pressed);
 
     if (pressed && this.state.drawInteraction) {
       this.state.drawInteraction.setActive(pressed);
@@ -781,6 +792,7 @@ class MeasureButton extends React.Component {
       continueAngleMsg,
       decimalPlacesInTooltips,
       measureTooltipCssClasses,
+      onToggle,
       ...passThroughProps
     } = this.props;
 

--- a/src/Button/MeasureButton/MeasureButton.spec.jsx
+++ b/src/Button/MeasureButton/MeasureButton.spec.jsx
@@ -119,7 +119,7 @@ describe('<MeasureButton />', () => {
         const props = {
           map: map,
           measureType: 'line',
-          onToggle: onToggle
+          onToggle
         };
 
         const wrapper = TestUtil.mountComponent(MeasureButton, props);


### PR DESCRIPTION
<!-- Please choose one of the categories and choose the corresponding label, too. -->
## FEATURE 

### Description:
<!-- Please describe what this PR is about. -->
This PR adds a further props `onToogle` as function that will be called in the private `onToggle` of `DigitizeButton` and `MeasureButton`

<!--- CHECKLIST
Fixes Issue?
Examples added?
Tests added?
Docs added?
Would a screenshot be helpful?
Do you want to mention someone?
-->
