### PR TITLE
Div panel fixes

### DIFF
--- a/src/Panel/Panel/Panel.jsx
+++ b/src/Panel/Panel/Panel.jsx
@@ -364,15 +364,24 @@ export class Panel extends React.Component {
       {title}
     </Titlebar> : null;
 
+    const defWidth = this.state.width;
+    const defHeight = this.calculateHeight();
+    const {
+      x,
+      y
+    } = rndOpts;
+    const defX = x && isNumber(x) ? x : window.innerWidth / 2 - defWidth / 2;
+    const defY = y && isNumber(y) ? y : window.innerHeight / 2 - defHeight / 2;
+
     return (
       <Rnd
         className={rndClassName}
         ref={rnd => this.rnd = rnd}
         default={{
-          x: isNumber(rndOpts.x) ? rndOpts.x : (window.innerWidth / 2) - 160,
-          y: isNumber(rndOpts.y) ? rndOpts.y : (window.innerHeight / 2) - 100,
-          width: this.state.width,
-          height: this.calculateHeight()
+          x: defX,
+          y: defY,
+          width: defWidth,
+          height: defHeight
         }}
         dragHandleClassName="drag-handle"
         disableDragging={!draggable}

--- a/src/Panel/Panel/Panel.jsx
+++ b/src/Panel/Panel/Panel.jsx
@@ -4,7 +4,6 @@ import Rnd from 'react-rnd';
 import uniqueId from 'lodash/uniqueId.js';
 import isNumber from 'lodash/isNumber.js';
 import isFunction from 'lodash/isFunction.js';
-import cloneDeep from 'lodash/cloneDeep.js';
 
 import Titlebar from '../Titlebar/Titlebar.jsx';
 import SimpleButton from '../../Button/SimpleButton/SimpleButton.jsx';
@@ -331,7 +330,7 @@ export class Panel extends React.Component {
       ...rndOpts
     } = this.props;
 
-    let toolsClone = cloneDeep(tools);
+    let toolsClone = tools.map(t => React.cloneElement(t));
 
     const finalClassName = className
       ? `${className} ${this.className}`

--- a/src/Window/Window.example.md
+++ b/src/Window/Window.example.md
@@ -54,6 +54,8 @@ class WindowExample extends React.Component {
               title="This is the window title"
               width={300}
               height={150}
+              x={(window.innerWidth / 2 - 150) / 2}
+              y={(window.innerHeight / 2 - 75) / 2}
               style={{
                 position: 'fixed',
                 boxShadow: '5px 5px 5px 0px #888888'
@@ -80,6 +82,8 @@ class WindowExample extends React.Component {
               onEscape={this.onClickEsc.bind(this)}
               width={300}
               height={150}
+              x={(window.innerWidth / 2 - 150) / 2}
+              y={(window.innerHeight / 2 - 75) / 2}
               style={{
                 position: 'fixed',
                 boxShadow: '5px 5px 5px 0px #888888'


### PR DESCRIPTION
<!-- Please choose one of the categories and choose the corresponding label, too. -->
## BUGFIX
Follow up of #804.

### Description:
Fixes bug with cloning of `tools` prop introduced in #804:
`cloneDeep` method of `lodash` library seems to not work properly with cloning of react nodes, so an alternative solution by using of `React.cloneElement()` method was prefered.

Additionally got rid of some hard coded values by computing of default panel position and fixed wrong positioned windows in examples.

BTW, determination of default panel/window position seems to be buggy since last major update of `rnd` package, so fixing of window examples should be temporary solution only --> s. #812 

Please review @terrestris/devs 