### PR TITLE
make LayerTree update when prop nodeTitleRenderer has changed

### DIFF
--- a/src/LayerTree/LayerTree.jsx
+++ b/src/LayerTree/LayerTree.jsx
@@ -168,7 +168,7 @@ class LayerTree extends React.Component {
       }
     }
 
-    if (nodeTitleRenderer != prevProps.nodeTitleRenderer){
+    if (nodeTitleRenderer !== prevProps.nodeTitleRenderer){
       this.rebuildTreeNodes();
     }
   }

--- a/src/LayerTree/LayerTree.jsx
+++ b/src/LayerTree/LayerTree.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import isBoolean from 'lodash/isBoolean.js';
 import isFunction from 'lodash/isFunction.js';
-import isEqual from 'lodash/isEqual.js';       
+import isEqual from 'lodash/isEqual.js';
 import { Tree } from 'antd';
 import OlMap from 'ol/map';
 import OlLayerBase from 'ol/layer/base';
@@ -154,7 +154,8 @@ class LayerTree extends React.Component {
    */
   componentDidUpdate(prevProps, prevState) {
     const {
-      layerGroup
+      layerGroup,
+      nodeTitleRenderer
     } = this.props;
 
     if (layerGroup && prevState.layerGroup) {
@@ -165,6 +166,10 @@ class LayerTree extends React.Component {
         this.registerAddRemoveListeners(layerGroup);
         this.rebuildTreeNodes();
       }
+    }
+
+    if (nodeTitleRenderer != prevProps.nodeTitleRenderer){
+      this.rebuildTreeNodes();
     }
   }
 

--- a/src/LayerTree/LayerTree.spec.jsx
+++ b/src/LayerTree/LayerTree.spec.jsx
@@ -312,6 +312,32 @@ describe('<LayerTree />', () => {
       expect(treeNode.props().checked).toBe(true);
     });
 
+    it('triggers tree rebuild on nodeTitleRenderer changes', () => {
+      const nodeTitleRenderer = function(layer) {
+        return (
+          <span className="span-1">
+            {layer.get('name')}
+          </span>
+        );
+      };
+
+      const props = {
+        layerGroup,
+        map,
+        nodeTitleRenderer
+      };
+      const wrapper = TestUtil.mountComponent(LayerTree, props);
+
+      const rebuildSpy = jest.spyOn(wrapper.instance(), 'rebuildTreeNodes');
+      wrapper.setProps({
+        nodeTitleRenderer: null
+      });
+      expect(rebuildSpy).toHaveBeenCalledTimes(1);
+
+      rebuildSpy.mockReset();
+      rebuildSpy.mockRestore();
+    });
+
     it('triggers tree rebuild on layer add', () => {
       const props = {
         layerGroup,

--- a/src/LayerTree/LayerTree.spec.jsx
+++ b/src/LayerTree/LayerTree.spec.jsx
@@ -313,7 +313,7 @@ describe('<LayerTree />', () => {
     });
 
     it('triggers tree rebuild on nodeTitleRenderer changes', () => {
-      const nodeTitleRenderer = function(layer) {
+      const exampleNodeTitleRenderer = function(layer) {
         return (
           <span className="span-1">
             {layer.get('name')}
@@ -323,16 +323,20 @@ describe('<LayerTree />', () => {
 
       const props = {
         layerGroup,
-        map,
-        nodeTitleRenderer
+        map
       };
       const wrapper = TestUtil.mountComponent(LayerTree, props);
-
       const rebuildSpy = jest.spyOn(wrapper.instance(), 'rebuildTreeNodes');
+
+      wrapper.setProps({
+        nodeTitleRenderer: exampleNodeTitleRenderer
+      });
+      expect(rebuildSpy).toHaveBeenCalledTimes(1);
+
       wrapper.setProps({
         nodeTitleRenderer: null
       });
-      expect(rebuildSpy).toHaveBeenCalledTimes(1);
+      expect(rebuildSpy).toHaveBeenCalledTimes(2);
 
       rebuildSpy.mockReset();
       rebuildSpy.mockRestore();


### PR DESCRIPTION

##  BUGFIX

### Description:
The LayerTree does now update when the nodeTitleRenderer prop has changed. This is needed for example when you want to dynamically show/ hide the node title (or with image/ without image).

Please review also if the test makes sense like this.