### PR TITLE
AgFeatureGrid add original event to onRowClick callback

### DIFF
--- a/src/Grid/AgFeatureGrid/AgFeatureGrid.jsx
+++ b/src/Grid/AgFeatureGrid/AgFeatureGrid.jsx
@@ -800,7 +800,7 @@ export class AgFeatureGrid extends React.Component {
     const feature = this.getFeatureFromRowKey(row.key);
 
     if (isFunction(onRowMouseOver)) {
-      onRowMouseOver(row, feature);
+      onRowMouseOver(row, feature, evt);
     }
 
     this.highlightFeatures([feature]);
@@ -820,7 +820,7 @@ export class AgFeatureGrid extends React.Component {
     const feature = this.getFeatureFromRowKey(row.key);
 
     if (isFunction(onRowMouseOut)) {
-      onRowMouseOut(row, feature);
+      onRowMouseOut(row, feature, evt);
     }
 
     this.unhighlightFeatures([feature]);
@@ -965,7 +965,7 @@ export class AgFeatureGrid extends React.Component {
     });
 
     if (isFunction(onRowSelectionChange)) {
-      onRowSelectionChange(selectedRowsAfter, selectedFeatures, deselectedRows, deselectedFeatures);
+      onRowSelectionChange(selectedRowsAfter, selectedFeatures, deselectedRows, deselectedFeatures, evt);
     }
 
     this.resetFeatureStyles();

--- a/src/Grid/AgFeatureGrid/AgFeatureGrid.jsx
+++ b/src/Grid/AgFeatureGrid/AgFeatureGrid.jsx
@@ -779,7 +779,7 @@ export class AgFeatureGrid extends React.Component {
     const feature = this.getFeatureFromRowKey(row.key);
 
     if (isFunction(onRowClick)) {
-      onRowClick(row, feature);
+      onRowClick(row, feature, evt);
     } else {
       this.zoomToFeatures([feature]);
     }


### PR DESCRIPTION
## FEATURE

### Description:

When using AgFeatureGrid's `onRowClick` property, two parameters will be added to the callback function: `row` and `feature`, where `row` equals the original event's `event.data` property (see code below). This PR adds the original event as a whole as third property, so we don't have a loss of information here. This could be useful for instance to allow editing of specific cells but still keep the onRowClick event active.

resolves https://github.com/terrestris/react-geo/issues/846

