### PR TITLE
Fix window className prop to be dynamic

### DIFF
--- a/src/Window/Window.jsx
+++ b/src/Window/Window.jsx
@@ -85,13 +85,8 @@ export class Window extends React.Component {
       'parameter was set correctly (default value is `app`)');
     }
 
-    const finalClassName = props.className
-      ? `${props.className} ${this.className}`
-      : this.className;
-
     const div = document.createElement('div');
     div.id = id;
-    div.className = finalClassName;
     this._elementDiv = div;
 
     this.state = {
@@ -135,6 +130,12 @@ export class Window extends React.Component {
       parentId,
       ...passThroughProps
     } = this.props;
+
+    const finalClassName = className
+      ? `${className} ${this.className}`
+      : this.className;
+
+    this._elementDiv.className = finalClassName;
 
     return ReactDOM.createPortal(
       <Panel {...passThroughProps} >

--- a/src/Window/Window.spec.jsx
+++ b/src/Window/Window.spec.jsx
@@ -60,4 +60,25 @@ describe('<Window />', () => {
     expect(document.getElementById(windowId)).toBeNull();
   });
 
+  it('changes class of component when className is changed in props', () => {
+    const testIdToMountIn = 'testAppId';
+    const windowId = 'testId1';
+    let className = 'test1';
+    const divToBeRenderedIn = document.createElement('div');
+    divToBeRenderedIn.id = testIdToMountIn;
+    document.body.appendChild(divToBeRenderedIn);
+    const wrapper = TestUtil.mountComponent(Window, {
+      parentId: testIdToMountIn,
+      className: className,
+      id: windowId
+    });
+    expect(document.getElementById(windowId)).toBeDefined();
+    expect(document.getElementById(windowId).className).toEqual(expect.stringContaining(className));
+    className = 'test2';
+    wrapper.setProps({
+      className: className
+    });
+    expect(document.getElementById(windowId).className).toEqual(expect.stringContaining(className));
+  });
+
 });


### PR DESCRIPTION
<!-- Please choose one of the categories and choose the corresponding label, too. -->
## BUGFIX

### Description:
<!-- Please describe what this PR is about. -->
This fixes the prop `className` to be dynamic on the window div.
Changing the prop now also changes the class, before it was only set once in the constructor.

