### PR TITLE
Introduce `WfsSearchInput` component

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
   "dependencies": {
     "@turf/turf": "5.1.6",
     "@terrestris/base-util": "0.1.1",
-    "@terrestris/ol-util": "1.2.0",
+    "@terrestris/ol-util": "1.3.0",
     "ag-grid": "18.1.2",
     "ag-grid-react": "18.1.0",
     "lodash": "4.17.10",

--- a/src/Field/WfsSearch/WfsSearch.jsx
+++ b/src/Field/WfsSearch/WfsSearch.jsx
@@ -456,8 +456,10 @@ export class WfsSearch extends React.Component {
       propertyNames,
       renderOption,
       searchAttributes,
+      attributeDetails,
       srsName,
       wfsFormatOptions,
+      displayValue,
       ...passThroughProps
     } = this.props;
 

--- a/src/Field/WfsSearch/WfsSearch.jsx
+++ b/src/Field/WfsSearch/WfsSearch.jsx
@@ -168,6 +168,13 @@ export class WfsSearch extends React.Component {
      */
     onChange: PropTypes.func,
     /**
+      * Optional callback function, that will be called before WFS search starts.
+      * Can be useful if input value manipulation is needed (e.g. umlaut
+      * replacement `ä => oa` etc.)
+      * @type {function}
+      */
+    onBeforeSearch: PropTypes.func,
+    /**
      * Options which are added to the fetch-POST-request. credentials is set to
      * 'same-origin' as default but can be overwritten. See also
      * https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch
@@ -281,12 +288,17 @@ export class WfsSearch extends React.Component {
   onUpdateInput(value) {
     const {
       minChars,
-      onChange
+      onChange,
+      onBeforeSearch
     } = this.props;
 
     this.setState({
       data: []
     });
+
+    if (isFunction(onBeforeSearch)) {
+      value = onBeforeSearch(value);
+    }
 
     if (value) {
       this.setState({

--- a/src/Field/WfsSearch/WfsSearch.jsx
+++ b/src/Field/WfsSearch/WfsSearch.jsx
@@ -1,7 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Select, Spin } from 'antd';
-const Option = Select.Option;
+import {
+  AutoComplete,
+  Spin
+} from 'antd';
+const Option = AutoComplete.Option;
 import isFunction from 'lodash/isFunction.js';
 
 import Logger from '@terrestris/base-util/src/Logger';
@@ -478,8 +481,7 @@ export class WfsSearch extends React.Component {
       : this.className;
 
     return (
-      <Select
-        mode="combobox"
+      <AutoComplete
         className={finalClassName}
         defaultActiveFirstOption={false}
         allowClear={true}
@@ -495,7 +497,7 @@ export class WfsSearch extends React.Component {
             return renderOption(d, this.props);
           })
         }
-      </Select>
+      </AutoComplete>
     );
   }
 }

--- a/src/Field/WfsSearchInput/WfsSearchInput.example.md
+++ b/src/Field/WfsSearchInput/WfsSearchInput.example.md
@@ -1,0 +1,115 @@
+This demonstrates the usage of the WfsSearchInput with presentation of found
+results in AgFeatureGrid component.
+
+
+```jsx
+const React = require('react');
+const OlMap = require('ol/Map').default;
+const OlView = require('ol/View').default;
+const OlLayerTile = require('ol/layer/Tile').default;
+const OlSourceOsm = require('ol/source/OSM').default;
+const fromLonLat = require('ol/proj').fromLonLat;
+const OlFormatGeoJson = require('ol/format/GeoJSON').default;
+
+class WfsSearchInputExample extends React.Component {
+
+  constructor(props) {
+
+    super(props);
+
+    this.state = {
+      data: []
+    }
+
+    this.mapDivId = `map-${Math.random()}`;
+
+    this.map = new OlMap({
+      layers: [
+        new OlLayerTile({
+          name: 'OSM',
+          source: new OlSourceOsm()
+        })
+      ],
+      view: new OlView({
+        center: fromLonLat([37.40570, 8.81566]),
+        zoom: 4
+      })
+    });
+  }
+
+  componentDidMount() {
+    this.map.setTarget(this.mapDivId);
+  }
+
+  onFetchSuccess(data) {
+    const format = new OlFormatGeoJson();
+    const features = data.map(d => format.readFeature(d));
+    this.setState({
+      data: features
+    });
+  }
+
+  onClearClick() {
+    this.setState({
+      data: []
+    });
+  }
+
+  render() {
+    return(
+      <div>
+        <div className="example-block">
+          <label>WFS Search Input:<br />
+            <WfsSearchInput
+              placeholder="Type a countryname in its own language…"
+              baseUrl='https://ows.terrestris.de/geoserver/osm/wfs'
+              featureTypes={['osm:osm-country-borders']}
+              searchAttributes={{
+                'osm:osm-country-borders': ['name']
+              }}
+              map={this.map}
+              style={{
+                width: '80%'
+              }}
+              onFetchSuccess={this.onFetchSuccess.bind(this)}
+              onClearClick={this.onClearClick.bind(this)}
+            />
+            {
+              this.state.data.length > 0 &&
+              <AgFeatureGrid
+                features={this.state.data}
+                map={this.map}
+                enableSorting={true}
+                enableFilter={true}
+                enableColResize={true}
+                attributeBlacklist={['osm_id', 'admin_level', 'administrative']}
+                columnDefs={{
+                  'id': {
+                    headerName: 'ID'
+                  },
+                  'name': {
+                    headerName: 'Country name'
+                  },
+                  'admin_level': {
+                    headerName: 'Administrative level'
+                  }
+                }}
+                zoomToExtent={true}
+                selectable={true}
+              />
+            }
+          </label>
+        </div>
+        <div
+          id={this.mapDivId}
+          style={{
+            height: '400px'
+          }}
+        />
+      </div>
+    )
+  }
+}
+
+<WfsSearchInputExample />
+```

--- a/src/Field/WfsSearchInput/WfsSearchInput.jsx
+++ b/src/Field/WfsSearchInput/WfsSearchInput.jsx
@@ -1,0 +1,442 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {
+  Input,
+  Icon,
+} from 'antd';
+import isFunction from 'lodash/isFunction.js';
+
+import Logger from '@terrestris/base-util/src/Logger';
+import WfsFilterUtil from '@terrestris/ol-util/src/WfsFilterUtil/WfsFilterUtil';
+import { CSS_PREFIX } from '../../constants';
+
+import OlMap from 'ol/Map';
+
+/**
+ * The WfsSearchInput field.
+ * Implements an input field to do a WFS-GetFeature request.
+ *
+ * The GetFeature request is created with `ol.format.WFS.writeGetFeature`
+ * so most of the WFS specific options work like document in the corresponding
+ * API-docs: https://openlayers.org/en/latest/apidoc/module-ol_format_WFS.html
+ *
+ * @class WfsSearchInput
+ * @extends React.Component
+ */
+export class WfsSearchInput extends React.Component {
+
+  /**
+   * The className added to this component.
+   * @type {String}
+   * @private
+   */
+  className = `${CSS_PREFIX}wfssearchinput`
+
+  static propTypes = {
+    /**
+     * An optional CSS class which should be added.
+     * @type {String}
+     */
+    className: PropTypes.string,
+    /**
+     * The base URL. Please make sure that the WFS-Server supports CORS.
+     * @type {String}
+     */
+    baseUrl: PropTypes.string.isRequired,
+    /**
+     * An object mapping feature types to an array of attributes that should be searched through.
+     * @type {Object}
+     */
+    searchAttributes: PropTypes.object.isRequired,
+    /**
+     * A nested object mapping feature types to an object of attribute details,
+     * which are also mapped by search attribute name.
+     *
+     * Example:
+     *   ```
+     *   attributeDetails: {
+     *    featType1: {
+     *      attr1: {
+     *        matchCase: true,
+     *        type: 'number',
+     *        exactSearch: false
+     *      },
+     *      attr2: {
+     *        matchCase: false,
+     *        type: 'string',
+     *        exactSearch: true
+     *      }
+     *    },
+     *    featType2: {...}
+     *   }
+     *   ```
+     * @type {Object}
+     */
+    attributeDetails: PropTypes.objectOf(
+      PropTypes.objectOf(
+        PropTypes.shape({
+          matchCase: PropTypes.bool,
+          type: PropTypes.string,
+          exactSearch: PropTypes.bool
+        })
+      )
+    ),
+    /**
+     * The namespace URI used for features.
+     * @type {String}
+     */
+    featureNS: PropTypes.string,
+    /**
+     * The prefix for the feature namespace.
+     * @type {String}
+     */
+    featurePrefix: PropTypes.string,
+    /**
+     * The feature type names. Required.
+     * @type {String[]}
+     */
+    featureTypes: PropTypes.arrayOf(PropTypes.string).isRequired,
+    /**
+     * SRS name. No srsName attribute will be set on geometries when this is not
+     * provided.
+     * @type {string}
+     */
+    srsName: PropTypes.string,
+    /**
+     * The output format of the response.
+     * @type {string}
+     */
+    outputFormat: PropTypes.string,
+    /**
+     * Maximum number of features to fetch.
+     * @type {number}
+     */
+    maxFeatures: PropTypes.number,
+    /**
+     * Geometry name to use in a BBOX filter.
+     * @type {string}
+     */
+    geometryName: PropTypes.string,
+    /**
+     * Optional list of property names to serialize.
+     * @type {String[]}
+     */
+    propertyNames: PropTypes.arrayOf(PropTypes.string),
+    /**
+     * Filter condition. See https://openlayers.org/en/latest/apidoc/ol.format.filter.html
+     * for more information.
+     * @type {object}
+     */
+    filter: PropTypes.object,
+    /**
+     * The ol.map to interact with on selection.
+     *
+     * @type {Object}
+     */
+    map: PropTypes.instanceOf(OlMap),
+    /**
+     * The minimal amount of characters entered in the input to start a search.
+     * @type {Number}
+     */
+    minChars: PropTypes.number,
+    /**
+     * An onFetchSuccess callback function which gets called with the
+     * successfully fetched data.
+     * Please note: if omitted only data fetch will be performed and no data
+     * will be shown afterwards!
+     * @type {function}
+     */
+    onFetchSuccess: PropTypes.func,
+    /**
+     * An onFetchError callback function which gets called if data fetch is
+     * failed.
+     * @type {function}
+     */
+    onFetchError: PropTypes.func,
+    /**
+     * Optional callback function, that will be called if 'clear' button of
+     * input field was clicked.
+     * @type {function}
+     */
+    onClearClick: PropTypes.func,
+    /**
+      * Optional callback function, that will be called before WFS search starts.
+      * Can be useful if input value manipulation is needed before (e.g. umlaut
+      * replacement `ä => oa` etc.)
+      * @type {function}
+      */
+    onBeforeSearch: PropTypes.func,
+    /**
+     * Options which are added to the fetch-POST-request. credentials is set to
+     * 'same-origin' as default but can be overwritten. See also
+     * https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch
+     * @type {object}
+     */
+    additionalFetchOptions: PropTypes.object,
+    /**
+     * Options which are passed to the constructor of the ol.format.WFS.
+     * compare: https://openlayers.org/en/latest/apidoc/ol.format.WFS.html
+     * @type {object}
+     */
+    wfsFormatOptions: PropTypes.object,
+    /**
+     * Delay in ms before actually sending requests.
+     * @type {number}
+     */
+    delay: PropTypes.number
+  }
+
+  static defaultProps = {
+    srsName: 'EPSG:3857',
+    outputFormat: 'application/json',
+    minChars: 3,
+    additionalFetchOptions: {},
+    attributeDetails: {},
+    delay: 300,
+  }
+
+  /**
+   * Create the WfsSearchInput.
+   *
+   * @param {Object} props The initial props.
+   * @constructs WfsSearchInput
+   */
+  constructor(props) {
+    super(props);
+    this.state = {
+      searchTerm: '',
+      data: [],
+      latestRequestTime: 0
+    };
+    this.onUpdateInput = this.onUpdateInput.bind(this);
+  }
+
+  /**
+   * Called if the input is being updated. It sets the current inputValue
+   * as searchTerm and starts a search if the inputValue has
+   * a length of at least `this.props.minChars` (default 3).
+   *
+   * @param {Event|undefined} evt The input value from `keyup` event.
+   * Gets undefined if clear btn is pressed.
+   */
+  onUpdateInput(evt) {
+    const {
+      minChars,
+      onBeforeSearch
+    } = this.props;
+
+    this.setState({
+      data: []
+    });
+
+    let value = '';
+
+    if (evt && evt.target && evt.target.value) {
+      value = evt.target.value;
+    }
+
+    if (isFunction(onBeforeSearch)) {
+      value = onBeforeSearch(value);
+    }
+
+    if (value) {
+      this.setState({
+        searchTerm: value
+      }, () => {
+        if (this.state.searchTerm.length >= minChars) {
+          this.doSearch();
+        }
+      });
+    }
+  }
+
+  /**
+   * Perform the search.
+   * @private
+   */
+  doSearch() {
+    if (this.timeoutHandle) {
+      clearTimeout(this.timeoutHandle);
+    }
+    const {
+      additionalFetchOptions,
+      baseUrl,
+      featureNS,
+      featurePrefix,
+      featureTypes,
+      geometryName,
+      maxFeatures,
+      outputFormat,
+      propertyNames,
+      srsName,
+      wfsFormatOptions,
+      searchAttributes,
+      attributeDetails
+    } = this.props;
+
+    const searchOpts = {
+      featureNS,
+      featurePrefix,
+      featureTypes,
+      geometryName,
+      maxFeatures,
+      outputFormat,
+      propertyNames,
+      srsName,
+      wfsFormatOptions,
+      searchAttributes,
+      attributeDetails
+    };
+
+    const request = WfsFilterUtil.getCombinedRequests(
+      searchOpts, this.state.searchTerm
+    );
+
+    const fetchTime = new Date();
+    if (request) {
+      this.timeoutHandle = setTimeout(() => {
+        this.setState({
+          fetching: true,
+          latestRequestTime: fetchTime.getTime()
+        }, () => {
+          fetch(`${baseUrl}`, {
+            method: 'POST',
+            credentials: additionalFetchOptions.credentials
+              ? additionalFetchOptions.credentials
+              : 'same-origin',
+            body: new XMLSerializer().serializeToString(request),
+            ...additionalFetchOptions
+          })
+            .then(response => response.json())
+            .then(this.onFetchSuccess.bind(this, fetchTime.getTime()))
+            .catch(this.onFetchError.bind(this));
+        });
+      }, this.props.delay);
+    } else {
+      this.onFetchError('Missing GetFeature request parameters');
+    }
+  }
+
+  /**
+   * This function gets called on success of the WFS GetFeature fetch request.
+   * It sets the response as data.
+   * If an additional function `onFetchSuccess` is provided, it will be called
+   * as callback.
+   * @param {Number} searchTime the timestamp when the search was sent out
+   * @param {Array<object>} response The found features.
+   */
+  onFetchSuccess(searchTime, response) {
+    const {
+      onFetchSuccess
+    } = this.props;
+    const latestTime = this.state.latestRequestTime;
+    if (latestTime !== searchTime) {
+      return;
+    }
+    const data = response.features ? response.features : [];
+    data.forEach(feature => feature.searchTerm = this.state.searchTerm);
+    this.setState({
+      data,
+      fetching: false
+    }, () => {
+      if (isFunction(onFetchSuccess)) {
+        onFetchSuccess(data);
+      }
+    });
+  }
+
+  /**
+   * This function gets called when the WFS GetFeature fetch request returns an error.
+   * It logs the error to the console.
+   * If an additional function `onFetchSuccess` is provided, it will be called
+   * as callback.
+   *
+   * @param {String} error The errorstring.
+   */
+  onFetchError(error) {
+    const {
+      onFetchError
+    } = this.props;
+    Logger.error(`Error while requesting WFS GetFeature: ${error}`);
+    this.setState({
+      fetching: false
+    }, () => {
+      if (isFunction(onFetchError)) {
+        onFetchError(error);
+      }
+    });
+  }
+
+  /**
+   * Resets input field value and previously fetched data on reset button click.
+   */
+  resetSearch() {
+    const {
+      onClearClick
+    } = this.props;
+    this.inputRef.input.value = '';
+    this.setState({
+      data: []
+    });
+
+    if (isFunction(onClearClick)) {
+      onClearClick();
+    }
+  }
+
+  /**
+   * The render function.
+   */
+  render() {
+    const {
+      fetching
+    } = this.state;
+
+    const {
+      additionalFetchOptions,
+      baseUrl,
+      className,
+      featureNS,
+      featurePrefix,
+      featureTypes,
+      filter,
+      geometryName,
+      map,
+      maxFeatures,
+      minChars,
+      outputFormat,
+      propertyNames,
+      searchAttributes,
+      attributeDetails,
+      srsName,
+      wfsFormatOptions,
+      onFetchSuccess,
+      onFetchError,
+      onClearClick,
+      onBeforeSearch,
+      ...passThroughProps
+    } = this.props;
+
+    const finalClassName = className
+      ? `${className} ${this.className}`
+      : this.className;
+
+    return (
+      <Input
+        className={finalClassName}
+        ref={inputRef => {this.inputRef = inputRef;}}
+        suffix={
+          <Icon
+            type={fetching ? 'loading' : 'close-circle'}
+            onClick={this.resetSearch.bind(this)}
+          />
+        }
+        onPressEnter={this.onUpdateInput}
+        onKeyUp={this.onUpdateInput}
+        {...passThroughProps}
+      />
+    );
+  }
+}
+
+export default WfsSearchInput;

--- a/src/Field/WfsSearchInput/WfsSearchInput.jsx
+++ b/src/Field/WfsSearchInput/WfsSearchInput.jsx
@@ -162,7 +162,7 @@ export class WfsSearchInput extends React.Component {
     /**
       * Optional callback function, that will be called before WFS search starts.
       * Can be useful if input value manipulation is needed before (e.g. umlaut
-      * replacement `ä => oa` etc.)
+      * replacement `ä => ae` etc.)
       * @type {function}
       */
     onBeforeSearch: PropTypes.func,

--- a/src/Field/WfsSearchInput/WfsSearchInput.spec.jsx
+++ b/src/Field/WfsSearchInput/WfsSearchInput.spec.jsx
@@ -1,0 +1,132 @@
+/*eslint-env jest*/
+
+import TestUtil from '../../Util/TestUtil';
+import Logger from '@terrestris/base-util/src/Logger';
+
+import { WfsSearchInput } from '../../index';
+
+describe('<WfsSearchInput />', () => {
+  it('is defined', () => {
+    expect(WfsSearchInput).not.toBeUndefined();
+  });
+
+  it('can be rendered', () => {
+    const wrapper = TestUtil.mountComponent(WfsSearchInput);
+    expect(wrapper).not.toBeUndefined();
+  });
+
+  describe('#onUpdateInput', () => {
+    it('resets state.data', () => {
+      const wrapper = TestUtil.mountComponent(WfsSearchInput);
+      wrapper.instance().onUpdateInput();
+      expect(wrapper.state().data).toEqual([]);
+    });
+
+    it('sets the inputValue as state.searchTerm', () => {
+      const wrapper = TestUtil.mountComponent(WfsSearchInput);
+      const evt = {
+        target: {
+          value: 'a'
+        }
+      };
+      wrapper.instance().onUpdateInput(evt);
+      expect(wrapper.state().searchTerm).toBe(evt.target.value);
+    });
+
+    it ('calls onBeforeSearch callback if passed in props', () => {
+      const wrapper = TestUtil.mountComponent(WfsSearchInput);
+      wrapper.setProps({
+        onBeforeSearch: jest.fn()
+      });
+      const evt = {
+        target: {
+          value: 'a'
+        }
+      };
+      wrapper.instance().onUpdateInput(evt);
+      expect(wrapper.props().onBeforeSearch).toHaveBeenCalled();
+    });
+
+    it('sends a request if input is as long as props.minChars', () => {
+      // expect.assertions(1);
+      const wrapper = TestUtil.mountComponent(WfsSearchInput, {
+        placeholder: 'Type a countryname in its own language…',
+        baseUrl: 'https://ows.terrestris.de/geoserver/osm/wfs',
+        featureTypes: ['osm:osm-country-borders'],
+        searchAttributes: {
+          'osm:osm-country-borders': ['name']
+        }
+      });
+      wrapper.instance().doSearch = jest.fn();
+      const evt = {
+        target: {
+          value: 'abc'
+        }
+      };
+      wrapper.instance().onUpdateInput(evt);
+      expect(wrapper.instance().doSearch).toHaveBeenCalled();
+      wrapper.instance().doSearch.mockReset();
+    });
+  });
+
+  describe('#onFetchSuccess', () => {
+    it('sets the response features as state.data', () => {
+      const wrapper = TestUtil.mountComponent(WfsSearchInput);
+      wrapper.setState({latestRequestTime: 1, fetching: true});
+      const features = [{
+        id: '752526',
+        properties: {
+          name: 'Deutschland'
+        }
+      }];
+      wrapper.instance().onFetchSuccess(1, {features});
+      expect(wrapper.state().data).toEqual(features);
+    });
+  });
+
+  describe('#onFetchError', () => {
+    it('sets the response as state.data', () => {
+      const wrapper = TestUtil.mountComponent(WfsSearchInput);
+      const loggerSpy = jest.spyOn(Logger, 'error');
+      wrapper.instance().onFetchError('Peter');
+      expect(loggerSpy).toHaveBeenCalled();
+      expect(loggerSpy).toHaveBeenCalledWith('Error while requesting WFS GetFeature: Peter');
+      loggerSpy.mockReset();
+      loggerSpy.mockRestore();
+    });
+  });
+
+  describe('#resetSearch', () => {
+    it('resets input value', () => {
+      const wrapper = TestUtil.mountComponent(WfsSearchInput);
+      wrapper.instance().inputRef.input.value = 'some value';
+      wrapper.instance().resetSearch();
+      expect(wrapper.instance().inputRef.input.value).toBe('');
+    });
+
+    it('resets state value for data', () => {
+      const wrapper = TestUtil.mountComponent(WfsSearchInput);
+      wrapper.setState({
+        data: [{
+          feat1: {
+            prop: 'peter'
+          }
+        }]
+      });
+      expect(wrapper.state().data.length).toBe(1);
+      wrapper.instance().resetSearch();
+      expect(wrapper.state().data.length).toBe(0);
+      expect(wrapper.state().data).toEqual([]);
+
+    });
+
+    it('calls onClearClick callback function if passed in props', () => {
+      const wrapper = TestUtil.mountComponent(WfsSearchInput);
+      wrapper.setProps({
+        onClearClick: jest.fn()
+      });
+      wrapper.instance().resetSearch();
+      expect(wrapper.props().onClearClick).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,7 @@ import ZoomToExtentButton from './Button/ZoomToExtentButton/ZoomToExtentButton.j
 import CoordinateReferenceSystemCombo from './Field/CoordinateReferenceSystemCombo/CoordinateReferenceSystemCombo.jsx';
 import NominatimSearch from './Field/NominatimSearch/NominatimSearch.jsx';
 import WfsSearch from './Field/WfsSearch/WfsSearch.jsx';
+import WfsSearchInput from './Field/WfsSearchInput/WfsSearchInput.jsx';
 import ScaleCombo from './Field/ScaleCombo/ScaleCombo.jsx';
 import LayerTree from './LayerTree/LayerTree.jsx';
 import LayerTreeNode from './LayerTreeNode/LayerTreeNode.jsx';
@@ -68,6 +69,7 @@ export {
   CoordinateReferenceSystemCombo,
   NominatimSearch,
   WfsSearch,
+  WfsSearchInput,
   TimeSlider,
   MultiLayerSlider,
   MapProvider,


### PR DESCRIPTION
<!-- Please choose one of the categories and choose the corresponding label, too. -->
## FEATURE | REFACTORING

### Description:
Introduced `WfsSearchInput` component which can be actually regarded as an alternative to already existing `WfsSearch` component which depends on `ant` `Select``component.

The new component based on `ant` `Input` field only and shows by default no output on successfully fetched features. The way how retrieved features should be represented is determined from user and can be passed with  `onFetchSuccess` function in prop.

Additionally:
* fixed existing `WfsSearch` component by replacing of deprecated `mode=combobox` property of `Select` by `<AutoComplete>`
* Passing an optional callback function `onBeforeSearch` to be able to manipulate user input before search starts
* Moved `getCombinedRequests` function to `ol-util` 

Note: https://github.com/terrestris/ol-util/pull/30 must be merged and released before.


Please review  @terrestris/devs