### PR TITLE
Use lodash/debounce for delayed function calls

### DIFF
--- a/src/Field/WfsSearch/WfsSearch.jsx
+++ b/src/Field/WfsSearch/WfsSearch.jsx
@@ -102,22 +102,22 @@ export class WfsSearch extends React.Component {
     /**
      * SRS name. No srsName attribute will be set on geometries when this is not
      * provided.
-     * @type {string}
+     * @type {String}
      */
     srsName: PropTypes.string,
     /**
      * The output format of the response.
-     * @type {string}
+     * @type {String}
      */
     outputFormat: PropTypes.string,
     /**
      * Maximum number of features to fetch.
-     * @type {number}
+     * @type {Number}
      */
     maxFeatures: PropTypes.number,
     /**
      * Geometry name to use in a BBOX filter.
-     * @type {string}
+     * @type {String}
      */
     geometryName: PropTypes.string,
     /**
@@ -126,15 +126,15 @@ export class WfsSearch extends React.Component {
      */
     propertyNames: PropTypes.arrayOf(PropTypes.string),
     /**
-     * Filter condition. See https://openlayers.org/en/latest/apidoc/ol.format.filter.html
+     * Filter condition. See https://openlayers.org/en/latest/apidoc/module-ol_format_filter.html
      * for more information.
-     * @type {object}
+     * @type {Object}
      */
     filter: PropTypes.object,
     /**
      * The ol.map to interact with on selection.
      *
-     * @type {Object}
+     * @type {ol.Map}
      */
     map: PropTypes.instanceOf(OlMap),
     /**
@@ -150,7 +150,7 @@ export class WfsSearch extends React.Component {
      * and requires an `id` field on the feature. A custom function is required
      * if your features don't have an `id` field.
      *
-     * @type {function}
+     * @type {Function}
      */
     renderOption: PropTypes.func,
     /**
@@ -158,43 +158,43 @@ export class WfsSearch extends React.Component {
      * returned by server.
      * The default function will create a searchlayer, adds the feature and will
      * zoom to its extend.
-     * @type {function}
+     * @type {Function}
      */
     onSelect: PropTypes.func,
     /**
      * An onChange function which gets called with the current value of the
      * field.
-     * @type {function}
+     * @type {Function}
      */
     onChange: PropTypes.func,
     /**
       * Optional callback function, that will be called before WFS search starts.
       * Can be useful if input value manipulation is needed (e.g. umlaut
       * replacement `ä => oa` etc.)
-      * @type {function}
+      * @type {Function}
       */
     onBeforeSearch: PropTypes.func,
     /**
      * Options which are added to the fetch-POST-request. credentials is set to
      * 'same-origin' as default but can be overwritten. See also
      * https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch
-     * @type {object}
+     * @type {Object}
      */
     additionalFetchOptions: PropTypes.object,
     /**
      * Options which are passed to the constructor of the ol.format.WFS.
      * compare: https://openlayers.org/en/latest/apidoc/ol.format.WFS.html
-     * @type {object}
+     * @type {Object}
      */
     wfsFormatOptions: PropTypes.object,
     /**
      * Which prop value of option will render as content of select.
-     * @type {string}
+     * @type {String}
      */
     displayValue: PropTypes.string,
     /**
      * Delay in ms before actually sending requests.
-     * @type {number}
+     * @type {Number}
      */
     delay: PropTypes.number
   }

--- a/src/Field/WfsSearch/WfsSearch.jsx
+++ b/src/Field/WfsSearch/WfsSearch.jsx
@@ -183,7 +183,7 @@ export class WfsSearch extends React.Component {
     additionalFetchOptions: PropTypes.object,
     /**
      * Options which are passed to the constructor of the ol.format.WFS.
-     * compare: https://openlayers.org/en/latest/apidoc/ol.format.WFS.html
+     * compare: https://openlayers.org/en/latest/apidoc/module-ol_format_WFS.html
      * @type {Object}
      */
     wfsFormatOptions: PropTypes.object,

--- a/src/Field/WfsSearch/WfsSearch.jsx
+++ b/src/Field/WfsSearch/WfsSearch.jsx
@@ -304,7 +304,7 @@ export class WfsSearch extends React.Component {
     this.setState({
       searchTerm: value
     }, () => {
-      if (this.state.searchTerm.length >= minChars) {
+      if (this.state.searchTerm && this.state.searchTerm.length >= minChars) {
         this.doSearch();
       }
     });
@@ -354,17 +354,21 @@ export class WfsSearch extends React.Component {
     );
 
     if (request) {
-      fetch(`${baseUrl}`, {
-        method: 'POST',
-        credentials: additionalFetchOptions.credentials
-          ? additionalFetchOptions.credentials
-          : 'same-origin',
-        body: new XMLSerializer().serializeToString(request),
-        ...additionalFetchOptions
-      })
-        .then(response => response.json())
-        .then(this.onFetchSuccess.bind(this))
-        .catch(this.onFetchError.bind(this));
+      this.setState({
+        fetching: true
+      }, () => {
+        fetch(`${baseUrl}`, {
+          method: 'POST',
+          credentials: additionalFetchOptions.credentials
+            ? additionalFetchOptions.credentials
+            : 'same-origin',
+          body: new XMLSerializer().serializeToString(request),
+          ...additionalFetchOptions
+        })
+          .then(response => response.json())
+          .then(this.onFetchSuccess.bind(this))
+          .catch(this.onFetchError.bind(this));
+      });
     } else {
       this.onFetchError('Missing GetFeature request parameters');
     }

--- a/src/Field/WfsSearch/WfsSearch.spec.jsx
+++ b/src/Field/WfsSearch/WfsSearch.spec.jsx
@@ -55,15 +55,21 @@ describe('<WfsSearch />', () => {
   describe('#onFetchSuccess', () => {
     it('sets the response features as state.data', () => {
       const wrapper = TestUtil.mountComponent(WfsSearch);
-      wrapper.setState({latestRequestTime: 1, fetching: true});
-      const features = [{
-        id: '752526',
-        properties: {
-          name: 'Deutschland'
-        }
-      }];
-      wrapper.instance().onFetchSuccess(1, {features});
-      expect(wrapper.state().data).toEqual(features);
+      const response = {
+        features: [{
+          id: '752526',
+          properties: {
+            name: 'Deutschland'
+          }
+        }]
+      };
+      wrapper.instance().onFetchSuccess(response);
+      const promise = new Promise(resolve => {
+        setTimeout(resolve, 350);
+      });
+      return promise.then(() => {
+        expect(wrapper.state().data).toEqual(response.features);
+      });
     });
   });
 

--- a/src/Field/WfsSearchInput/WfsSearchInput.jsx
+++ b/src/Field/WfsSearchInput/WfsSearchInput.jsx
@@ -244,7 +244,7 @@ export class WfsSearchInput extends React.Component {
     this.setState({
       searchTerm: value
     }, () => {
-      if (this.state.searchTerm.length >= minChars) {
+      if (this.state.searchTerm && this.state.searchTerm.length >= minChars) {
         this.doSearch();
       }
     });

--- a/src/Field/WfsSearchInput/WfsSearchInput.jsx
+++ b/src/Field/WfsSearchInput/WfsSearchInput.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {
   Input,
-  Icon,
+  Icon
 } from 'antd';
 import isFunction from 'lodash/isFunction.js';
 import debounce from 'lodash/debounce.js'
@@ -100,22 +100,22 @@ export class WfsSearchInput extends React.Component {
     /**
      * SRS name. No srsName attribute will be set on geometries when this is not
      * provided.
-     * @type {string}
+     * @type {String}
      */
     srsName: PropTypes.string,
     /**
      * The output format of the response.
-     * @type {string}
+     * @type {String}
      */
     outputFormat: PropTypes.string,
     /**
      * Maximum number of features to fetch.
-     * @type {number}
+     * @type {Number}
      */
     maxFeatures: PropTypes.number,
     /**
      * Geometry name to use in a BBOX filter.
-     * @type {string}
+     * @type {String}
      */
     geometryName: PropTypes.string,
     /**
@@ -124,15 +124,15 @@ export class WfsSearchInput extends React.Component {
      */
     propertyNames: PropTypes.arrayOf(PropTypes.string),
     /**
-     * Filter condition. See https://openlayers.org/en/latest/apidoc/ol.format.filter.html
+     * Filter condition. See https://openlayers.org/en/latest/apidoc/module-ol_format_filter.html.
      * for more information.
-     * @type {object}
+     * @type {Object}
      */
     filter: PropTypes.object,
     /**
      * The ol.map to interact with on selection.
      *
-     * @type {Object}
+     * @type {ol.Map}
      */
     map: PropTypes.instanceOf(OlMap),
     /**
@@ -145,46 +145,46 @@ export class WfsSearchInput extends React.Component {
      * successfully fetched data.
      * Please note: if omitted only data fetch will be performed and no data
      * will be shown afterwards!
-     * @type {function}
+     * @type {Function}
      */
     onFetchSuccess: PropTypes.func,
     /**
      * An onFetchError callback function which gets called if data fetch is
      * failed.
-     * @type {function}
+     * @type {Function}
      */
     onFetchError: PropTypes.func,
     /**
      * Optional callback function, that will be called if 'clear' button of
      * input field was clicked.
-     * @type {function}
+     * @type {Function}
      */
     onClearClick: PropTypes.func,
     /**
       * Optional callback function, that will be called before WFS search starts.
       * Can be useful if input value manipulation is needed before (e.g. umlaut
       * replacement `ä => ae` etc.)
-      * @type {function}
+      * @type {Function}
       */
     onBeforeSearch: PropTypes.func,
     /**
      * Options which are added to the fetch-POST-request. credentials is set to
      * 'same-origin' as default but can be overwritten. See also
      * https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch
-     * @type {object}
+     * @type {Object}
      */
     additionalFetchOptions: PropTypes.object,
     /**
      * Options which are passed to the constructor of the ol.format.WFS.
      * compare: https://openlayers.org/en/latest/apidoc/ol.format.WFS.html
-     * @type {object}
+     * @type {Object}
      */
     wfsFormatOptions: PropTypes.object,
     /**
      * Delay in ms before actually sending requests.
-     * @type {number}
+     * @type {Number}
      */
-    delay: PropTypes.number
+    delay: PropTypes.Number
   }
 
   static defaultProps = {

--- a/src/Field/WfsSearchInput/WfsSearchInput.jsx
+++ b/src/Field/WfsSearchInput/WfsSearchInput.jsx
@@ -176,7 +176,7 @@ export class WfsSearchInput extends React.Component {
     additionalFetchOptions: PropTypes.object,
     /**
      * Options which are passed to the constructor of the ol.format.WFS.
-     * compare: https://openlayers.org/en/latest/apidoc/ol.format.WFS.html
+     * compare: https://openlayers.org/en/latest/apidoc/module-ol_format_WFS.html
      * @type {Object}
      */
     wfsFormatOptions: PropTypes.object,

--- a/src/Field/WfsSearchInput/WfsSearchInput.jsx
+++ b/src/Field/WfsSearchInput/WfsSearchInput.jsx
@@ -5,7 +5,7 @@ import {
   Icon
 } from 'antd';
 import isFunction from 'lodash/isFunction.js';
-import debounce from 'lodash/debounce.js'
+import debounce from 'lodash/debounce.js';
 
 import Logger from '@terrestris/base-util/src/Logger';
 import WfsFilterUtil from '@terrestris/ol-util/src/WfsFilterUtil/WfsFilterUtil';
@@ -184,7 +184,7 @@ export class WfsSearchInput extends React.Component {
      * Delay in ms before actually sending requests.
      * @type {Number}
      */
-    delay: PropTypes.Number
+    delay: PropTypes.number
   }
 
   static defaultProps = {
@@ -193,7 +193,7 @@ export class WfsSearchInput extends React.Component {
     minChars: 3,
     additionalFetchOptions: {},
     attributeDetails: {},
-    delay: 300,
+    delay: 300
   }
 
   /**
@@ -291,6 +291,9 @@ export class WfsSearchInput extends React.Component {
     );
 
     if (request) {
+      this.setState({
+        fetching: true
+      }, () => {
         fetch(`${baseUrl}`, {
           method: 'POST',
           credentials: additionalFetchOptions.credentials
@@ -302,6 +305,7 @@ export class WfsSearchInput extends React.Component {
           .then(response => response.json())
           .then(this.onFetchSuccess.bind(this))
           .catch(this.onFetchError.bind(this));
+      });
     } else {
       this.onFetchError('Missing GetFeature request parameters');
     }

--- a/src/Field/WfsSearchInput/WfsSearchInput.jsx
+++ b/src/Field/WfsSearchInput/WfsSearchInput.jsx
@@ -362,11 +362,11 @@ export class WfsSearchInput extends React.Component {
     this.inputRef.input.value = '';
     this.setState({
       data: []
+    }, () => {
+      if (isFunction(onClearClick)) {
+        onClearClick();
+      }
     });
-
-    if (isFunction(onClearClick)) {
-      onClearClick();
-    }
   }
 
   /**

--- a/src/Field/WfsSearchInput/WfsSearchInput.spec.jsx
+++ b/src/Field/WfsSearchInput/WfsSearchInput.spec.jsx
@@ -34,15 +34,17 @@ describe('<WfsSearchInput />', () => {
     });
 
     it ('calls onBeforeSearch callback if passed in props', () => {
-      const wrapper = TestUtil.mountComponent(WfsSearchInput);
+      const wrapper = TestUtil.mountComponent(WfsSearchInput, {
+      });
       wrapper.setProps({
-        onBeforeSearch: jest.fn()
+        onBeforeSearch: jest.fn(),
       });
       const evt = {
         target: {
-          value: 'a'
+          value: 'abc'
         }
       };
+
       wrapper.instance().onUpdateInput(evt);
       expect(wrapper.props().onBeforeSearch).toHaveBeenCalled();
     });
@@ -72,15 +74,21 @@ describe('<WfsSearchInput />', () => {
   describe('#onFetchSuccess', () => {
     it('sets the response features as state.data', () => {
       const wrapper = TestUtil.mountComponent(WfsSearchInput);
-      wrapper.setState({latestRequestTime: 1, fetching: true});
-      const features = [{
-        id: '752526',
-        properties: {
-          name: 'Deutschland'
-        }
-      }];
-      wrapper.instance().onFetchSuccess(1, {features});
-      expect(wrapper.state().data).toEqual(features);
+      const response = {
+        features: [{
+          id: '752526',
+          properties: {
+            name: 'Deutschland'
+          }
+        }]
+      };
+      wrapper.instance().onFetchSuccess(response);
+      const promise = new Promise(resolve => {
+        setTimeout(resolve, 350);
+      });
+      return promise.then(() => {
+        expect(wrapper.state().data).toEqual(response.features);
+      });
     });
   });
 


### PR DESCRIPTION
<!-- Please choose one of the categories and choose the corresponding label, too. -->
## FEATURE | BUGFIX | REFACTORING 

### Description:
Get rid of timeout function and use `lodash/debounce` function instead to delay invoking of `doSearch` method call for `WfsSearch` and `WfsSearchInput` component.

Also addresses notes mentioned by @dkoch in #878.

Please review @terrestris/devs 
