### PR TITLE
Add callback props onModalLabelOk and onModalLabelCancel to DigitizeButton

### DIFF
--- a/src/Button/DigitizeButton/DigitizeButton.jsx
+++ b/src/Button/DigitizeButton/DigitizeButton.jsx
@@ -406,8 +406,18 @@ class DigitizeButton extends React.Component {
     /**
      * Callback function that will be called
      * when the ok-button of the modal was clicked
+     *
+     * @type {Function} onModalLabelOk
      */
-    onModalLabelOk: PropTypes.func
+    onModalLabelOk: PropTypes.func,
+
+    /**
+     * Callback function that will be called
+     * when the cancel-button of the modal was clicked
+     *
+     * @type {Function} onModalLabelCancel
+     */
+    onModalLabelCancel: PropTypes.func
   };
 
   /**
@@ -964,6 +974,10 @@ class DigitizeButton extends React.Component {
    * digitize layer.
    */
   onModalLabelCancel = () => {
+    const {
+      onModalLabelCancel
+    } = this.props;
+
     this.setState({
       showLabelPrompt: false,
       textLabel: ''
@@ -971,6 +985,9 @@ class DigitizeButton extends React.Component {
       if (!(this.state.interactions.length > 1)) {
         this._digitizeFeatures.remove(this._digitizeTextFeature);
         this._digitizeTextFeature = null;
+      }
+      if (onModalLabelCancel) {
+        onModalLabelCancel();
       }
     });
   }
@@ -1060,6 +1077,7 @@ class DigitizeButton extends React.Component {
       translateInteractionConfig,
       onToggle,
       onModalLabelOk,
+      onModalLabelCancel,
       ...passThroughProps
     } = this.props;
 

--- a/src/Button/DigitizeButton/DigitizeButton.jsx
+++ b/src/Button/DigitizeButton/DigitizeButton.jsx
@@ -401,7 +401,13 @@ class DigitizeButton extends React.Component {
      *
      * @type {Function} onToggle
      */
-    onToggle: PropTypes.func
+    onToggle: PropTypes.func,
+
+    /**
+     * Callback function that will be called
+     * when the ok-button of the modal was clicked
+     */
+    onModalLabelOk: PropTypes.func
   };
 
   /**
@@ -934,10 +940,21 @@ class DigitizeButton extends React.Component {
    * Turns visibility of modal off and call `setTextOnFeature` method.
    */
   onModalLabelOk = () => {
+    const {
+      textLabel
+    } = this.state;
+
+    const {
+      onModalLabelOk
+    } = this.props;
+
     this.setState({
       showLabelPrompt: false
     }, () => {
       this.setTextOnFeature(this._digitizeTextFeature);
+      if (onModalLabelOk) {
+        onModalLabelOk(this._digitizeTextFeature, textLabel);
+      }
     });
   }
 
@@ -1042,6 +1059,7 @@ class DigitizeButton extends React.Component {
       modifyInteractionConfig,
       translateInteractionConfig,
       onToggle,
+      onModalLabelOk,
       ...passThroughProps
     } = this.props;
 


### PR DESCRIPTION
<!-- Please choose one of the categories and choose the corresponding label, too. -->
## FEATURE

### Description:
The digitizeButton was lacking a callback function after clicking on OK and CANCEL in the modal that pops up when adding a label. The properties `onModalLabelOk` and `onModalLabelCancel` now implement this.

`onModalLabelOk` returns the added feature as well as the text content of the input field in the modal.

`onModalLabelCancel` does not return anything.

Edit: Added `onModalLabelCancel` to desription

<!--- CHECKLIST
Fixes Issue?
Examples added?
Tests added?
Docs added?
Would a screenshot be helpful?
Do you want to mention someone?
-->
