### PR TITLE
Add callback props onModalLabelOk and onModalLabelCancel to DigitizeButton for ol4

### DIFF
--- a/src/Button/DigitizeButton/DigitizeButton.jsx
+++ b/src/Button/DigitizeButton/DigitizeButton.jsx
@@ -404,10 +404,20 @@ class DigitizeButton extends React.Component {
     onToggle: PropTypes.func,
 
     /**
-     * Callback function that will be called when
-     * Modal Ok-Button is clicked
+     * Callback function that will be called
+     * when the ok-button of the modal was clicked
+     *
+     * @type {Function} onModalLabelOk
      */
-    onModalLabelOk: PropTypes.func
+    onModalLabelOk: PropTypes.func,
+
+    /**
+     * Callback function that will be called
+     * when the cancel-button of the modal was clicked
+     *
+     * @type {Function} onModalLabelCancel
+     */
+    onModalLabelCancel: PropTypes.func
   };
 
   /**
@@ -963,6 +973,10 @@ class DigitizeButton extends React.Component {
    * digitize layer.
    */
   onModalLabelCancel = () => {
+    const {
+      onModalLabelCancel
+    } = this.props;
+
     this.setState({
       showLabelPrompt: false,
       textLabel: ''
@@ -970,6 +984,9 @@ class DigitizeButton extends React.Component {
       if (!(this.state.interactions.length > 1)) {
         this._digitizeFeatures.remove(this._digitizeTextFeature);
         this._digitizeTextFeature = null;
+      }
+      if (onModalLabelCancel) {
+        onModalLabelCancel();
       }
     });
   }
@@ -1059,6 +1076,7 @@ class DigitizeButton extends React.Component {
       translateInteractionConfig,
       onToggle,
       onModalLabelOk,
+      onModalLabelCancel,
       ...passThroughProps
     } = this.props;
 

--- a/src/Button/DigitizeButton/DigitizeButton.jsx
+++ b/src/Button/DigitizeButton/DigitizeButton.jsx
@@ -401,7 +401,13 @@ class DigitizeButton extends React.Component {
      *
      * @type {Function} onToggle
      */
-    onToggle: PropTypes.func
+    onToggle: PropTypes.func,
+
+    /**
+     * Callback function that will be called when
+     * Modal Ok-Button is clicked
+     */
+    onModalLabelOk: PropTypes.func
   };
 
   /**
@@ -419,7 +425,8 @@ class DigitizeButton extends React.Component {
     selectInteractionConfig: {},
     modifyInteractionConfig: {},
     translateInteractionConfig: {},
-    onToggle: () => {}
+    onToggle: () => {},
+    onModalLabelOk: () => {}
   }
 
   /**
@@ -549,9 +556,7 @@ class DigitizeButton extends React.Component {
    * @return {OlStyleStyle} The style to use.
    */
   getDigitizeStyleFunction = feature => {
-    const {
-      drawStyle,
-    } = this.props;
+    const drawStyle = this.props.drawStyle;
 
     let styleObj;
 
@@ -568,7 +573,7 @@ class DigitizeButton extends React.Component {
                 color: DigitizeButton.DEFAULT_STROKE_COLOR
               })
             })
-          });
+          });        
         } else {
           styleObj = drawStyle || new OlStyleStyle({
             text: new OlStyleText({
@@ -934,10 +939,21 @@ class DigitizeButton extends React.Component {
    * Turns visibility of modal off and call `setTextOnFeature` method.
    */
   onModalLabelOk = () => {
+    const {
+      textLabel
+    } = this.state;
+
+    const {
+      onModalLabelOk
+    } = this.props;
+
     this.setState({
       showLabelPrompt: false
     }, () => {
       this.setTextOnFeature(this._digitizeTextFeature);
+      if (onModalLabelOk) {
+        onModalLabelOk(this._digitizeTextFeature, textLabel);
+      }
     });
   }
 
@@ -1042,6 +1058,7 @@ class DigitizeButton extends React.Component {
       modifyInteractionConfig,
       translateInteractionConfig,
       onToggle,
+      onModalLabelOk,
       ...passThroughProps
     } = this.props;
 

--- a/src/HigherOrderComponent/LoadifiedComponent/LoadifiedComponent.jsx
+++ b/src/HigherOrderComponent/LoadifiedComponent/LoadifiedComponent.jsx
@@ -68,11 +68,11 @@ export function loadify(WrappedComponent, {
     spinning: false
   }
 
-    /**
-     * Create the Loadify.
-     *
-     * @constructs Loadify
-     */
+  /**
+   * Create the Loadify.
+   *
+   * @constructs Loadify
+   */
   constructor(props) {
     super(props);
 


### PR DESCRIPTION
<!-- Please choose one of the categories and choose the corresponding label, too. -->
## FEATURE

### Description:
The digitizeButton was lacking a callback function after clicking on OK and CANCEL in the modal that pops up when adding a label. The properties `onModalLabelOk` and `onModalLabelCancel` now implement this.

`onModalLabelOk` returns the added feature as well as the text content of the input field in the modal.

`onModalLabelCancel` does not return anything.

<!--- CHECKLIST
Fixes Issue?
Examples added?
Tests added?
Docs added?
Would a screenshot be helpful?
Do you want to mention someone?
-->
