### PR TITLE
Specify react version for linter

### DIFF
--- a/.eslint-common.js
+++ b/.eslint-common.js
@@ -42,5 +42,10 @@ module.exports = {
       }
     }],
     "space-infix-ops": ["error", {"int32Hint": false}]
+  },
+  "settings": {
+    "react": {
+      "version": "16.0"
+    }
   }
 };


### PR DESCRIPTION
<!-- Please choose one of the categories and choose the corresponding label, too. -->
## DEVSETUP

### Description:
This removes a warning when linting by configuring the react version for an eslint plugin

Before:

```
$ npm run lint:src

> @terrestris/react-geo@10.3.0 lint:src /home/jansen/code/react-geo
> eslint -c .eslint-src.js --ext js,jsx,html src/

Warning: React version not specified in eslint-plugin-react settings. See https://github.com/yannickcr/eslint-plugin-react#configuration.
```

After:

```
$ npm run lint:src

> @terrestris/react-geo@10.3.0 lint:src /home/jansen/code/react-geo
> eslint -c .eslint-src.js --ext js,jsx,html src/
```