### PR TITLE
Update several dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -126,6 +126,6 @@
     "style-loader": "0.23.0",
     "url-loader": "1.1.1",
     "webpack": "4.19.1",
-    "whatwg-fetch": "2.0.4"
+    "whatwg-fetch": "3.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "eslint-plugin-markdown": "1.0.0-beta.7",
     "eslint-plugin-react": "7.11.1",
     "file-loader": "2.0.0",
-    "jest": "22.4.3",
+    "jest": "23.6.0",
     "less": "3.8.1",
     "less-loader": "4.1.0",
     "np": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "eslint-plugin-html": "4.0.6",
     "eslint-plugin-markdown": "1.0.0-beta.7",
     "eslint-plugin-react": "7.11.1",
-    "file-loader": "1.1.11",
+    "file-loader": "2.0.0",
     "jest": "22.4.3",
     "less": "3.8.1",
     "less-loader": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "css-loader": "1.0.0",
     "enzyme": "3.6.0",
     "enzyme-adapter-react-16": "1.5.0",
-    "eslint": "5.5.0",
+    "eslint": "5.6.0",
     "eslint-plugin-html": "4.0.6",
     "eslint-plugin-markdown": "1.0.0-beta.7",
     "eslint-plugin-react": "7.11.1",


### PR DESCRIPTION
<!-- Please choose one of the categories and choose the corresponding label, too. -->
## DEPENDENCY UPDATE

### Description:

This updates several dependencies.

* `whatwg-fetch` from `2.0.4` to `3.0.0` (used by `jest`, testing only, breaking changes shouldn't affect us) 
* `file-loader` from `1.1.11` to `2.0.0` (the breaking change there is the requirement for `"node": ">=6.9.0 < 7.0.0 || >= 8.9.0"`, even though we do not specify it, we require Node > 8 already, e.g. on Travis.) 
* `eslint` from `5.5.0` to `5.6.0` (feature update)
* `jest` from `22.4.3` to `23.6.0` (unproblematic in my local setup)