### PR TITLE
Always cancel animation

### DIFF
--- a/src/Button/ZoomButton/ZoomButton.jsx
+++ b/src/Button/ZoomButton/ZoomButton.jsx
@@ -90,6 +90,9 @@ class ZoomButton extends React.Component {
     if (!view) { // no view, no zooming
       return;
     }
+    if (view.getAnimating()) {
+      view.cancelAnimations();
+    }
     const currentZoom = view.getZoom();
     const zoom = currentZoom + delta;
     if (animate) {
@@ -98,9 +101,6 @@ class ZoomButton extends React.Component {
         duration,
         easing
       };
-      if (view.getAnimating()) {
-        view.cancelAnimations();
-      }
       view.animate(finalOptions);
     } else {
       view.setZoom(zoom);


### PR DESCRIPTION
<!-- Please choose one of the categories and choose the corresponding label, too. -->
## BUGFIX

### Description:

We should always cancel any pending/running animations, regardless of whether we will change the zoom in an animated way or not.