### PR TITLE
Less strict PropTypes type & slightly enhanced docs

### DIFF
--- a/src/Button/ZoomToExtentButton/ZoomToExtentButton.jsx
+++ b/src/Button/ZoomToExtentButton/ZoomToExtentButton.jsx
@@ -41,7 +41,7 @@ class ZoomToExtentButton extends React.Component {
 
     /**
      * The extent `[minx, miny, maxx, maxy]` in the maps coordinate system or an
-     * instance of Ol SimpleGeometry that the map should zoom to.
+     * instance of ol.geom.SimpleGeometry that the map should zoom to.
      * @type {Array<Number>|OlSimpleGeometry}
      */
     extent: PropTypes.oneOfType([

--- a/src/Button/ZoomToExtentButton/ZoomToExtentButton.jsx
+++ b/src/Button/ZoomToExtentButton/ZoomToExtentButton.jsx
@@ -54,13 +54,7 @@ class ZoomToExtentButton extends React.Component {
      * https://openlayers.org/en/latest/apidoc/module-ol_View-View.html#fit
      * @type {Object}
      */
-    fitOptions: PropTypes.shape({
-      constrainResolution: PropTypes.bool,
-      duration: PropTypes.number,
-      easing: PropTypes.func,
-      padding: PropTypes.arrayOf(PropTypes.number),
-      nearest: PropTypes.bool
-    })
+    fitOptions: PropTypes.object
 
   }
 


### PR DESCRIPTION
<!-- Please choose one of the categories and choose the corresponding label, too. -->
## FEATURE & DOCUMENTATION

### Description:

This addresses two comments by @dnlkoch on #897:
* Less strict PropTypes type for `fitOptions` (=> a feature, people cann now pass more options than before)
* A minor change in the documentation

Please review.