### PR TITLE
Provide optional callback prop `onFeatureSelect` to be used with `ol.interaction.Select` (ol5)

### DIFF
--- a/src/Button/DigitizeButton/DigitizeButton.jsx
+++ b/src/Button/DigitizeButton/DigitizeButton.jsx
@@ -418,12 +418,13 @@ class DigitizeButton extends React.Component {
      * @type {Function} onModalLabelCancel
      */
     onModalLabelCancel: PropTypes.func,
+
     /**
      * Listener function for the 'select' event of the ol.interaction.Select
      * if in `Edit` mode.
      * Can be also called inside of 'select' listener function of
      * the ol.interaction.Select in `Copy` and `Delete` mode if provided.
-     * See https://openlayers.org/en/latest/apidoc/ol.interaction.Select.Event.html
+     * See https://openlayers.org/en/latest/apidoc/module-ol_interaction_Select.html
      * for more information.
      */
     onFeatureSelect: PropTypes.func


### PR DESCRIPTION
<!-- Please choose one of the categories and choose the corresponding label, too. -->
## FEATURE | BUGFIX 

### Description:
Title says it all. 

Possible use case: `styleFunction` of `ol.select.Interaction` doesn't take effect when selected feature already has style. The proposed callback function can be used to force setting of overriden select style.

ol4 compatible PR version can be found under https://github.com/terrestris/react-geo/pull/906.

Please review @terrestris/devs 
