### PR TITLE
Enhance label handling in `DigitizeButton` component (ol4)

### DIFF
--- a/src/Button/DigitizeButton/DigitizeButton.jsx
+++ b/src/Button/DigitizeButton/DigitizeButton.jsx
@@ -1004,10 +1004,7 @@ class DigitizeButton extends React.Component {
     this.setState({
       showLabelPrompt: false
     }, () => {
-      this.setTextOnFeature(this._digitizeTextFeature);
-      if (onModalLabelOk) {
-        onModalLabelOk(this._digitizeTextFeature, textLabel);
-      }
+      this.setTextOnFeature(this._digitizeTextFeature, onModalLabelOk);
     });
   }
 
@@ -1029,7 +1026,7 @@ class DigitizeButton extends React.Component {
         this._digitizeFeatures.remove(this._digitizeTextFeature);
         this._digitizeTextFeature = null;
       }
-      if (onModalLabelCancel) {
+      if (isFunction(onModalLabelCancel)) {
         onModalLabelCancel();
       }
     });
@@ -1037,8 +1034,10 @@ class DigitizeButton extends React.Component {
 
   /**
    * Sets formatted label on feature.
+   * Calls `onModalLabelOk` callback function if provided.
    *
    * @param {OlFeature} feat The point feature to be styled with label.
+   * @param {Function} onModalOkCbk Optional callback function.
    */
   setTextOnFeature = (feat, onModalOkCbk) => {
     const {
@@ -1054,6 +1053,10 @@ class DigitizeButton extends React.Component {
     feat.set('label', label);
     this.setState({
       textLabel: ''
+    }, () => {
+      if (isFunction(onModalOkCbk)) {
+        onModalOkCbk(feat, label);
+      }
     });
   }
 

--- a/src/Button/DigitizeButton/DigitizeButton.jsx
+++ b/src/Button/DigitizeButton/DigitizeButton.jsx
@@ -1052,10 +1052,14 @@ class DigitizeButton extends React.Component {
       maxLabelLineLength
     } = this.props;
 
-    let label = this.state.textLabel;
+    const {
+      textLabel
+    } = this.state;
+
+    let label = textLabel;
     if (maxLabelLineLength) {
       label = StringUtil.stringDivider(
-        this.state.textLabel, maxLabelLineLength, '\n'
+        textLabel, maxLabelLineLength, '\n'
       );
     }
     feat.set('label', label);

--- a/src/Button/DigitizeButton/DigitizeButton.jsx
+++ b/src/Button/DigitizeButton/DigitizeButton.jsx
@@ -907,7 +907,8 @@ class DigitizeButton extends React.Component {
     if (feature.get('isLabel')) {
       this._digitizeTextFeature = feature;
       this.setState({
-        showLabelPrompt: true
+        showLabelPrompt: true,
+        textLabel: feature.getStyle().getText().getText() || ''
       });
     }
   }

--- a/src/Button/DigitizeButton/DigitizeButton.jsx
+++ b/src/Button/DigitizeButton/DigitizeButton.jsx
@@ -429,7 +429,15 @@ class DigitizeButton extends React.Component {
      * See https://openlayers.org/en/latest/apidoc/ol.interaction.Select.Event.html
      * for more information.
      */
-    onFeatureSelect: PropTypes.func
+    onFeatureSelect: PropTypes.func,
+
+    /**
+     * Maximal length of feature label.
+     * If exceeded label will be divided into multiple lines. Optional.
+     *
+     * @type {Number} maxLabelLineLength
+     */
+    maxLabelLineLength: PropTypes.number
   };
 
   /**
@@ -1031,8 +1039,17 @@ class DigitizeButton extends React.Component {
    *
    * @param {OlFeature} feat The point feature to be styled with label.
    */
-  setTextOnFeature = feat => {
-    const label = StringUtil.stringDivider(this.state.textLabel, 16, '\n');
+  setTextOnFeature = (feat, onModalOkCbk) => {
+    const {
+      maxLabelLineLength
+    } = this.props;
+
+    let label = this.state.textLabel;
+    if (maxLabelLineLength) {
+      label = StringUtil.stringDivider(
+        this.state.textLabel, maxLabelLineLength, '\n'
+      );
+    }
     feat.set('label', label);
     this.setState({
       textLabel: ''
@@ -1113,6 +1130,7 @@ class DigitizeButton extends React.Component {
       onToggle,
       onModalLabelOk,
       onModalLabelCancel,
+      maxLabelLineLength,
       ...passThroughProps
     } = this.props;
 

--- a/src/Button/DigitizeButton/DigitizeButton.jsx
+++ b/src/Button/DigitizeButton/DigitizeButton.jsx
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types';
 
 import { Modal, Input } from 'antd';
 
+const TextArea = Input.TextArea;
+
 import isFunction from 'lodash/isFunction.js';
 
 import OlMap from 'ol/map';
@@ -1138,9 +1140,10 @@ class DigitizeButton extends React.Component {
               onOk={this.onModalLabelOk}
               onCancel={this.onModalLabelCancel}
             >
-              <Input
+              <TextArea
                 value={this.state.textLabel}
                 onChange={this.onLabelChange}
+                autosize
               />
             </Modal>
             : null

--- a/src/Button/DigitizeButton/DigitizeButton.jsx
+++ b/src/Button/DigitizeButton/DigitizeButton.jsx
@@ -994,10 +994,6 @@ class DigitizeButton extends React.Component {
    */
   onModalLabelOk = () => {
     const {
-      textLabel
-    } = this.state;
-
-    const {
       onModalLabelOk
     } = this.props;
 

--- a/src/Button/DigitizeButton/DigitizeButton.jsx
+++ b/src/Button/DigitizeButton/DigitizeButton.jsx
@@ -668,6 +668,10 @@ class DigitizeButton extends React.Component {
       selectStrokeColor
     } = this.props;
 
+    if (feature.get('label')) {
+      text = feature.get('label');
+    }
+
     return new OlStyleStyle({
       image: new OlStyleCircle({
         radius: 7,
@@ -906,9 +910,17 @@ class DigitizeButton extends React.Component {
     const feature = evt.features.getArray()[0];
     if (feature.get('isLabel')) {
       this._digitizeTextFeature = feature;
+      let textLabel = '';
+
+      if (feature.getStyle() && feature.getStyle().getText()) {
+        textLabel = feature.getStyle().getText().getText();
+      } else if (feature.get('label')) {
+        textLabel = feature.get('label');
+      }
+
       this.setState({
         showLabelPrompt: true,
-        textLabel: feature.getStyle().getText().getText() || ''
+        textLabel
       });
     }
   }

--- a/src/Button/DigitizeButton/DigitizeButton.spec.jsx
+++ b/src/Button/DigitizeButton/DigitizeButton.spec.jsx
@@ -325,7 +325,7 @@ describe('<DigitizeButton />', () => {
           selectStrokeColor: 'blue'
         });
 
-        const expectedStyle = wrapper.instance().getSelectedStyleFunction();
+        const expectedStyle = wrapper.instance().getSelectedStyleFunction(new OlFeature());
         expect(expectedStyle instanceof OlStyleStyle).toBeTruthy();
         expect(expectedStyle.getStroke().getColor()).toBe(wrapper.props().selectStrokeColor);
         expect(expectedStyle.getFill().getColor()).toBe(wrapper.props().selectFillColor);

--- a/src/Button/DigitizeButton/DigitizeButton.spec.jsx
+++ b/src/Button/DigitizeButton/DigitizeButton.spec.jsx
@@ -446,6 +446,9 @@ describe('<DigitizeButton />', () => {
         const wrapper = setupWrapper();
         const feat = new OlFeature();
         feat.set('isLabel', true);
+        feat.setStyle(new OlStyleStyle({
+          text: new OlStyleText()
+        }));
         const mockEvt = {
           features: {}
         };


### PR DESCRIPTION
<!-- Please choose one of the categories and choose the corresponding label, too. -->
## FEATURE | BUGFIX 

### Description:
* Use `ant` `Input.TextArea` instead of `Input` to enable multiline labels
* Set currently modifying label as value in label edit modal (previously value was always empty)
* Introduced new numerical prop `maxLabelLineLength` to determine if label should be divided into multiline label after provided threshold is exceeded
* Ensure that `onModalLabelOk` / `onModalLabelCancel` callback function will be called with updated values by moving them into `setState` callback

Please review @terrestris/devs 
