### PR TITLE
`lodash` imports cleanup

### DIFF
--- a/src/Button/DigitizeButton/DigitizeButton.jsx
+++ b/src/Button/DigitizeButton/DigitizeButton.jsx
@@ -2,10 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import { Modal, Input } from 'antd';
-
 const TextArea = Input.TextArea;
-
-import isFunction from 'lodash/isFunction.js';
 
 import OlMap from 'ol/Map';
 import OlLayerVector from 'ol/layer/Vector';
@@ -22,11 +19,14 @@ import OlInteractionModify from 'ol/interaction/Modify';
 import OlInteractionTranslate from 'ol/interaction/Translate';
 import { never, singleClick } from 'ol/events/condition';
 
+import isFunction from 'lodash/isFunction';
+
 import ToggleButton from '../ToggleButton/ToggleButton.jsx';
 import MapUtil from '@terrestris/ol-util/src/MapUtil/MapUtil';
 import StringUtil from '@terrestris/base-util/src/StringUtil/StringUtil';
 import AnimateUtil from '@terrestris/ol-util/src/AnimateUtil/AnimateUtil';
 import Logger from '@terrestris/base-util/src/Logger';
+
 import { CSS_PREFIX } from '../../constants';
 
 /**

--- a/src/Button/MeasureButton/MeasureButton.jsx
+++ b/src/Button/MeasureButton/MeasureButton.jsx
@@ -1,8 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import isEmpty from 'lodash/isEmpty.js';
-
 import OlMap from 'ol/Map';
 import OlLayerVector from 'ol/layer/Vector';
 import OlSourceVector from 'ol/source/Vector';
@@ -17,9 +15,12 @@ import OlInteractionDraw from 'ol/interaction/Draw';
 import { unByKey } from 'ol/Observable';
 import OlOverlay from 'ol/Overlay';
 
+import isEmpty from 'lodash/isEmpty';
+
 import ToggleButton from '../ToggleButton/ToggleButton.jsx';
 import MeasureUtil from '@terrestris/ol-util/src/MeasureUtil/MeasureUtil';
 import MapUtil from '@terrestris/ol-util/src/MapUtil/MapUtil';
+
 import { CSS_PREFIX } from '../../constants';
 
 import './MeasureButton.less';

--- a/src/Button/ToggleButton/ToggleButton.jsx
+++ b/src/Button/ToggleButton/ToggleButton.jsx
@@ -1,11 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+
 import {
   Button,
   Tooltip
 } from 'antd';
 import { Icon } from 'react-fa';
-import isFunction from 'lodash/isFunction.js';
+
+import isFunction from 'lodash/isFunction';
 
 import './ToggleButton.less';
 

--- a/src/Button/ToggleGroup/ToggleGroup.jsx
+++ b/src/Button/ToggleGroup/ToggleGroup.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import isFunction from 'lodash/isFunction.js';
+
+import isFunction from 'lodash/isFunction';
 
 import { CSS_PREFIX } from '../../constants';
 

--- a/src/Container/AddWmsPanel/AddWmsPanel.jsx
+++ b/src/Container/AddWmsPanel/AddWmsPanel.jsx
@@ -4,15 +4,17 @@ import { Checkbox } from 'antd';
 import OlLayerTile from 'ol/layer/Tile';
 import OlLayerImage  from 'ol/layer/Image';
 import OlMap from 'ol/Map';
-import isFunction from 'lodash/isFunction.js';
+
+import isFunction from 'lodash/isFunction';
 
 import Panel from '../../Panel/Panel/Panel.jsx';
 import Titlebar from '../../Panel/Titlebar/Titlebar.jsx';
 import SimpleButton from '../../Button/SimpleButton/SimpleButton.jsx';
 import Logger from '@terrestris/base-util/src/Logger';
 
-import './AddWmsPanel.less';
 import AddWmsLayerEntry from './AddWmsLayerEntry/AddWmsLayerEntry.jsx';
+
+import './AddWmsPanel.less';
 
 /**
  * Panel containing a (checkable) list of AddWmsLayerEntry instances.

--- a/src/Field/ScaleCombo/ScaleCombo.jsx
+++ b/src/Field/ScaleCombo/ScaleCombo.jsx
@@ -2,15 +2,15 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Select } from 'antd';
 const Option = Select.Option;
+
 import OlMap from 'ol/Map';
-import {
-  isInteger,
-  isEmpty,
-  isEqual,
-  isFunction,
-  reverse,
-  clone
-} from 'lodash';
+
+import isInteger from 'lodash/isInteger';
+import isEmpty from 'lodash/isEmpty';
+import isEqual from 'lodash/isEqual';
+import isFunction from 'lodash/isFunction';
+import reverse from 'lodash/reverse';
+import clone from 'lodash/clone';
 
 import Logger from '@terrestris/base-util/src/Logger';
 import MapUtil from '@terrestris/ol-util/src/MapUtil/MapUtil';

--- a/src/Field/WfsSearch/WfsSearch.jsx
+++ b/src/Field/WfsSearch/WfsSearch.jsx
@@ -1,19 +1,22 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+
 import {
   AutoComplete,
   Spin
 } from 'antd';
 const Option = AutoComplete.Option;
-import isFunction from 'lodash/isFunction.js';
-import debounce from 'lodash/debounce.js';
-
-import Logger from '@terrestris/base-util/src/Logger';
-import WfsFilterUtil from '@terrestris/ol-util/src/WfsFilterUtil/WfsFilterUtil';
-import { CSS_PREFIX } from '../../constants';
 
 import OlMap from 'ol/Map';
 import OlFormatGeoJSON from 'ol/format/GeoJSON';
+
+import isFunction from 'lodash/isFunction';
+import debounce from 'lodash/debounce';
+
+import Logger from '@terrestris/base-util/src/Logger';
+import WfsFilterUtil from '@terrestris/ol-util/src/WfsFilterUtil/WfsFilterUtil';
+
+import { CSS_PREFIX } from '../../constants';
 
 /**
  * The WfsSearch field.

--- a/src/Field/WfsSearchInput/WfsSearchInput.jsx
+++ b/src/Field/WfsSearchInput/WfsSearchInput.jsx
@@ -1,17 +1,20 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+
 import {
   Input,
   Icon
 } from 'antd';
-import isFunction from 'lodash/isFunction.js';
-import debounce from 'lodash/debounce.js';
+
+import OlMap from 'ol/Map';
+
+import isFunction from 'lodash/isFunction';
+import debounce from 'lodash/debounce';
 
 import Logger from '@terrestris/base-util/src/Logger';
 import WfsFilterUtil from '@terrestris/ol-util/src/WfsFilterUtil/WfsFilterUtil';
-import { CSS_PREFIX } from '../../constants';
 
-import OlMap from 'ol/Map';
+import { CSS_PREFIX } from '../../constants';
 
 /**
  * The WfsSearchInput field.

--- a/src/Grid/AgFeatureGrid/AgFeatureGrid.jsx
+++ b/src/Grid/AgFeatureGrid/AgFeatureGrid.jsx
@@ -1,10 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+
 import { AgGridReact } from 'ag-grid-react';
-import differenceWith from 'lodash/differenceWith.js';
-import isEqual from 'lodash/isEqual.js';
-import isFunction from 'lodash/isFunction.js';
-import kebabCase from 'lodash/kebabCase.js';
+
 import OlStyle from 'ol/style/Style';
 import OlStyleFill from 'ol/style/Fill';
 import OlStyleCircle from 'ol/style/Circle';
@@ -16,11 +14,15 @@ import OlLayerVector from 'ol/layer/Vector';
 import OlGeomGeometry from 'ol/geom/Geometry';
 import OlGeomGeometryCollection from 'ol/geom/GeometryCollection';
 
+import isArray from 'lodash/isArray';
+import differenceWith from 'lodash/differenceWith';
+import isEqual from 'lodash/isEqual';
+import isFunction from 'lodash/isFunction';
+import kebabCase from 'lodash/kebabCase';
+
 import MapUtil from '@terrestris/ol-util/src/MapUtil/MapUtil';
 
 import { CSS_PREFIX } from '../../constants';
-
-import isArray from 'lodash/isArray.js';
 
 import 'ag-grid/dist/styles/ag-grid.css';
 import 'ag-grid/dist/styles/ag-theme-balham.css';

--- a/src/Grid/AgFeatureGrid/AgFeatureGrid.spec.jsx
+++ b/src/Grid/AgFeatureGrid/AgFeatureGrid.spec.jsx
@@ -3,7 +3,7 @@ import OlSourceVector from 'ol/source/Vector';
 import OlLayerVector from 'ol/layer/Vector';
 import OlGeomGeometryCollection from 'ol/geom/GeometryCollection';
 
-import differenceWith from 'lodash/differenceWith.js';
+import differenceWith from 'lodash/differenceWith';
 
 import TestUtil from '../../Util/TestUtil';
 

--- a/src/Grid/FeatureGrid/FeatureGrid.jsx
+++ b/src/Grid/FeatureGrid/FeatureGrid.jsx
@@ -1,9 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+
 import { Table } from 'antd';
-import isEqual from 'lodash/isEqual.js';
-import isFunction from 'lodash/isFunction.js';
-import kebabCase from 'lodash/kebabCase.js';
+
 import OlStyle from 'ol/style/Style';
 import OlStyleFill from 'ol/style/Fill';
 import OlStyleCircle from 'ol/style/Circle';
@@ -14,6 +13,10 @@ import OlSourceVector from 'ol/source/Vector';
 import OlLayerVector from 'ol/layer/Vector';
 import OlGeomGeometry from 'ol/geom/Geometry';
 import OlGeomGeometryCollection from 'ol/geom/GeometryCollection';
+
+import isEqual from 'lodash/isEqual';
+import isFunction from 'lodash/isFunction';
+import kebabCase from 'lodash/kebabCase';
 
 import MapUtil from '@terrestris/ol-util/src/MapUtil/MapUtil';
 

--- a/src/Grid/PropertyGrid/PropertyGrid.jsx
+++ b/src/Grid/PropertyGrid/PropertyGrid.jsx
@@ -1,8 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+
 import { Table } from 'antd';
+
 import OlFeature from 'ol/Feature';
-import get from 'lodash/get.js';
+
+import get from 'lodash/get';
 
 import { CSS_PREFIX } from '../../constants';
 

--- a/src/HigherOrderComponent/TimeLayerAware/TimeLayerAware.jsx
+++ b/src/HigherOrderComponent/TimeLayerAware/TimeLayerAware.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import isArray from 'lodash/isArray.js';
+
+import isArray from 'lodash/isArray';
 
 /**
  * HOC that updates layers based on the wrapped components time instant or

--- a/src/LayerTree/LayerTree.jsx
+++ b/src/LayerTree/LayerTree.jsx
@@ -1,8 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import isBoolean from 'lodash/isBoolean.js';
-import isFunction from 'lodash/isFunction.js';
-import isEqual from 'lodash/isEqual.js';
+
 import { Tree } from 'antd';
 
 import OlMap from 'ol/Map';
@@ -11,9 +9,15 @@ import OlLayerGroup from 'ol/layer/Group';
 import OlCollection from 'ol/Collection';
 import { unByKey } from 'ol/Observable';
 
+import isBoolean from 'lodash/isBoolean';
+import isFunction from 'lodash/isFunction';
+import isEqual from 'lodash/isEqual';
+
 import Logger from '@terrestris/base-util/src/Logger';
 import MapUtil from '@terrestris/ol-util/src/MapUtil/MapUtil';
+
 import LayerTreeNode from '../LayerTreeNode/LayerTreeNode.jsx';
+
 import { CSS_PREFIX } from '../constants';
 
 /**

--- a/src/Legend/Legend.jsx
+++ b/src/Legend/Legend.jsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import isEqual from 'lodash/isEqual';
+
 import Logger from '@terrestris/base-util/src/Logger';
 import MapUtil from '@terrestris/ol-util/src/MapUtil/MapUtil';
-import isEqual from 'lodash/isEqual.js';
 
 import { CSS_PREFIX } from '../constants';
 

--- a/src/Panel/Panel/Panel.jsx
+++ b/src/Panel/Panel/Panel.jsx
@@ -1,12 +1,14 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Rnd from 'react-rnd';
-import uniqueId from 'lodash/uniqueId.js';
-import isNumber from 'lodash/isNumber.js';
-import isFunction from 'lodash/isFunction.js';
+
+import uniqueId from 'lodash/uniqueId';
+import isNumber from 'lodash/isNumber';
+import isFunction from 'lodash/isFunction';
 
 import Titlebar from '../Titlebar/Titlebar.jsx';
 import SimpleButton from '../../Button/SimpleButton/SimpleButton.jsx';
+
 import { CSS_PREFIX } from '../../constants';
 
 import './Panel.less';

--- a/src/Panel/Titlebar/Titlebar.jsx
+++ b/src/Panel/Titlebar/Titlebar.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import isEmpty from 'lodash/isEmpty.js';
+
+import isEmpty from 'lodash/isEmpty';
 
 import { CSS_PREFIX } from '../../constants';
 

--- a/src/Slider/TimeSlider.jsx
+++ b/src/Slider/TimeSlider.jsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import moment from 'moment';
-import isArray from 'lodash/isArray.js';
-import isObject from 'lodash/isObject.js';
 
 import { Slider } from 'antd';
+
+import isArray from 'lodash/isArray';
+import isObject from 'lodash/isObject';
 
 /**
  * Customized slider that uses ISO 8601 time strings as input.

--- a/src/Window/Window.jsx
+++ b/src/Window/Window.jsx
@@ -1,10 +1,12 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
-import uniqueId from 'lodash/uniqueId.js';
+
+import uniqueId from 'lodash/uniqueId';
 
 import Panel from  '../Panel/Panel/Panel.jsx';
 import Logger from '@terrestris/base-util/src/Logger';
+
 import { CSS_PREFIX } from '../constants';
 
 import './Window.less';


### PR DESCRIPTION
<!-- Please choose one of the categories and choose the corresponding label, too. -->
## BUGFIX | REFACTORING

### Description:
Non-functional changes.

* Remove unneeded `*.js extension from `lodash` imports
* Import specific `lodash` functions instead of whole package for `ScaleCombo` class.

Please review @terrestris/devs