### PR TITLE
Fix greenkeeper initial

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "babel-core": "6.26.3",
     "babel-eslint": "10.0.1",
     "babel-jest": "23.6.0",
-    "babel-loader": "8.0.4",
+    "babel-loader": "7.1.5",
     "babel-plugin-dynamic-import-node": "2.2.0",
     "babel-plugin-import": "1.11.0",
     "babel-plugin-transform-es2015-modules-commonjs": "6.26.2",

--- a/src/Panel/Panel/Panel.jsx
+++ b/src/Panel/Panel/Panel.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import Rnd from 'react-rnd';
+import { Rnd } from 'react-rnd';
 
 import uniqueId from 'lodash/uniqueId';
 import isNumber from 'lodash/isNumber';


### PR DESCRIPTION
<!-- Please choose one of the categories and choose the corresponding label, too. -->
## BUGFIX

### Description:
<!-- Please describe what this PR is about. -->
For unknown reasons we had to reset greenkeeper for this repo (see [greenkeeper-initial PR](#938)). Due to the update of all dependencies, two issues were introduced and will be fixed with this PR:
* Downgrade `babel-loader` to 7.1.5 as were not compatible with Babel 7.
* Fix import for `rnd`.

<!--- CHECKLIST
Fixes Issue?
Examples added?
Tests added?
Docs added?
Would a screenshot be helpful?
Do you want to mention someone?
-->
