### PR TITLE
Typo in prop

### DIFF
--- a/src/Button/GeoLocationButton/GeoLocationButton.jsx
+++ b/src/Button/GeoLocationButton/GeoLocationButton.jsx
@@ -125,7 +125,7 @@ class GeoLocationButton extends React.Component {
      * https://www.w3.org/TR/geolocation-API/#position_options_interface
      * @type {Object}
      */
-    trackingoptions: PropTypes.shape({
+    trackingOptions: PropTypes.shape({
       maximumAge: PropTypes.number,
       enableHighAccuracy: PropTypes.bool,
       timeout: PropTypes.number
@@ -141,7 +141,7 @@ class GeoLocationButton extends React.Component {
     onError: () => undefined,
     showMarker: true,
     follow: false,
-    trackingoptions: {
+    trackingOptions: {
       maximumAge: 10000,
       enableHighAccuracy: true,
       timeout: 600000
@@ -241,7 +241,7 @@ class GeoLocationButton extends React.Component {
   onToggle = (pressed) => {
     const {
       showMarker,
-      trackingoptions,
+      trackingOptions,
       map
     } = this.props;
 
@@ -262,7 +262,7 @@ class GeoLocationButton extends React.Component {
     // Geolocation Control
     this._geoLocationInteraction = new OlGeolocation({
       projection: view.getProjection(),
-      trackingOptions: trackingoptions
+      trackingOptions: trackingOptions
     });
     this._geoLocationInteraction.setTracking(true);
 

--- a/src/Map/FloatingMapLogo/FloatingMapLogo.jsx
+++ b/src/Map/FloatingMapLogo/FloatingMapLogo.jsx
@@ -46,7 +46,7 @@ class FloatingMapLogo extends React.Component {
      * Whether the map-logo is absolutely postioned or not
      * @type {boolean}
      */
-    absolutelyPostioned: PropTypes.bool,
+    absolutelyPositioned: PropTypes.bool,
 
     /**
      * The style object
@@ -61,7 +61,7 @@ class FloatingMapLogo extends React.Component {
    */
   static defaultProps = {
     imageSrc: 'logo.png',
-    absolutelyPostioned: false
+    absolutelyPositioned: false
   }
 
   /**
@@ -71,7 +71,7 @@ class FloatingMapLogo extends React.Component {
     const {
       imageSrc,
       imageHeight,
-      absolutelyPostioned,
+      absolutelyPositioned,
       className,
       style
     } = this.props;
@@ -80,7 +80,7 @@ class FloatingMapLogo extends React.Component {
       ? `${className} ${this.className}`
       : this.className;
 
-    if (absolutelyPostioned) {
+    if (absolutelyPositioned) {
       Object.assign(style, {'position': 'absolute'});
     }
 

--- a/src/Map/FloatingMapLogo/FloatingMapLogo.spec.jsx
+++ b/src/Map/FloatingMapLogo/FloatingMapLogo.spec.jsx
@@ -53,7 +53,7 @@ describe('<FloatingMapLogo />', () => {
   it('passes position prop', () => {
     let props = {
       imageSrc: testLogo,
-      absolutelyPostioned: true,
+      absolutelyPositioned: true,
       style: {
         backgroundColor: 'yellow'
       }


### PR DESCRIPTION
<!-- Please choose one of the categories and choose the corresponding label, too. -->
## BREAKING CHANGE

### Description:
This renames two ill-named properties

* In the `GeoLocationButton`
  * Rename `trackingoptions` to `trackingOptions` (Upper case `O`)
* In the `FloatingMapLogo`
  * Rename `absolutelyPostioned` to `absolutelyPositioned` (added an `i`)
  * (Side note: A better name for this would be much appreciated)

Please review, and caution: this is a **semver major change**