### PR TITLE
Inherit LayerTreeNode and MapContainer from React.PureComponent

### DIFF
--- a/src/LayerTreeNode/LayerTreeNode.jsx
+++ b/src/LayerTreeNode/LayerTreeNode.jsx
@@ -10,7 +10,7 @@ import { CSS_PREFIX } from '../constants';
 /**
  * Class representing a layer tree node
  */
-class LayerTreeNode extends React.Component {
+class LayerTreeNode extends React.PureComponent {
 
   /**
    * The prop types.

--- a/src/Map/MapComponent/MapComponent.jsx
+++ b/src/Map/MapComponent/MapComponent.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import OlMap from 'ol/Map';
 
@@ -6,9 +6,9 @@ import OlMap from 'ol/Map';
  * Class representing a map.
  *
  * @class The MapComponent.
- * @extends React.Component
+ * @extends React.PureComponent
  */
-export class MapComponent extends React.Component {
+export class MapComponent extends PureComponent {
 
   /**
    * The properties.


### PR DESCRIPTION
<!-- Please choose one of the categories and choose the corresponding label, too. -->
## BREAKING CHANGE | REFACTORING

This PR introduces `PureComponents` for `LayerTreeNode` and `MapContainer` component of react-geo so that implicitly a `shouldComponentUpdate` function is generated. 

### Description:
<!-- Please describe what this PR is about. -->
See also https://github.com/terrestris/react-geo/issues/650

<!--- CHECKLIST
Fixes Issue?
Examples added?
Tests added?
Docs added?
Would a screenshot be helpful?
Do you want to mention someone?
-->
