### PR TITLE
Rebuild tree nodes on moveend event of map if resolution changed

### DIFF
--- a/src/LayerTree/LayerTree.jsx
+++ b/src/LayerTree/LayerTree.jsx
@@ -7,6 +7,7 @@ import OlMap from 'ol/Map';
 import OlLayerBase from 'ol/layer/Base';
 import OlLayerGroup from 'ol/layer/Group';
 import OlCollection from 'ol/Collection';
+import OlMapEvent from 'ol/MapEvent';
 import { unByKey } from 'ol/Observable';
 
 import isBoolean from 'lodash/isBoolean';
@@ -29,7 +30,6 @@ import { CSS_PREFIX } from '../constants';
  * @extends React.Component
  */
 class LayerTree extends React.Component {
-
 
   /**
    * The className added to this component.
@@ -110,8 +110,6 @@ class LayerTree extends React.Component {
         };
       }
     }
-
-    return null;
   }
 
   /**
@@ -126,7 +124,8 @@ class LayerTree extends React.Component {
       layerGroup: null,
       layerGroupRevision: null,
       treeNodes: [],
-      checkedKeys: []
+      checkedKeys: [],
+      mapResolution: -1
     };
   }
 
@@ -225,10 +224,8 @@ class LayerTree extends React.Component {
    * nodes whenever the view's resolution changes.
    */
   registerResolutionChangeHandler() {
-    const mapView = this.props.map.getView();
-    const evtKey = mapView.on('change:resolution', () => {
-      this.rebuildTreeNodes();
-    });
+    const { map } = this.props;
+    const evtKey = map.on('moveend', this.rebuildTreeNodes.bind(this));
     this.olListenerKeys.push(evtKey); // TODO when and how to we unbind?
   }
 
@@ -309,12 +306,24 @@ class LayerTree extends React.Component {
 
   /**
    * Rebuilds the treeNodes and its checked states.
+   * @param {ol.MapEvent} evt The OpenLayers MapEvent (passed by moveend)
+   *
    */
-  rebuildTreeNodes = () => {
+  rebuildTreeNodes = evt => {
+    const { mapResolution } = this.state;
+
+    if (evt && evt instanceof OlMapEvent && evt.target && evt.target.getView) {
+      if (mapResolution === evt.target.getView().getResolution()) {
+        // If map resolution didn't change => ne redraw of tree nodes needed.
+        return;
+      }
+    }
+
     this.treeNodesFromLayerGroup(this.state.layerGroup);
     const checkedKeys = this.getVisibleOlUids();
     this.setState({
-      checkedKeys
+      checkedKeys,
+      mapResolution: evt ? evt.target.getView().getResolution() : -1
     });
   }
 

--- a/src/LayerTree/LayerTree.jsx
+++ b/src/LayerTree/LayerTree.jsx
@@ -314,7 +314,7 @@ class LayerTree extends React.Component {
 
     if (evt && evt instanceof OlMapEvent && evt.target && evt.target.getView) {
       if (mapResolution === evt.target.getView().getResolution()) {
-        // If map resolution didn't change => ne redraw of tree nodes needed.
+        // If map resolution didn't change => no redraw of tree nodes needed.
         return;
       }
     }


### PR DESCRIPTION
<!-- Please choose one of the categories and choose the corresponding label, too. -->
## BREAKING CHANGE | REFACTORING

### Description:
<!-- Please describe what this PR is about. -->
Until now, `change:resolution` has been used to detect resolution changes. However, this has a drawback since it is fired as long the view is animating (see https://github.com/openlayers/openlayers/issues/7402). Since a "final" `change:resolution` after animation is not fired yet (see [here](https://github.com/openlayers/openlayers/issues/7409)) the `moveend` event of the map is used to detect changes in current map resolution.

As a consequence Layertree will me rendered less often.

<!--- CHECKLIST
Fixes Issue?
Examples added?
Tests added?
Docs added?
Would a screenshot be helpful?
Do you want to mention someone?
-->
