### PR TITLE
A valid state object (or null) must be returned in getDerivedStateFromProps

### DIFF
--- a/src/LayerTree/LayerTree.jsx
+++ b/src/LayerTree/LayerTree.jsx
@@ -110,6 +110,7 @@ class LayerTree extends React.Component {
         };
       }
     }
+    return null;
   }
 
   /**


### PR DESCRIPTION
<!-- Please choose one of the categories and choose the corresponding label, too. -->
## BUGFIX

### Description:
<!-- Please describe what this PR is about. -->
Title says it all. Affected component: `LayerTree.jsx`



<!--- CHECKLIST
Fixes Issue?
Examples added?
Tests added?
Docs added?
Would a screenshot be helpful?
Do you want to mention someone?
-->
