### PR TITLE
Don't pass trackingOptions prop to ToggleButton

### DIFF
--- a/src/Button/GeoLocationButton/GeoLocationButton.jsx
+++ b/src/Button/GeoLocationButton/GeoLocationButton.jsx
@@ -330,6 +330,7 @@ class GeoLocationButton extends React.Component {
       follow,
       onGeolocationChange,
       onError,
+      trackingOptions,
       ...passThroughProps
     } = this.props;
 


### PR DESCRIPTION
<!-- Please choose one of the categories and choose the corresponding label, too. -->
## BUGFIX

### Description:
This fixes a nasty error on the console as the prop isn't a valid button attribute.

<!--- CHECKLIST
Fixes Issue?
Examples added?
Tests added?
Docs added?
Would a screenshot be helpful?
Do you want to mention someone?
-->
