### PR TITLE
Remove warnings in AgFeatureGrid example

### DIFF
--- a/src/Grid/AgFeatureGrid/AgFeatureGrid.example.md
+++ b/src/Grid/AgFeatureGrid/AgFeatureGrid.example.md
@@ -73,22 +73,28 @@ class AgFeatureGridExample extends React.Component {
         <AgFeatureGrid
           features={features}
           map={this.map}
-          enableSorting={true}
-          enableFilter={true}
-          enableColResize={true}
           attributeBlacklist={['gml_id', 'USE', 'RS', 'RS_ALT']}
           columnDefs={{
             'GEN': {
               headerName: 'Name',
-              cellRenderer: 'nameColumnRenderer'
+              cellRenderer: 'nameColumnRenderer',
+              sortable: true,
+              filter: true,
+              resizable: true
             },
             'SHAPE_LENG': {
               headerName: 'Length',
-              cellRenderer: 'mathRoundRenderer'
+              cellRenderer: 'mathRoundRenderer',
+              sortable: true,
+              filter: true,
+              resizable: true
             },
             'SHAPE_AREA': {
               headerName: 'Area',
-              cellRenderer: 'mathRoundRenderer'
+              cellRenderer: 'mathRoundRenderer',
+              sortable: true,
+              filter: true,
+              resizable: true
             }
           }}
           zoomToExtent={true}


### PR DESCRIPTION
<!-- Please choose one of the categories and choose the corresponding label, too. -->
## DOCUMENTATION

### Description:
This removes some warnings in the `AgFeatureGrid` example by removing the usage of the outdated API.

<!--- CHECKLIST
Fixes Issue?
Examples added?
Tests added?
Docs added?
Would a screenshot be helpful?
Do you want to mention someone?
-->
