### PR TITLE
Fixup prop type checking in DigitizeButton

### DIFF
--- a/src/Button/DigitizeButton/DigitizeButton.jsx
+++ b/src/Button/DigitizeButton/DigitizeButton.jsx
@@ -289,7 +289,7 @@ class DigitizeButton extends React.Component {
      *
      * @type {OlStyleStyle | FeatureStyleFunction}
      */
-    drawStyle: PropTypes.oneOf([
+    drawStyle: PropTypes.oneOfType([
       PropTypes.instanceOf(OlStyleStyle),
       PropTypes.func
     ]),


### PR DESCRIPTION
<!-- Please choose one of the categories and choose the corresponding label, too. -->
## BUGFIX

### Description:
Fixes prop type check by replacing `oneOf` (literal comaprison) with `oneOfType` for property `drawStyle`

<!--- CHECKLIST
Fixes Issue?
Examples added?
Tests added?
Docs added?
Would a screenshot be helpful?
Do you want to mention someone?
-->
