### PR TITLE
Replace outdated babel plugin

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -11,7 +11,14 @@ module.exports = {
     },
     build: {
       plugins: [
-        'babel-plugin-transform-import-extension-jsx-to-js'
+        [
+          'module-resolver',
+          {
+            resolvePath(sourcePath) {
+              return sourcePath.replace('.jsx', '.js');
+            }
+          }
+        ]
       ]
     }
   },

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "babel-loader": "8.0.5",
     "babel-plugin-dynamic-import-node": "2.2.0",
     "babel-plugin-import": "1.11.0",
-    "babel-plugin-transform-import-extension-jsx-to-js": "0.1.0",
+    "babel-plugin-module-resolver": "3.1.3",
     "canvas-prebuilt": "1.6.11",
     "coveralls": "3.0.2",
     "css-loader": "2.1.0",


### PR DESCRIPTION
<!-- Please choose one of the categories and choose the corresponding label, too. -->
## DEVSETUP

### Description:
<!-- Please describe what this PR is about. -->
This replaces the outdated babel plugin `babel-plugin-transform-import-extension-jsx-to-js` with `babel-plugin-module-resolver`.

<!--- CHECKLIST
Fixes Issue?
Examples added?
Tests added?
Docs added?
Would a screenshot be helpful?
Do you want to mention someone?
-->
