### PR TITLE
Forces rebuildTreeNodes onExpand

### DIFF
--- a/src/LayerTree/LayerTree.jsx
+++ b/src/LayerTree/LayerTree.jsx
@@ -70,6 +70,11 @@ class LayerTree extends React.Component {
     nodeTitleRenderer: PropTypes.func,
 
     /**
+     * Compare https://ant.design/components/tree/
+     */
+    onExpand: PropTypes.func,
+
+    /**
      * An optional array-filter function that is applied to every layer and
      * subLayer. Return false to exclude this layer from the layerTree or true
      * to include it.
@@ -505,6 +510,20 @@ class LayerTree extends React.Component {
   }
 
   /**
+   * Call rebuildTreeNodes onExpand to avoid sync issues.
+   *
+   */
+  onExpand = (expandedKeys, {expanded, node}) => {
+    const {
+      onExpand
+    } = this.props;
+    this.rebuildTreeNodes();
+    if (onExpand) {
+      onExpand(expandedKeys, {expanded, node});
+    }
+  }
+
+  /**
    * The render function.
    */
   render() {
@@ -534,6 +553,7 @@ class LayerTree extends React.Component {
         onCheck={this.onCheck.bind(this)}
         {...ddListeners}
         {...passThroughProps}
+        onExpand={this.onExpand}
       >
         {this.state.treeNodes}
       </Tree>

--- a/src/LayerTreeNode/LayerTreeNode.jsx
+++ b/src/LayerTreeNode/LayerTreeNode.jsx
@@ -53,7 +53,7 @@ class LayerTreeNode extends React.PureComponent {
 }
 
 // Otherwise rc-tree wouldn't recognize this component as TreeNode, see
-// https://github.com/react-component/tree/blob/master/src/TreeNode.jsx#L328
+// https://github.com/react-component/tree/blob/master/src/TreeNode.jsx#L534
 LayerTreeNode.isTreeNode = 1;
 
 export default LayerTreeNode;


### PR DESCRIPTION
<!-- Please choose one of the categories and choose the corresponding label, too. -->
## BUGFIX

### Description:
<!-- Please describe what this PR is about. -->
This introduces a `onExpand` listener that calls `rebuildTreeNodes`, as expanding Trees with more the 1 level didn't work properly.

<!--- CHECKLIST
Fixes Issue?
Examples added?
Tests added?
Docs added?
Would a screenshot be helpful?
Do you want to mention someone?
-->
