### PR TITLE
Fix `onEscape` function call for Window component

### DIFF
--- a/src/Panel/Panel/Panel.jsx
+++ b/src/Panel/Panel/Panel.jsx
@@ -202,13 +202,22 @@ export class Panel extends React.Component {
   }
 
   /**
-   * The reference callback.
-   *
-   * @param {Element} element The body div DOMElement of the panel.
+   * componentDidMount life cycle method.
+   * Registers `keydown` listener if `onEscape` function was provided via props.
    */
-  onBodyRef(element){
-    if (element) {
-      element.focus();
+  componentDidMount() {
+    if (this.props.onEscape) {
+      document.addEventListener('keydown', this.onKeyDown, false);
+    }
+  }
+
+  /**
+   * componentWillUnmount life cycle method.
+   * Unregisters `keydown` listener if `onEscape` function was provided via props.
+   */
+  componentWillUnmount() {
+    if (this.props.onEscape) {
+      document.removeEventListener('keydown', this.onKeyDown, false);
     }
   }
 
@@ -302,8 +311,9 @@ export class Panel extends React.Component {
    * is `escape` key and `onEscape` function is provided via props.
    * @param {React.KeyboardEvent<HTMLDivElement>} evt `keydown` event.
    */
-  onKeyDown(evt) {
-    if (evt.key === this._escapeKeyboardEventKey && this.props.onEscape) {
+  onKeyDown = evt => {
+    if (evt && evt.key === this._escapeKeyboardEventKey && this.props.onEscape) {
+      this.rnd.getSelfElement().focus();
       this.props.onEscape();
     }
   }
@@ -407,8 +417,6 @@ export class Panel extends React.Component {
         <div
           className="body"
           tabIndex="0"
-          ref={this.onBodyRef}
-          onKeyDown={this.onKeyDown.bind(this)}
           style={{
             cursor: 'default',
             overflow: 'hidden',

--- a/src/Panel/Panel/Panel.spec.jsx
+++ b/src/Panel/Panel/Panel.spec.jsx
@@ -25,35 +25,19 @@ describe('<Panel />', () => {
     expect(rnd.props.fc).toBe('koeln');
   });
 
-  describe('#onBodyRef', () => {
-
-    const wrapper = TestUtil.mountComponent(Panel);
-    const element = wrapper.find('div.body');
-    const elNode = element.getDOMNode();
-    const focusedElement = document.activeElement;
-
-    it('is defined', () => {
-      expect(wrapper.instance().onBodyRef).not.toBeUndefined();
-    });
-
-    it ('doesn\'t focus element if not provided', () => {
-      wrapper.instance().onBodyRef();
-      expect(element.matchesElement(focusedElement)).toBeFalsy();
-    });
-
-    it ('focuses element if provided', () => {
-      const focusSpy = jest.spyOn(elNode, 'focus');
-      wrapper.instance().onBodyRef(elNode);
-      expect(focusSpy).toHaveBeenCalledTimes(1);
-      expect(elNode).toEqual(focusedElement);
-      focusSpy.mockReset();
-      focusSpy.mockRestore();
-    });
-  });
-
   describe('#onKeyDown', () => {
 
     const wrapper = TestUtil.mountComponent(Panel);
+
+    // Mock a DOM to play around
+    document.body.innerHTML =
+        '<div class="body" tabindex="0" ' +
+          'style="cursor: default; ' +
+          'overflow: hidden; height: auto;">' +
+        '</div>';
+
+    const element = wrapper.instance().rnd.getSelfElement();
+    const focusedElement = document.activeElement;
 
     it('is defined', () => {
       expect(wrapper.instance().onKeyDown).not.toBeUndefined();
@@ -69,17 +53,21 @@ describe('<Panel />', () => {
       });
 
       const onEscSpy = jest.spyOn(wrapper.props(), 'onEscape');
+      const focusSpy = jest.spyOn(element, 'focus');
 
       wrapper.instance().onKeyDown(mockEvt);
       expect(onEscSpy).toHaveBeenCalledTimes(0);
+      expect(focusSpy).toHaveBeenCalledTimes(0);
 
       // call once again with valid key and onEscape function
       mockEvt.key = 'Escape';
+
       wrapper.instance().onKeyDown(mockEvt);
       expect(onEscSpy).toHaveBeenCalledTimes(1);
-
-      onEscSpy.mockReset();
-      onEscSpy.mockRestore();
+      expect(focusSpy).toHaveBeenCalledTimes(1);
+      expect(element.innerHTML).toEqual(focusedElement.innerHTML);
+      jest.resetAllMocks();
+      jest.restoreAllMocks();
     });
   });
 


### PR DESCRIPTION
<!-- Please choose one of the categories and choose the corresponding label, too. -->
## BUGFIX

### Description:
`Window` component  won't be autofocused on render. That leads to missing behaviour of `onEscape` function which can be optionally provided as prop (e.g. closing window on Escape didn't work anymore out of the box -> to get it work, user had to click manually into the window body firstly to set focus on component).
This PR fix the described issue, `onEscape` handler will be called now even if the Window component is not currently focused.

Please review @terrestris/devs 

<!--- CHECKLIST
Fixes Issue?
Examples added?
Tests added?
Docs added?
Would a screenshot be helpful?
Do you want to mention someone?
-->
