### PR TITLE
Adds leaf/folder css-class to TreeNode

### DIFF
--- a/src/LayerTreeNode/LayerTreeNode.jsx
+++ b/src/LayerTreeNode/LayerTreeNode.jsx
@@ -17,6 +17,7 @@ class LayerTreeNode extends React.PureComponent {
    * @type {Object}
    */
   static propTypes = {
+    children: PropTypes.array,
     inResolutionRange: PropTypes.bool
   }
 
@@ -37,16 +38,22 @@ class LayerTreeNode extends React.PureComponent {
   render() {
     const {
       inResolutionRange,
+      children,
       ...passThroughProps
     } = this.props;
 
-    const addClassName = (inResolutionRange ? 'within' : 'out-off') + '-range';
+    const isFolder = Array.isArray(children) && children.length > 0;
+    let addClassName = (inResolutionRange ? 'within' : 'out-off') + '-range';
+    addClassName += isFolder ? ' tree-folder' : ' tree-leaf';
     const finalClassname = `${CSS_PREFIX}layertree-node ${addClassName}`;
+
     return(
       <TreeNode
         className={finalClassname}
         {...passThroughProps}
-      />
+      >
+        {children}
+      </TreeNode>
     );
   }
 


### PR DESCRIPTION
<!-- Please choose one of the categories and choose the corresponding label, too. -->
## FEATURE

### Description:
<!-- Please describe what this PR is about. -->
This adds an extra CSS class to `LayerTreeNodes` to differentiate between folders and leafs.

<!--- CHECKLIST
Fixes Issue?
Examples added?
Tests added?
Docs added?
Would a screenshot be helpful?
Do you want to mention someone?
-->
