### PR TITLE
Fix escape key for IE

### DIFF
--- a/src/Panel/Panel/Panel.jsx
+++ b/src/Panel/Panel/Panel.jsx
@@ -34,7 +34,7 @@ export class Panel extends React.Component {
     * @type {String}
     * @private
     */
-   _escapeKeyboardEventKey = 'Escape';
+   _escapeKeyboardEventKey = 'Esc';
 
   /**
    * The properties.
@@ -308,11 +308,11 @@ export class Panel extends React.Component {
 
   /**
    * Called on keyboard `keydown` event. Will be only triggered if pressed key
-   * is `escape` key and `onEscape` function is provided via props.
+   * is `Escape` key and `onEscape` function is provided via props.
    * @param {React.KeyboardEvent<HTMLDivElement>} evt `keydown` event.
    */
   onKeyDown = evt => {
-    if (evt && evt.key === this._escapeKeyboardEventKey && this.props.onEscape) {
+    if (evt && evt.key.startsWith(this._escapeKeyboardEventKey) && this.props.onEscape) {
       this.rnd.getSelfElement().focus();
       this.props.onEscape();
     }


### PR DESCRIPTION
<!-- Please choose one of the categories and choose the corresponding label, too. -->
## BUGFIX

### Description:
Tiny fix to ensure that `Escape` key will also be matched while using IE.

Please review @terrestris/devs 