### PR TITLE
Fixup nominatim search by comparing strings

### DIFF
--- a/src/Field/NominatimSearch/NominatimSearch.jsx
+++ b/src/Field/NominatimSearch/NominatimSearch.jsx
@@ -267,9 +267,9 @@ export class NominatimSearch extends React.Component {
    * @param {value} key The key of the selected option.
    */
   onMenuItemSelected(key) {
-    const selected = this.state.dataSource.filter(
+    const selected = this.state.dataSource.find(
       i => i.place_id.toString() === key.toString()
-    )[0];
+    );
     this.props.onSelect(selected, this.props.map);
   }
 

--- a/src/Field/NominatimSearch/NominatimSearch.jsx
+++ b/src/Field/NominatimSearch/NominatimSearch.jsx
@@ -267,7 +267,9 @@ export class NominatimSearch extends React.Component {
    * @param {value} key The key of the selected option.
    */
   onMenuItemSelected(key) {
-    const selected = this.state.dataSource.filter(i => i.place_id === key)[0];
+    const selected = this.state.dataSource.filter(
+      i => i.place_id.toString() === key.toString()
+    )[0];
     this.props.onSelect(selected, this.props.map);
   }
 

--- a/src/Field/NominatimSearch/NominatimSearch.spec.jsx
+++ b/src/Field/NominatimSearch/NominatimSearch.spec.jsx
@@ -103,7 +103,7 @@ describe('<NominatimSearch />', () => {
     it('calls this.props.onSelect with the selected item', () => {
       //SETUP
       const dataSource = [{
-        place_id: '752526',
+        place_id: 752526,
         display_name: 'Böen, Löningen, Landkreis Cloppenburg, Niedersachsen, Deutschland'
       }];
       const map = new OlMap({


### PR DESCRIPTION
<!-- Please choose one of the categories and choose the corresponding label, too. -->
## BUGFIX

### Description:
This fixes the `onMenuItemSelected` handler of the `NominatimSearch`, which is currently broken due to a change in the response of the API. 

The property `place_id` has been changed from string to a number, which causes a comparison to fail. This has been fixed by comparing both values stringified with `toString()`

