### PR TITLE
Customizable id property in WfsSearch

### DIFF
--- a/src/Field/WfsSearch/WfsSearch.jsx
+++ b/src/Field/WfsSearch/WfsSearch.jsx
@@ -149,10 +149,8 @@ export class WfsSearch extends React.Component {
      * A render function which gets called with the selected item as it is
      * returned by the server. It must return an `AutoComplete.Option` with
      * `key={feature.id}`.
-     * The default will display the property `name` if existing or the `id` to
-     * and requires an `id` field on the feature. A custom function is required
-     * if your features don't have an `id` field.
-     *
+     * The default will display the property `name` if existing or the
+     * property defined in `props.idProperty` (default is to `id`).
      * @type {Function}
      */
     renderOption: PropTypes.func,
@@ -196,6 +194,11 @@ export class WfsSearch extends React.Component {
      */
     displayValue: PropTypes.string,
     /**
+     * The id property of the feature. Default is to `id`.
+     * @type {String}
+     */
+    idProperty: PropTypes.string,
+    /**
      * Delay in ms before actually sending requests.
      * @type {Number}
      */
@@ -208,6 +211,7 @@ export class WfsSearch extends React.Component {
     minChars: 3,
     additionalFetchOptions: {},
     displayValue: 'name',
+    idProperty: 'id',
     attributeDetails: {},
     delay: 300,
     /**
@@ -220,16 +224,17 @@ export class WfsSearch extends React.Component {
      */
     renderOption: (feature, props) => {
       const {
-        displayValue
+        displayValue,
+        idProperty
       } = props;
 
       const display = feature.properties[displayValue] ?
-        feature.properties[displayValue] : feature.id;
+        feature.properties[displayValue] : feature[idProperty];
 
       return (
         <Option
           value={display}
-          key={feature.id}
+          key={feature[idProperty]}
           title={display}
         >
           {display}
@@ -413,10 +418,12 @@ export class WfsSearch extends React.Component {
    */
   onMenuItemSelected(value, option) {
     const {
-      map
+      map,
+      idProperty
     } = this.props;
 
-    const selectedFeature = this.state.data.filter(feat => feat.id === option.key)[0];
+    const selectedFeature = this.state.data.filter(feat =>
+      feat[idProperty] === option.key)[0];
     this.props.onSelect(selectedFeature, map);
   }
 

--- a/src/Field/WfsSearch/WfsSearch.spec.jsx
+++ b/src/Field/WfsSearch/WfsSearch.spec.jsx
@@ -175,9 +175,31 @@ describe('<WfsSearch />', () => {
         }
       };
       const option = wrapper.props().renderOption(feature, {
-        displayValue: 'name'
+        // Props must be passed to the renderOption function.
+        displayValue: 'name',
+        idProperty: 'id'
       });
+
       expect(option.key).toBe(feature.id);
+      expect(option.props.children).toBe(feature.properties.name);
+    });
+  });
+
+  describe('#idProperty', () => {
+    it('can be specified', () => {
+      const wrapper = TestUtil.mountComponent(WfsSearch);
+      const feature = {
+        customId: '7355608',
+        properties: {
+          name: 'Deutschland'
+        }
+      };
+      const option = wrapper.props().renderOption(feature, {
+        displayValue: 'name',
+        idProperty: 'customId'
+      });
+
+      expect(option.key).toBe(feature.customId);
       expect(option.props.children).toBe(feature.properties.name);
     });
   });


### PR DESCRIPTION
<!-- Please choose one of the categories and choose the corresponding label, too. -->
## FEATURE

### Description:
This adds the prop `idProperty` to the `WfsSearch` to define a custom id property for the requested feature types.

See #1097.

<!--- CHECKLIST
Fixes Issue?
Examples added?
Tests added?
Docs added?
Would a screenshot be helpful?
Do you want to mention someone?
-->
