### PR TITLE
Make `collapsed` property of Panel component configurable

### DIFF
--- a/src/Panel/Panel/Panel.example.md
+++ b/src/Panel/Panel/Panel.example.md
@@ -18,17 +18,31 @@ import Panel from '@terrestris/react-geo/Panel/Panel/Panel';
 ```jsx
 import Panel from '@terrestris/react-geo/Panel/Panel/Panel';
 
-<Panel
-  style={{position: 'relative'}}
-  x={0}
-  y={0}
-  title="Collapsible"
-  collapsible={true}
->
-  <div style={{padding: '5px'}}>
-    Content
-  </div>
-</Panel>
+<div style={{display: 'flex'}}>
+  <Panel
+    style={{position: 'relative', 'padding-right': '15px'}}
+    x={0}
+    y={0}
+    title="Collapsible"
+    collapsible={true}
+  >
+    <div style={{padding: '5px'}}>
+      Content
+    </div>
+  </Panel>
+  <Panel
+    style={{position: 'relative'}}
+    x={0}
+    y={0}
+    title="Initially collapsed"
+    collapsible={true}
+    collapsed={true}
+  >
+    <div style={{padding: '5px'}}>
+      Content
+    </div>
+  </Panel>
+</div>
 ```
 
 ```jsx

--- a/src/Panel/Panel/Panel.jsx
+++ b/src/Panel/Panel/Panel.jsx
@@ -113,16 +113,22 @@ export class Panel extends React.Component {
      */
     onEscape: PropTypes.func,
     /**
-     * Whether to allow dragging or not.
+     * Whether to allow dragging or not. Default is false.
      * @type {boolean}
      */
     draggable: PropTypes.bool,
 
     /**
-     * Whether to allow collasping or not.
+     * Whether to allow collapsing or not. Default is false.
      * @type {boolean}
      */
     collapsible: PropTypes.bool,
+
+    /**
+     * Whether to show panel collapsed initially or not. Default is false.
+     * @type {boolean}
+     */
+    collapsed: PropTypes.bool,
 
     /**
      * The height of the panel.
@@ -175,6 +181,7 @@ export class Panel extends React.Component {
   static defaultProps = {
     draggable: false,
     collapsible: false,
+    collapsed: false,
     resizeOpts: false,
     titleBarHeight: 37.5,
     tools: [],
@@ -193,7 +200,7 @@ export class Panel extends React.Component {
     const id = props.id || uniqueId('panel-');
     this.state = {
       id: id,
-      collapsed: false,
+      collapsed: this.props.collapsible ? this.props.collapsed : false,
       titleBarHeight: this.props.title ? props.titleBarHeight : 0,
       height: props.height,
       width: props.width,


### PR DESCRIPTION
<!-- Please choose one of the categories and choose the corresponding label, too. -->
## FEATURE 

### Description:
Introduces `collapsed` property on `Panel` to be able to decide whether the component should be rendered collapsed initially or not.

Also provides an appropriate example.

Resolves #1102 

Please review @terrestris/devs 

