### PR TITLE
ZoomButton: Destructure map prop in render

### DIFF
--- a/src/Button/ZoomButton/ZoomButton.jsx
+++ b/src/Button/ZoomButton/ZoomButton.jsx
@@ -116,6 +116,7 @@ class ZoomButton extends React.Component {
       delta,
       animate,
       animateOptions,
+      map,
       ...passThroughProps
     } = this.props;
 


### PR DESCRIPTION
<!-- Please choose one of the categories and choose the corresponding label, too. -->
## BUGFIX

### Description:
<!-- Please describe what this PR is about. -->
This PR adds `map` to prop destructuring in `render` of `ZoomButton`. Otherwise, the map will be passed as object string to antd button.

<!--- CHECKLIST
Fixes Issue?
Examples added?
Tests added?
Docs added?
Would a screenshot be helpful?
Do you want to mention someone?
-->
