### PR TITLE
Fix method name after @terrestris/ol-util major upgrade

### DIFF
--- a/src/Container/AddWmsPanel/AddWmsPanel.example.md
+++ b/src/Container/AddWmsPanel/AddWmsPanel.example.md
@@ -50,7 +50,7 @@ class AddWmsPanelExample extends React.Component {
 
   onClick() {
     CapabilitiesUtil.parseWmsCapabilities(WMS_CAPABILITIES_URL)
-      .then(CapabilitiesUtil.getLayersFromWmsCapabilties)
+      .then(CapabilitiesUtil.getLayersFromWmsCapabilities)
       .then(layers => {
         this.setState({
           layers: layers


### PR DESCRIPTION
<!-- Please choose one of the categories and choose the corresponding label, too. -->
## BUGFIX

### Description:
Fix example for `AddWmsPanel` after [@terrestris/ol-util](https://github.com/terrestris/ol-util/) major upgrade caused by https://github.com/terrestris/ol-util/pull/86

Please review @terrestris/devs 
