### PR TITLE
 Replace canvas-prebuilt with canvas

### DIFF
--- a/jest/setup.js
+++ b/jest/setup.js
@@ -1,5 +1,9 @@
 import Enzyme from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
+import { XMLSerializer } from 'xmldom';
 import 'whatwg-fetch';
+import 'jest-canvas-mock';
+
+global.XMLSerializer = XMLSerializer;
 
 Enzyme.configure({ adapter: new Adapter() });

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "babel-plugin-dynamic-import-node": "2.2.0",
     "babel-plugin-import": "1.12.0",
     "babel-plugin-module-resolver": "3.2.0",
-    "canvas-prebuilt": "1.6.11",
+    "canvas": "2.5.0",
     "coveralls": "3.0.4",
     "css-loader": "2.1.1",
     "enzyme": "3.10.0",

--- a/package.json
+++ b/package.json
@@ -119,6 +119,7 @@
     "eslint-plugin-react": "7.13.0",
     "file-loader": "4.0.0",
     "jest": "24.8.0",
+    "jest-canvas-mock": "2.1.0",
     "less": "3.9.0",
     "less-loader": "5.0.0",
     "np": "5.0.3",
@@ -131,6 +132,7 @@
     "style-loader": "0.23.1",
     "url-loader": "2.0.0",
     "webpack": "4.33.0",
-    "whatwg-fetch": "3.0.0"
+    "whatwg-fetch": "3.0.0",
+    "xmldom": "0.1.27"
   }
 }

--- a/src/Button/DigitizeButton/DigitizeButton.spec.jsx
+++ b/src/Button/DigitizeButton/DigitizeButton.spec.jsx
@@ -120,7 +120,6 @@ describe('<DigitizeButton />', () => {
         expect.stringContaining('Warning: Failed prop type')
       );
 
-      consoleSpy.mockReset();
       consoleSpy.mockRestore();
     });
   });
@@ -148,7 +147,6 @@ describe('<DigitizeButton />', () => {
         wrapper.instance().onToggle(true);
         expect(createDrawInteraction).toHaveBeenCalledTimes(1);
 
-        createDrawInteraction.mockReset();
         createDrawInteraction.mockRestore();
       });
 
@@ -163,7 +161,6 @@ describe('<DigitizeButton />', () => {
         wrapper.instance().onToggle(true);
         expect(createSelectOrModifyInteraction).toHaveBeenCalledTimes(1);
 
-        createSelectOrModifyInteraction.mockReset();
         createSelectOrModifyInteraction.mockRestore();
       });
 
@@ -435,7 +432,6 @@ describe('<DigitizeButton />', () => {
 
         expect(moveFeatureSpy).toHaveBeenCalledTimes(1);
 
-        moveFeatureSpy.mockReset();
         moveFeatureSpy.mockRestore();
       });
     });

--- a/src/Button/MeasureButton/MeasureButton.spec.jsx
+++ b/src/Button/MeasureButton/MeasureButton.spec.jsx
@@ -60,7 +60,6 @@ describe('<MeasureButton />', () => {
         expect.stringContaining('Warning: Failed prop type')
       );
 
-      consoleSpy.mockReset();
       consoleSpy.mockRestore();
     });
 
@@ -210,8 +209,10 @@ describe('<MeasureButton />', () => {
         expect(createHelpTooltipSpy).toHaveBeenCalledTimes(1);
         expect(createMeasureTooltipSpy).toHaveBeenCalledTimes(1);
 
-        jest.resetAllMocks();
-        jest.restoreAllMocks();
+        removeHelpTooltipSpy.mockRestore();
+        removeMeasureTooltipSpy.mockRestore();
+        createHelpTooltipSpy.mockRestore();
+        createMeasureTooltipSpy.mockRestore();
       });
     });
 
@@ -259,8 +260,10 @@ describe('<MeasureButton />', () => {
         expect(createHelpTooltipSpy).toHaveBeenCalledTimes(1);
         expect(clearSpy).toHaveBeenCalledTimes(1);
 
-        jest.resetAllMocks();
-        jest.restoreAllMocks();
+        cleanupTooltipsSpy.mockRestore();
+        createMeasureTooltipSpy.mockRestore();
+        createHelpTooltipSpy.mockRestore();
+        clearSpy.mockRestore();
       });
     });
 
@@ -294,7 +297,6 @@ describe('<MeasureButton />', () => {
 
         expect(unByKeySpy).toHaveBeenCalledTimes(1);
 
-        unByKeySpy.mockReset();
         unByKeySpy.mockRestore();
       });
 
@@ -305,8 +307,7 @@ describe('<MeasureButton />', () => {
         const removeMeasureTooltipSpy = jest.spyOn(instance, 'removeMeasureTooltip');
         instance.onDrawEnd(mockEvt);
         expect(removeMeasureTooltipSpy).toHaveBeenCalledTimes(1);
-        jest.resetAllMocks();
-        jest.restoreAllMocks();
+        removeMeasureTooltipSpy.mockRestore();
       });
 
       it ('sets correct properties on measureTooltipElement', () => {
@@ -335,8 +336,7 @@ describe('<MeasureButton />', () => {
         const createMeasureTooltipSpy = jest.spyOn(instance, 'createMeasureTooltip');
         instance.onDrawEnd(mockEvt);
         expect(createMeasureTooltipSpy).toHaveBeenCalledTimes(1);
-        jest.resetAllMocks();
-        jest.restoreAllMocks();
+        createMeasureTooltipSpy.mockRestore();
       });
     });
 
@@ -673,7 +673,6 @@ describe('<MeasureButton />', () => {
 
         expect(cleanupSpy).toHaveBeenCalledTimes(1);
 
-        cleanupSpy.mockReset();
         cleanupSpy.mockRestore();
       });
 

--- a/src/CircleMenu/CircleMenu.spec.jsx
+++ b/src/CircleMenu/CircleMenu.spec.jsx
@@ -46,7 +46,6 @@ describe('<CircleMenu />', () => {
     })
       .then(() => {
         expect(transformationSpy).toHaveBeenCalledTimes(1);
-        transformationSpy.mockReset();
         transformationSpy.mockRestore();
       });
   });

--- a/src/CircleMenu/CircleMenuItem/CircleMenuItem.spec.jsx
+++ b/src/CircleMenu/CircleMenuItem/CircleMenuItem.spec.jsx
@@ -31,7 +31,6 @@ describe('<CircleMenuItem />', () => {
     })
       .then(() => {
         expect(transformationSpy).toHaveBeenCalledTimes(1);
-        transformationSpy.mockReset();
         transformationSpy.mockRestore();
       });
   });

--- a/src/Field/CoordinateReferenceSystemCombo/CoordinateReferenceSystemCombo.spec.jsx
+++ b/src/Field/CoordinateReferenceSystemCombo/CoordinateReferenceSystemCombo.spec.jsx
@@ -72,7 +72,6 @@ describe('<CoordinateReferenceSystemCombo />', () => {
       expect(loggerSpy).toHaveBeenCalled();
       expect(loggerSpy).toHaveBeenCalledWith('Error while requesting in CoordinateReferenceSystemCombo: Peter');
 
-      loggerSpy.mockReset();
       loggerSpy.mockRestore();
     });
   });

--- a/src/Field/NominatimSearch/NominatimSearch.spec.jsx
+++ b/src/Field/NominatimSearch/NominatimSearch.spec.jsx
@@ -40,7 +40,6 @@ describe('<NominatimSearch />', () => {
       const inputValue = 'Bonn';
       wrapper.instance().onUpdateInput(inputValue);
       expect(fetchSpy).toHaveBeenCalled();
-      fetchSpy.mockReset();
       fetchSpy.mockRestore();
     });
   });
@@ -70,7 +69,6 @@ describe('<NominatimSearch />', () => {
       expectations.forEach(expectation => {
         expect(fetchUrl).toMatch(expectation);
       });
-      fetchSpy.mockReset();
       fetchSpy.mockRestore();
     });
   });
@@ -94,7 +92,6 @@ describe('<NominatimSearch />', () => {
       wrapper.instance().onFetchError('Peter');
       expect(loggerSpy).toHaveBeenCalled();
       expect(loggerSpy).toHaveBeenCalledWith('Error while requesting Nominatim: Peter');
-      loggerSpy.mockReset();
       loggerSpy.mockRestore();
     });
   });
@@ -128,7 +125,6 @@ describe('<NominatimSearch />', () => {
       expect(selectSpy).toHaveBeenCalled();
       expect(selectSpy).toHaveBeenCalledWith(dataSource[0], map);
 
-      selectSpy.mockReset();
       selectSpy.mockRestore();
     });
   });
@@ -162,7 +158,6 @@ describe('<NominatimSearch />', () => {
       wrapper.props().onSelect(item, map);
       expect(fitSpy).toHaveBeenCalled();
       expect(fitSpy).toHaveBeenCalledWith(transformedExtent, expect.any(Object) );
-      fitSpy.mockReset();
       fitSpy.mockRestore();
     });
   });

--- a/src/Field/ScaleCombo/ScaleCombo.spec.jsx
+++ b/src/Field/ScaleCombo/ScaleCombo.spec.jsx
@@ -60,7 +60,6 @@ describe('<ScaleCombo />', () => {
       });
       wrapper.instance().getOptionsFromMap();
       expect(logSpy).toHaveBeenCalled();
-      logSpy.mockReset();
       logSpy.mockRestore();
 
       TestUtil.removeMap(map);

--- a/src/Field/WfsSearch/WfsSearch.spec.jsx
+++ b/src/Field/WfsSearch/WfsSearch.spec.jsx
@@ -44,11 +44,11 @@ describe('<WfsSearch />', () => {
           'osm:osm-country-borders': ['name']
         }
       });
-      wrapper.instance().doSearch = jest.fn();
+      const doSearchSpy = jest.spyOn(wrapper.instance(), 'doSearch');
       const inputValue = 'Deutsch';
       wrapper.instance().onUpdateInput(inputValue);
-      expect(wrapper.instance().doSearch).toHaveBeenCalled();
-      wrapper.instance().doSearch.mockReset();
+      expect(doSearchSpy).toHaveBeenCalled();
+      doSearchSpy.mockRestore();
     });
   });
 
@@ -80,7 +80,6 @@ describe('<WfsSearch />', () => {
       wrapper.instance().onFetchError('Peter');
       expect(loggerSpy).toHaveBeenCalled();
       expect(loggerSpy).toHaveBeenCalledWith('Error while requesting WFS GetFeature: Peter');
-      loggerSpy.mockReset();
       loggerSpy.mockRestore();
     });
   });
@@ -116,7 +115,6 @@ describe('<WfsSearch />', () => {
       expect(selectSpy).toHaveBeenCalled();
       expect(selectSpy).toHaveBeenCalledWith(data[0], map);
 
-      selectSpy.mockReset();
       selectSpy.mockRestore();
     });
   });
@@ -159,7 +157,6 @@ describe('<WfsSearch />', () => {
         .then(() => {
           expect(map.getView().getCenter()).toEqual([25, 25]);
           expect(map.getView().getZoom()).toEqual(2);
-          fitSpy.mockReset();
           fitSpy.mockRestore();
         });
     });

--- a/src/Field/WfsSearchInput/WfsSearchInput.spec.jsx
+++ b/src/Field/WfsSearchInput/WfsSearchInput.spec.jsx
@@ -59,15 +59,15 @@ describe('<WfsSearchInput />', () => {
           'osm:osm-country-borders': ['name']
         }
       });
-      wrapper.instance().doSearch = jest.fn();
+      const doSearchSpy = jest.spyOn(wrapper.instance(), 'doSearch');
       const evt = {
         target: {
           value: 'abc'
         }
       };
       wrapper.instance().onUpdateInput(evt);
-      expect(wrapper.instance().doSearch).toHaveBeenCalled();
-      wrapper.instance().doSearch.mockReset();
+      expect(doSearchSpy).toHaveBeenCalled();
+      doSearchSpy.mockRestore();
     });
   });
 
@@ -99,7 +99,6 @@ describe('<WfsSearchInput />', () => {
       wrapper.instance().onFetchError('Peter');
       expect(loggerSpy).toHaveBeenCalled();
       expect(loggerSpy).toHaveBeenCalledWith('Error while requesting WFS GetFeature: Peter');
-      loggerSpy.mockReset();
       loggerSpy.mockRestore();
     });
   });

--- a/src/Grid/AgFeatureGrid/AgFeatureGrid.spec.jsx
+++ b/src/Grid/AgFeatureGrid/AgFeatureGrid.spec.jsx
@@ -95,7 +95,6 @@ describe('<AgFeatureGrid />', () => {
     expect(mapOnSpy).toHaveBeenCalledWith('pointermove', onPointerMove);
     expect(mapOnSpy).toHaveBeenCalledWith('singleclick', onMapSingleClick);
 
-    mapOnSpy.mockReset();
     mapOnSpy.mockRestore();
   });
 
@@ -112,7 +111,6 @@ describe('<AgFeatureGrid />', () => {
     expect(mapUnSpy).toHaveBeenCalledWith('pointermove', onPointerMove);
     expect(mapUnSpy).toHaveBeenCalledWith('singleclick', onMapSingleClick);
 
-    mapUnSpy.mockReset();
     mapUnSpy.mockRestore();
   });
 
@@ -234,10 +232,7 @@ describe('<AgFeatureGrid />', () => {
     expect(onRowClickSpy).toHaveBeenCalled();
     expect(zoomToFeaturesSpy).not.toHaveBeenCalled();
 
-    onRowClickSpy.mockReset();
     onRowClickSpy.mockRestore();
-
-    zoomToFeaturesSpy.mockReset();
     zoomToFeaturesSpy.mockRestore();
   });
 
@@ -256,10 +251,7 @@ describe('<AgFeatureGrid />', () => {
     expect(onRowMouseOverSpy).toHaveBeenCalled();
     expect(highlightFeaturesSpy).toHaveBeenCalled();
 
-    onRowMouseOverSpy.mockReset();
     onRowMouseOverSpy.mockRestore();
-
-    highlightFeaturesSpy.mockReset();
     highlightFeaturesSpy.mockRestore();
   });
 
@@ -288,7 +280,6 @@ describe('<AgFeatureGrid />', () => {
     expect(wrapper.instance()._source.getFeatures()).toEqual(features);
     expect(zoomToFeaturesSpy).toHaveBeenCalled();
 
-    zoomToFeaturesSpy.mockReset();
     zoomToFeaturesSpy.mockRestore();
 
     const mapOnSpy = jest.spyOn(map, 'on');
@@ -299,7 +290,6 @@ describe('<AgFeatureGrid />', () => {
 
     expect(mapOnSpy).toHaveBeenCalled();
 
-    mapOnSpy.mockReset();
     mapOnSpy.mockRestore();
 
     const mapUnSpy = jest.spyOn(map, 'un');
@@ -310,7 +300,6 @@ describe('<AgFeatureGrid />', () => {
 
     expect(mapUnSpy).toHaveBeenCalled();
 
-    mapUnSpy.mockReset();
     mapUnSpy.mockRestore();
   });
 

--- a/src/Grid/FeatureGrid/FeatureGrid.spec.jsx
+++ b/src/Grid/FeatureGrid/FeatureGrid.spec.jsx
@@ -93,7 +93,6 @@ describe('<FeatureGrid />', () => {
     expect(mapOnSpy).toHaveBeenCalledWith('pointermove', onPointerMove);
     expect(mapOnSpy).toHaveBeenCalledWith('singleclick', onMapSingleClick);
 
-    mapOnSpy.mockReset();
     mapOnSpy.mockRestore();
   });
 
@@ -110,7 +109,6 @@ describe('<FeatureGrid />', () => {
     expect(mapUnSpy).toHaveBeenCalledWith('pointermove', onPointerMove);
     expect(mapUnSpy).toHaveBeenCalledWith('singleclick', onMapSingleClick);
 
-    mapUnSpy.mockReset();
     mapUnSpy.mockRestore();
   });
 
@@ -266,10 +264,7 @@ describe('<FeatureGrid />', () => {
     expect(onRowClickSpy).toHaveBeenCalled();
     expect(zoomToFeaturesSpy).toHaveBeenCalled();
 
-    onRowClickSpy.mockReset();
     onRowClickSpy.mockRestore();
-
-    zoomToFeaturesSpy.mockReset();
     zoomToFeaturesSpy.mockRestore();
   });
 
@@ -286,10 +281,7 @@ describe('<FeatureGrid />', () => {
     expect(onRowMouseOverSpy).toHaveBeenCalled();
     expect(highlightFeaturesSpy).toHaveBeenCalled();
 
-    onRowMouseOverSpy.mockReset();
     onRowMouseOverSpy.mockRestore();
-
-    highlightFeaturesSpy.mockReset();
     highlightFeaturesSpy.mockRestore();
   });
 
@@ -306,10 +298,7 @@ describe('<FeatureGrid />', () => {
     expect(onRowMouseOutSpy).toHaveBeenCalled();
     expect(unhighlightFeaturesSpy).toHaveBeenCalled();
 
-    onRowMouseOutSpy.mockReset();
     onRowMouseOutSpy.mockRestore();
-
-    unhighlightFeaturesSpy.mockReset();
     unhighlightFeaturesSpy.mockRestore();
   });
 
@@ -338,7 +327,6 @@ describe('<FeatureGrid />', () => {
     expect(wrapper.instance()._source.getFeatures()).toEqual(features);
     expect(zoomToFeaturesSpy).toHaveBeenCalled();
 
-    zoomToFeaturesSpy.mockReset();
     zoomToFeaturesSpy.mockRestore();
 
     const mapOnSpy = jest.spyOn(map, 'on');
@@ -349,7 +337,6 @@ describe('<FeatureGrid />', () => {
 
     expect(mapOnSpy).toHaveBeenCalled();
 
-    mapOnSpy.mockReset();
     mapOnSpy.mockRestore();
 
     const mapUnSpy = jest.spyOn(map, 'un');
@@ -361,7 +348,6 @@ describe('<FeatureGrid />', () => {
     expect(mapUnSpy).toHaveBeenCalled();
     expect(wrapper.state('selectedRowKeys')).toEqual([]);
 
-    mapUnSpy.mockReset();
     mapUnSpy.mockRestore();
   });
 
@@ -380,7 +366,6 @@ describe('<FeatureGrid />', () => {
     expect(features[1].getStyle()).toEqual(null);
     expect(features[2].getStyle()).toEqual(null);
 
-    getFeaturesAtPixelSpy.mockReset();
     getFeaturesAtPixelSpy.mockRestore();
   });
 
@@ -396,7 +381,6 @@ describe('<FeatureGrid />', () => {
 
     expect(features[0].getStyle()).toEqual(wrapper.prop('selectStyle'));
 
-    getFeaturesAtPixelSpy.mockReset();
     getFeaturesAtPixelSpy.mockRestore();
   });
 

--- a/src/HigherOrderComponent/MappifiedComponent/MappifiedComponent.spec.jsx
+++ b/src/HigherOrderComponent/MappifiedComponent/MappifiedComponent.spec.jsx
@@ -54,7 +54,6 @@ describe('mappify', () => {
       expect(loggerSpy).toHaveBeenCalledWith('You trying to mappify a ' +
         'component without any map in the context. Did you implement ' +
         'the MapProvider?');
-      loggerSpy.mockReset();
       loggerSpy.mockRestore();
     });
 

--- a/src/LayerTree/LayerTree.spec.jsx
+++ b/src/LayerTree/LayerTree.spec.jsx
@@ -138,7 +138,6 @@ describe('<LayerTree />', () => {
       const rebuildSpy = jest.spyOn(wrapper.instance(), 'rebuildTreeNodes');
       map.getLayerGroup().setLayers(new OlCollection([subLayer]));
       expect(rebuildSpy).toHaveBeenCalled();
-      rebuildSpy.mockReset();
       rebuildSpy.mockRestore();
     });
 
@@ -246,7 +245,6 @@ describe('<LayerTree />', () => {
 
         expect(logSpy).toHaveBeenCalled();
 
-        logSpy.mockReset();
         logSpy.mockRestore();
         layerGroup.setVisible(true);
       });
@@ -335,7 +333,6 @@ describe('<LayerTree />', () => {
       });
       expect(rebuildSpy).toHaveBeenCalledTimes(2);
 
-      rebuildSpy.mockReset();
       rebuildSpy.mockRestore();
     });
 
@@ -353,7 +350,6 @@ describe('<LayerTree />', () => {
       layerGroup.getLayers().push(layer);
       expect(rebuildSpy).toHaveBeenCalled();
 
-      rebuildSpy.mockReset();
       rebuildSpy.mockRestore();
     });
 
@@ -376,9 +372,7 @@ describe('<LayerTree />', () => {
       expect(rebuildSpy).toHaveBeenCalled();
       expect(registerSpy).toHaveBeenCalled();
 
-      rebuildSpy.mockReset();
       rebuildSpy.mockRestore();
-      registerSpy.mockReset();
       registerSpy.mockRestore();
     });
 
@@ -395,9 +389,7 @@ describe('<LayerTree />', () => {
       expect(rebuildSpy).toHaveBeenCalled();
       expect(unregisterSpy).toHaveBeenCalled();
 
-      rebuildSpy.mockReset();
       rebuildSpy.mockRestore();
-      unregisterSpy.mockReset();
       unregisterSpy.mockRestore();
     });
 
@@ -426,9 +418,7 @@ describe('<LayerTree />', () => {
       expect(rebuildSpy).toHaveBeenCalledTimes(1);
       expect(unregisterSpy).toHaveBeenCalledTimes(3);
 
-      rebuildSpy.mockReset();
       rebuildSpy.mockRestore();
-      unregisterSpy.mockReset();
       unregisterSpy.mockRestore();
     });
 
@@ -517,7 +507,6 @@ describe('<LayerTree />', () => {
       wrapper.instance().setLayerVisibility(layer1 , 'peter');
       expect(logSpy).toHaveBeenCalled();
 
-      logSpy.mockReset();
       logSpy.mockRestore();
     });
 

--- a/src/Panel/Panel/Panel.spec.jsx
+++ b/src/Panel/Panel/Panel.spec.jsx
@@ -61,8 +61,9 @@ describe('<Panel />', () => {
       expect(onEscSpy).toHaveBeenCalledTimes(1);
       expect(focusSpy).toHaveBeenCalledTimes(1);
       expect(element.className).toContain(document.activeElement.className);
-      jest.resetAllMocks();
-      jest.restoreAllMocks();
+
+      onEscSpy.mockRestore();
+      focusSpy.mockRestore();
     });
   });
 

--- a/src/Window/Window.spec.jsx
+++ b/src/Window/Window.spec.jsx
@@ -32,7 +32,6 @@ describe('<Window />', () => {
       'Please ensure that parentId parameter was set correctly (default ' +
       'value is `app`)');
 
-    loggerSpy.mockReset();
     loggerSpy.mockRestore();
   });
 


### PR DESCRIPTION
<!-- Please choose one of the categories and choose the corresponding label, too. -->
## DEVSETUP

### Description:
<!-- Please describe what this PR is about. -->
This replaces the `canvas-prebuilt` with the `canvas` dependency. 

In addition all calls to `jest.resetAllMocks()` and `jest.restoreAllMocks()` are removed as they would also restore the newly introduced `jest-canvas-mock` functionality. Calls to `mockFn.mockReset()` are removed as well, because it will be called by `mockFn.mockRestore()` anyways (see [here](https://jestjs.io/docs/en/mock-function-api.html#mockfnmockrestore)).

Fixes #1118.

<!--- CHECKLIST
Fixes Issue?
Examples added?
Tests added?
Docs added?
Would a screenshot be helpful?
Do you want to mention someone?
-->
