### PR TITLE
Fix unsupported style property padding-right

### DIFF
--- a/src/Panel/Panel/Panel.example.md
+++ b/src/Panel/Panel/Panel.example.md
@@ -20,7 +20,7 @@ import Panel from '@terrestris/react-geo/Panel/Panel/Panel';
 
 <div style={{display: 'flex'}}>
   <Panel
-    style={{position: 'relative', 'padding-right': '15px'}}
+    style={{position: 'relative', paddingRight: '15px'}}
     x={0}
     y={0}
     title="Collapsible"


### PR DESCRIPTION
<!-- Please choose one of the categories and choose the corresponding label, too. -->
## BUGFIX

### Description:
Fix unsupported style property `padding-right` to get rid of warning in example for panel component:

`Warning: Unsupported style property padding-right. Did you mean paddingRight?`

Please review @terrestris/devs 
