### PR TITLE
Copy docs to latest for tags too

### DIFF
--- a/.ci/update-gh-pages.sh
+++ b/.ci/update-gh-pages.sh
@@ -62,13 +62,16 @@ cp $TRAVIS_BUILD_DIR/assets/favicon.ico ./assets/favicon.ico
 mkdir -p $SRC_DIR/styleguide/assets
 cp $TRAVIS_BUILD_DIR/assets/logo.svg $SRC_DIR/styleguide/assets/
 
+# Copy to latest
 if [ "$TRAVIS_BRANCH" = "master" ]; then
   cp -r $SRC_DIR/styleguide/ docs/latest/
 fi
 
+# Copy to latest and tag
 if [ -n "$TRAVIS_TAG" ]; then
   mkdir -p docs/v$VERSION
   cp -r $SRC_DIR/styleguide/. docs/v$VERSION/
+  cp -r $SRC_DIR/styleguide/ docs/latest/
 fi
 
 git add .


### PR DESCRIPTION
<!-- Please choose one of the categories and choose the corresponding label, too. -->
## BUGFIX | DOCUMENTATION

### Description:
<!-- Please describe what this PR is about. -->
This modifies the `update-gh-pages.sh` to also copy the docs to `latest` when a tag is pushed.
Previously pushing tags only [removed](https://github.com/terrestris/react-geo/blob/master/.ci/update-gh-pages.sh#L55) the `latest` folder but didn't copy the new docs.

Thx for the hint @cwillmes

<!--- CHECKLIST
Fixes Issue?
Examples added?
Tests added?
Docs added?
Would a screenshot be helpful?
Do you want to mention someone?
-->
