### PR TITLE
Unset the map's target on unmount

### DIFF
--- a/src/Map/MapComponent/MapComponent.jsx
+++ b/src/Map/MapComponent/MapComponent.jsx
@@ -30,20 +30,32 @@ export class MapComponent extends PureComponent {
 
   /**
    * Create a MapComponent.
-   *
-   * @constructs Map
    */
   constructor(props) {
     super(props);
   }
 
   /**
-   * The componentDidMount function
-   *
-   * @method componentDidMount
+   * The componentDidMount function.
    */
   componentDidMount() {
-    this.props.map.setTarget(this.props.mapDivId);
+    const {
+      map,
+      mapDivId
+    } = this.props;
+
+    map.setTarget(mapDivId);
+  }
+
+  /**
+   * The componentWillUnmount function.
+   */
+  componentWillUnmount() {
+    const {
+      map
+    } = this.props;
+
+    map.setTarget(null);
   }
 
   /**


### PR DESCRIPTION
<!-- Please choose one of the categories and choose the corresponding label, too. -->
## BUGFIX

### Description:
<!-- Please describe what this PR is about. -->
Unsets the target of the `ol.Map` if the `MapComponent` will unmount. This is needed, if the `MapComponent` runs through the lifecycle multiple times, e.g. in a routable application, as the map's target won't be set if the target has been set before.

Fixes #1216.

<!--- CHECKLIST
Fixes Issue?
Examples added?
Tests added?
Docs added?
Would a screenshot be helpful?
Do you want to mention someone?
-->
