### PR TITLE
Update antd to the latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@ant-design/colors": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@ant-design/colors/-/colors-3.1.0.tgz",
-      "integrity": "sha512-Td7g1P53sNFyT4Gya6836e70TrhoVZ+HjZs6mpWIHrxl4/VqsjjOyzj/8ktOuw0lCx+BfYu9UO1CiJ0MoYYfhg==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@ant-design/colors/-/colors-3.2.1.tgz",
+      "integrity": "sha512-ibJybOcR1+h2IEr0Yxx4y/Wcz8obEtKvl2EYvxh8ugMkYniGSItpLKGzKNyyqzOaum5jb6fVCyH1aR9VkdpFRA==",
       "dev": true,
       "requires": {
         "tinycolor2": "^1.4.1"
@@ -2898,15 +2898,15 @@
       "dev": true
     },
     "@types/prop-types": {
-      "version": "15.7.1",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.1.tgz",
-      "integrity": "sha512-CFzn9idOEpHrgdw8JsoTkaDDyRWk1jrzIV8djzcgpq0y9tG4B4lFT+Nxh52DVpDXV+n4+NPNv7M1Dj5uMp6XFg==",
+      "version": "15.7.2",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.2.tgz",
+      "integrity": "sha512-f8JzJNWVhKtc9dg/dyDNfliTKNOJSLa7Oht/ElZdF/UbMUmAH3rLmAk3ODNjw0mZajDEgatA03tRjB4+Dp/tzA==",
       "dev": true
     },
     "@types/react": {
-      "version": "16.8.23",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.8.23.tgz",
-      "integrity": "sha512-abkEOIeljniUN9qB5onp++g0EY38h7atnDHxwKUFz1r3VH1+yG1OKi2sNPTyObL40goBmfKFpdii2lEzwLX1cA==",
+      "version": "16.9.2",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.2.tgz",
+      "integrity": "sha512-jYP2LWwlh+FTqGd9v7ynUKZzjj98T8x7Yclz479QdRhHfuW9yQ+0jjnD31eXSXutmBpppj5PYNLYLRfnZJvcfg==",
       "dev": true,
       "requires": {
         "@types/prop-types": "*",
@@ -3375,13 +3375,13 @@
       }
     },
     "antd": {
-      "version": "3.20.0",
-      "resolved": "https://registry.npmjs.org/antd/-/antd-3.20.0.tgz",
-      "integrity": "sha512-PnYXyCzB9S9SkWixYGi2D0u+FzAeDO2YJTD0x+/8zGZvcCrPahNuvZkLkjMxLd7eJnbfsg6yWHRB2ZRs6tJRZg==",
+      "version": "3.23.2",
+      "resolved": "https://registry.npmjs.org/antd/-/antd-3.23.2.tgz",
+      "integrity": "sha512-S62EvyxPV0IoFR650qtCjUy2E7nY3JkxTP1t71LER09DTTK4fJGw4wWhalNCjkIHR2hPHWGfu0MSHocov3F4dw==",
       "dev": true,
       "requires": {
         "@ant-design/create-react-context": "^0.2.4",
-        "@ant-design/icons": "~2.1.0",
+        "@ant-design/icons": "~2.1.1",
         "@ant-design/icons-react": "~2.0.1",
         "@types/react-slick": "^0.23.4",
         "array-tree-filter": "^2.1.0",
@@ -3391,47 +3391,55 @@
         "css-animation": "^1.5.0",
         "dom-closest": "^0.2.0",
         "enquire.js": "^2.1.6",
-        "lodash": "^4.17.11",
+        "lodash": "^4.17.13",
         "moment": "^2.24.0",
         "omit.js": "^1.0.2",
         "prop-types": "^15.7.2",
         "raf": "^3.4.1",
         "rc-animate": "^2.8.3",
-        "rc-calendar": "~9.15.0",
+        "rc-calendar": "~9.15.5",
         "rc-cascader": "~0.17.4",
         "rc-checkbox": "~2.1.6",
         "rc-collapse": "~1.11.3",
-        "rc-dialog": "~7.4.0",
-        "rc-drawer": "~1.10.1",
+        "rc-dialog": "~7.5.2",
+        "rc-drawer": "~2.0.1",
         "rc-dropdown": "~2.4.1",
         "rc-editor-mention": "^1.1.13",
         "rc-form": "^2.4.5",
-        "rc-input-number": "~4.4.5",
-        "rc-mentions": "~0.3.1",
+        "rc-input-number": "~4.5.0",
+        "rc-mentions": "~0.4.0",
         "rc-menu": "~7.4.23",
         "rc-notification": "~3.3.1",
-        "rc-pagination": "~1.20.1",
+        "rc-pagination": "~1.20.5",
         "rc-progress": "~2.5.0",
         "rc-rate": "~2.5.0",
-        "rc-select": "~9.1.4",
+        "rc-select": "~9.2.0",
         "rc-slider": "~8.6.11",
-        "rc-steps": "~3.4.1",
+        "rc-steps": "~3.5.0",
         "rc-switch": "~1.9.0",
-        "rc-table": "~6.6.0",
+        "rc-table": "~6.7.0",
         "rc-tabs": "~9.6.4",
         "rc-time-picker": "~3.7.1",
         "rc-tooltip": "~3.7.3",
         "rc-tree": "~2.1.0",
         "rc-tree-select": "~2.9.1",
         "rc-trigger": "^2.6.2",
-        "rc-upload": "~2.6.7",
-        "rc-util": "^4.6.0",
+        "rc-upload": "~2.7.0",
+        "rc-util": "^4.10.0",
         "react-lazy-load": "^3.0.13",
         "react-lifecycles-compat": "^3.0.4",
-        "react-slick": "~0.24.0",
+        "react-slick": "~0.25.2",
         "resize-observer-polyfill": "^1.5.1",
         "shallowequal": "^1.1.0",
         "warning": "~4.0.3"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
+        }
       }
     },
     "any-observable": {
@@ -3709,13 +3717,10 @@
       "dev": true
     },
     "async-validator": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/async-validator/-/async-validator-1.11.3.tgz",
-      "integrity": "sha512-Xeyt+fpqTSYeC++J/M/KkBq8UEGiAkjjKTirKhvkR9M9q+iZNCsv6ffVWNySllAuNPZ+SqzKMgBuvWHILjHatg==",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.x"
-      }
+      "version": "1.11.5",
+      "resolved": "https://registry.npmjs.org/async-validator/-/async-validator-1.11.5.tgz",
+      "integrity": "sha512-XNtCsMAeAH1pdLMEg1z8/Bb3a8cdCbui9QbJATRFHHHW5kT6+NPI3zSVQUXgikTFITzsg+kYY5NTWhM2Orwt9w==",
+      "dev": true
     },
     "asynckit": {
       "version": "0.4.0",
@@ -5374,16 +5379,6 @@
         "object-assign": "^4.1.1"
       }
     },
-    "create-react-context": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/create-react-context/-/create-react-context-0.2.2.tgz",
-      "integrity": "sha512-KkpaLARMhsTsgp0d2NA/R94F/eDLbhXERdIq3LvX2biCAXcDvHYoOqHfWCHf1+OLj+HKBotLG3KqaOOf+C1C+A==",
-      "dev": true,
-      "requires": {
-        "fbjs": "^0.8.0",
-        "gud": "^1.0.0"
-      }
-    },
     "cross-spawn": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
@@ -5423,9 +5418,9 @@
       "dev": true
     },
     "css-animation": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/css-animation/-/css-animation-1.5.0.tgz",
-      "integrity": "sha512-hWYoWiOZ7Vr20etzLh3kpWgtC454tW5vn4I6rLANDgpzNSkO7UfOqyCEeaoBSG9CYWQpRkFWTWbWW8o3uZrNLw==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/css-animation/-/css-animation-1.6.1.tgz",
+      "integrity": "sha512-/48+/BaEaHRY6kNQ2OIPzKf9A6g8WjZYjhiNDNuIVbsm5tXCGIAsHDjB4Xu1C4vXJtUWZo26O68OQkDpNBaPog==",
       "dev": true,
       "requires": {
         "babel-runtime": "6.x",
@@ -5504,9 +5499,9 @@
       }
     },
     "csstype": {
-      "version": "2.6.5",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.5.tgz",
-      "integrity": "sha512-JsTaiksRsel5n7XwqPAfB0l3TFKdpjW/kgAELf9vrb5adGA7UCPLajKK5s3nFrcFm3Rkyp/Qkgl73ENc1UY3cA==",
+      "version": "2.6.6",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.6.tgz",
+      "integrity": "sha512-RpFbQGUE74iyPgvr46U9t1xoQBM8T4BL8SxrN66Le2xYAPSaDJJKeztV3awugusb3g3G9iL8StmkBBXhcbbXhg==",
       "dev": true
     },
     "currently-unhandled": {
@@ -5915,9 +5910,9 @@
       }
     },
     "dom-align": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/dom-align/-/dom-align-1.9.0.tgz",
-      "integrity": "sha512-HvPfXISxoU7dKrbqS4vIFa1hx88wD7VdKaZ7sHWeow8y76tuzsxXkiPGbeilemLXrTd9cWbPqR4MOl4y3dkcXA==",
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/dom-align/-/dom-align-1.10.2.tgz",
+      "integrity": "sha512-AYZUzLepy05E9bCY4ExoqHrrIlM49PEak9oF93JEFoibqKL0F7w5DLM70/rosLOawerWZ3MlepQcl+EmHskOyw==",
       "dev": true
     },
     "dom-closest": {
@@ -12836,9 +12831,9 @@
       }
     },
     "rc-animate": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/rc-animate/-/rc-animate-2.8.3.tgz",
-      "integrity": "sha512-VPSHJF/PW9zrPVCdQ94/YOI2lFfJVlaiAeQveJN2nlPVMivgvXkuFJyfe42GbZqm+qlnRjH9B4WbY9rCZz9miw==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/rc-animate/-/rc-animate-2.10.0.tgz",
+      "integrity": "sha512-gZM3WteZO0e3X8B71KP0bs95EY2tAPRuiZyKnlhdLpOjTX/64SrhDZM3pT2Z8mJjKWNiiB5q2SSSf+BD8ljwVw==",
       "dev": true,
       "requires": {
         "babel-runtime": "6.x",
@@ -12846,13 +12841,14 @@
         "css-animation": "^1.3.2",
         "prop-types": "15.x",
         "raf": "^3.4.0",
+        "rc-util": "^4.8.0",
         "react-lifecycles-compat": "^3.0.4"
       }
     },
     "rc-calendar": {
-      "version": "9.15.3",
-      "resolved": "https://registry.npmjs.org/rc-calendar/-/rc-calendar-9.15.3.tgz",
-      "integrity": "sha512-Z1pmNkdNIbCGNU/IWHbPK5/9DXzpDsN3aZQYJ3UnOrvOWEcQZhBHzc7g1qTBO1iWiIwn6nphpOWkonVdRzKqvg==",
+      "version": "9.15.5",
+      "resolved": "https://registry.npmjs.org/rc-calendar/-/rc-calendar-9.15.5.tgz",
+      "integrity": "sha512-nvoEXk5P0DADt5b7FHlKiXKj+IhoWawQGSkb5soa6gXQIfoqQJ5+zB2Ogy7k1RxNbxQu4iIkEW/a3+HObVRDdA==",
       "dev": true,
       "requires": {
         "babel-runtime": "6.x",
@@ -12865,9 +12861,9 @@
       }
     },
     "rc-cascader": {
-      "version": "0.17.4",
-      "resolved": "https://registry.npmjs.org/rc-cascader/-/rc-cascader-0.17.4.tgz",
-      "integrity": "sha512-CeFQJIMzY7x++uPqlx4Xl/cH8iTs8nRoW522+DLb21kdL5kWqKlK+3iHXExoxcAymjwo5ScIiXi+NY4m8Pgq9w==",
+      "version": "0.17.5",
+      "resolved": "https://registry.npmjs.org/rc-cascader/-/rc-cascader-0.17.5.tgz",
+      "integrity": "sha512-WYMVcxU0+Lj+xLr4YYH0+yXODumvNXDcVEs5i7L1mtpWwYkubPV/zbQpn+jGKFCIW/hOhjkU4J1db8/P/UKE7A==",
       "dev": true,
       "requires": {
         "array-tree-filter": "^2.1.0",
@@ -12892,9 +12888,9 @@
       }
     },
     "rc-collapse": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/rc-collapse/-/rc-collapse-1.11.3.tgz",
-      "integrity": "sha512-yECQX2iDPWnKcVi3Wz5bomZuJ2u+wv+kGxuKo2GIRz7Brh9jkGQz5ElghCV1jqDGnzy8GIRxxHHSwlSgdxdUog==",
+      "version": "1.11.7",
+      "resolved": "https://registry.npmjs.org/rc-collapse/-/rc-collapse-1.11.7.tgz",
+      "integrity": "sha512-ge3EEzIFtrDGuPX4bxXdQqwb91JnPIdj3B+FU88yNOUeOroNuA2q9kVK+UatpQ1Eft5hNo/ICTDrVFi8+685ng==",
       "dev": true,
       "requires": {
         "classnames": "2.x",
@@ -12902,30 +12898,31 @@
         "prop-types": "^15.5.6",
         "rc-animate": "2.x",
         "react-is": "^16.7.0",
+        "react-lifecycles-compat": "^3.0.4",
         "shallowequal": "^1.1.0"
       }
     },
     "rc-dialog": {
-      "version": "7.4.1",
-      "resolved": "https://registry.npmjs.org/rc-dialog/-/rc-dialog-7.4.1.tgz",
-      "integrity": "sha512-vvVVP7AUjxs2AEGL5GUr6BjfVzaiBV5RoiPYchCDqHmf8n7xTrfsACAhZ2Vezj6mtl2446zhxoGvhxNpyCyX7A==",
+      "version": "7.5.7",
+      "resolved": "https://registry.npmjs.org/rc-dialog/-/rc-dialog-7.5.7.tgz",
+      "integrity": "sha512-hSKzxdbkWylenjdyNwUPz2Wb4pkmpFld/Qp7u5uhXhlLUTUjQceCj+VFXHWKfBGlesm34SD4wNl4ZvyEYIAdNA==",
       "dev": true,
       "requires": {
         "babel-runtime": "6.x",
         "rc-animate": "2.x",
-        "rc-util": "^4.4.0"
+        "rc-util": "^4.8.1"
       }
     },
     "rc-drawer": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/rc-drawer/-/rc-drawer-1.10.1.tgz",
-      "integrity": "sha512-2KufXkWK9N19eGYmUldIe6sYaC6IIVrts6v8WXnPuIoI9zVPGnwXnK/of+lQEBhidEPBBMBXnvTdGwvTpl60vQ==",
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/rc-drawer/-/rc-drawer-2.0.9.tgz",
+      "integrity": "sha512-7qwEND3TLvJeyuUvZfMDkL2pHsR/XHX5HvoaBlIH9mTcFWBmMNrvYGDuGHgGsdNKZZgIBwlkvl5vhckydTUc9Q==",
       "dev": true,
       "requires": {
         "babel-runtime": "6.x",
         "classnames": "^2.2.5",
-        "prop-types": "^15.5.0",
-        "rc-util": "^4.5.1"
+        "rc-util": "^4.7.0",
+        "react-lifecycles-compat": "^3.0.4"
       }
     },
     "rc-dropdown": {
@@ -12999,9 +12996,9 @@
       }
     },
     "rc-input-number": {
-      "version": "4.4.5",
-      "resolved": "https://registry.npmjs.org/rc-input-number/-/rc-input-number-4.4.5.tgz",
-      "integrity": "sha512-Dt20e8Ylc/N/6oXiPUlwDVdx3fz7W5umUOa4z5pBuWFG7NPlBVXRWkq7+nbnTyaK24UxN67PVpmD3+Omo+QRZQ==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/rc-input-number/-/rc-input-number-4.5.0.tgz",
+      "integrity": "sha512-0igTdXuxVykBB82jafUmhbRVmgtd0FuGSIX4SbrynGNrLDOyze3EUKsZl+LyQ4JMRXLrcuZKJg385880RVLA2w==",
       "dev": true,
       "requires": {
         "babel-runtime": "6.x",
@@ -13012,13 +13009,12 @@
       }
     },
     "rc-mentions": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/rc-mentions/-/rc-mentions-0.3.1.tgz",
-      "integrity": "sha512-fa5dN3IMTahJfAga1nmma9OymK/ZBV/MZfV11h4kjDmCAVETv5EbAlV0mn6Y+JajvXS6n/XFoPUSF+nwK/AeWw==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/rc-mentions/-/rc-mentions-0.4.0.tgz",
+      "integrity": "sha512-xnkQBTUFp4llaJuDOLVFKX9ELrXFHk1FuUdIIC/ijQ6cLjDhCUu+jpHNcXWuQ/yIFzF376VlXkmT57iqxSnZzw==",
       "dev": true,
       "requires": {
         "@ant-design/create-react-context": "^0.2.4",
-        "babel-runtime": "^6.23.0",
         "classnames": "^2.2.6",
         "rc-menu": "^7.4.22",
         "rc-trigger": "^2.6.2",
@@ -13027,9 +13023,9 @@
       }
     },
     "rc-menu": {
-      "version": "7.4.23",
-      "resolved": "https://registry.npmjs.org/rc-menu/-/rc-menu-7.4.23.tgz",
-      "integrity": "sha512-d0pUMN0Zr3GCFxNpas8p7AUTeX8viItUOQXku4AsyX82ZzUz79HgGul2Nk17BIFTtLzqdB7/NT6WVb5PAOOILw==",
+      "version": "7.4.28",
+      "resolved": "https://registry.npmjs.org/rc-menu/-/rc-menu-7.4.28.tgz",
+      "integrity": "sha512-H61QBokniClkAVSLm2ZT5BMg7P2t1Vz7TwmUSuoF3Gbc1Q2M5ZFvnNnZBIQr8waHsLKfClsWyQVdA0BZe6iUfw==",
       "dev": true,
       "requires": {
         "babel-runtime": "6.x",
@@ -13059,9 +13055,9 @@
       }
     },
     "rc-pagination": {
-      "version": "1.20.1",
-      "resolved": "https://registry.npmjs.org/rc-pagination/-/rc-pagination-1.20.1.tgz",
-      "integrity": "sha512-EC2sxfKo1+R34fDN8EQgFiJn0Z6SKef4O0FizoqV3IomPczSikoarxL1RrHzqeGNsfg7JbUYaux5fQdmUAlPnA==",
+      "version": "1.20.5",
+      "resolved": "https://registry.npmjs.org/rc-pagination/-/rc-pagination-1.20.5.tgz",
+      "integrity": "sha512-gnVAowVIbRilW6bXYWCEpTsrtmAWTpM3qO/bltYfqTVKxgb6/sDqjRvCksJGy/D81pYkEkKeA9foWsgUgbUsQw==",
       "dev": true,
       "requires": {
         "babel-runtime": "6.x",
@@ -13071,9 +13067,9 @@
       }
     },
     "rc-progress": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/rc-progress/-/rc-progress-2.5.1.tgz",
-      "integrity": "sha512-jIoCYAktSG1SvA7gu2jM7hYwb2JiBrqOexY80TBiIIznhMDHh1Mb7rvtfIoEF3WS5evoqoKa3A+szGMyv3J9Cw==",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/rc-progress/-/rc-progress-2.5.2.tgz",
+      "integrity": "sha512-ajI+MJkbBz9zYDuE9GQsY5gsyqPF7HFioZEDZ9Fmc+ebNZoiSeSJsTJImPFCg0dW/5WiRGUy2F69SX1aPtSJgA==",
       "dev": true,
       "requires": {
         "babel-runtime": "6.x",
@@ -13093,9 +13089,9 @@
       }
     },
     "rc-select": {
-      "version": "9.1.5",
-      "resolved": "https://registry.npmjs.org/rc-select/-/rc-select-9.1.5.tgz",
-      "integrity": "sha512-P2QDl5xSdrYuvODnwZIKxhBv2AzfsuFNfaoXjRsPTlQvOjLMCGYgyRzZ4xdUy1IAc1yER6LV+g7e4N9Qc+3DDQ==",
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/rc-select/-/rc-select-9.2.1.tgz",
+      "integrity": "sha512-nW/Zr2OCgxN26OX8ff3xcO1wK0e1l5ixnEfyN15Rbdk7TNI/rIPJIjPCQAoihRpk9A2C/GH8pahjlvKV1Vj++g==",
       "dev": true,
       "requires": {
         "babel-runtime": "^6.23.0",
@@ -13128,9 +13124,9 @@
       }
     },
     "rc-steps": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/rc-steps/-/rc-steps-3.4.1.tgz",
-      "integrity": "sha512-zdeOFmFqiXlXCQyHet1qrDDbGKZ7OQTrlzn8DP5N6M/WqN7HaYoUDy1fZ+NY2htL5WzzVFQpDRKzjiOiHaSqgw==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/rc-steps/-/rc-steps-3.5.0.tgz",
+      "integrity": "sha512-2Vkkrpa7PZbg7qPsqTNzVDov4u78cmxofjjnIHiGB9+9rqKS8oTLPzbW2uiWDr3Lk+yGwh8rbpGO1E6VAgBCOg==",
       "dev": true,
       "requires": {
         "babel-runtime": "^6.23.0",
@@ -13151,9 +13147,9 @@
       }
     },
     "rc-table": {
-      "version": "6.6.7",
-      "resolved": "https://registry.npmjs.org/rc-table/-/rc-table-6.6.7.tgz",
-      "integrity": "sha512-NC6kaHl6q/Eed0THGVSFLfc0xRcctiVEv63oDCrpYRTJPCTfG9q5APDLzwh44dKDAfXHt2JCJ5QtRJH8zaM2IQ==",
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/rc-table/-/rc-table-6.7.0.tgz",
+      "integrity": "sha512-zzu7UtEHLTzZibB1EOoeKQejH21suoxRQx3evlGGLwz5NUh2HDUHobSr12z5Kd8EPr1+y/LPzXJdX1ctFPC+hA==",
       "dev": true,
       "requires": {
         "babel-runtime": "6.x",
@@ -13180,45 +13176,36 @@
       }
     },
     "rc-tabs": {
-      "version": "9.6.4",
-      "resolved": "https://registry.npmjs.org/rc-tabs/-/rc-tabs-9.6.4.tgz",
-      "integrity": "sha512-l4PoDSShNJ6pWGuR1UcUgvee48b3Qu1jgMEaD1hH3Rc+mqysoO7hA9AQ1YywkIy34afGTTejAWDSIFZ0lmg08g==",
+      "version": "9.6.6",
+      "resolved": "https://registry.npmjs.org/rc-tabs/-/rc-tabs-9.6.6.tgz",
+      "integrity": "sha512-8Vs4tLZKQODl72RetTNm+yVOuboAhtJlvf9fbxWJ4WiYuzMxU7Y8RZ8yVNDGt3+4WzCJUI53CtobptBWwcUkDA==",
       "dev": true,
       "requires": {
+        "@ant-design/create-react-context": "^0.2.4",
         "babel-runtime": "6.x",
         "classnames": "2.x",
-        "create-react-context": "0.2.2",
         "lodash": "^4.17.5",
         "prop-types": "15.x",
         "raf": "^3.4.1",
         "rc-hammerjs": "~0.6.0",
         "rc-util": "^4.0.4",
+        "react-lifecycles-compat": "^3.0.4",
         "resize-observer-polyfill": "^1.5.1",
-        "warning": "^3.0.0"
-      },
-      "dependencies": {
-        "warning": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz",
-          "integrity": "sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=",
-          "dev": true,
-          "requires": {
-            "loose-envify": "^1.0.0"
-          }
-        }
+        "warning": "^4.0.3"
       }
     },
     "rc-time-picker": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/rc-time-picker/-/rc-time-picker-3.7.1.tgz",
-      "integrity": "sha512-ULiLnal/0erk9LrPLcDMroPnqL/LBDT4gz9MzQgtc2QN6KBAOgGihHXZempSQTYCg575oAl+BNX5e1teKWOrjw==",
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/rc-time-picker/-/rc-time-picker-3.7.2.tgz",
+      "integrity": "sha512-UVWO9HXGyZoM4I2THlJsEAFcZQz+tYwdcpoHXCEFZsRLz9L2+7vV4EMp9Wa3UrtzMFEt83qSAX/90dCJeKl9sg==",
       "dev": true,
       "requires": {
         "classnames": "2.x",
         "moment": "2.x",
         "prop-types": "^15.5.8",
         "raf": "^3.4.1",
-        "rc-trigger": "^2.2.0"
+        "rc-trigger": "^2.2.0",
+        "react-lifecycles-compat": "^3.0.4"
       }
     },
     "rc-tooltip": {
@@ -13233,12 +13220,12 @@
       }
     },
     "rc-tree": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/rc-tree/-/rc-tree-2.1.0.tgz",
-      "integrity": "sha512-DyHG/W9rW8cYfBrqVrZUep5yt30scyBuYvFnGrU32bh1DUj8GKqOcdoRBaIiOBYurmIiJ02rq6BeBbvVtVp0mw==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/rc-tree/-/rc-tree-2.1.2.tgz",
+      "integrity": "sha512-IQG0bkY4bfK11oVIF44Y4V3IuIOAmIIc5j8b8XGkRjsnUOElRr/BNqKCvg9h2UsNJm1J2xv4OA0HfEIv70765Q==",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.23.0",
+        "@ant-design/create-react-context": "^0.2.4",
         "classnames": "2.x",
         "prop-types": "^15.5.8",
         "rc-animate": "^2.6.0",
@@ -13328,9 +13315,9 @@
       }
     },
     "rc-trigger": {
-      "version": "2.6.4",
-      "resolved": "https://registry.npmjs.org/rc-trigger/-/rc-trigger-2.6.4.tgz",
-      "integrity": "sha512-dN/Iia5E+xLh33OyvIol1Gg1WfHVfL9fUdq34/ejeYENghUNkF0965PDe+GYIgypYplhUM967rjbr/UEm6ctjA==",
+      "version": "2.6.5",
+      "resolved": "https://registry.npmjs.org/rc-trigger/-/rc-trigger-2.6.5.tgz",
+      "integrity": "sha512-m6Cts9hLeZWsTvWnuMm7oElhf+03GOjOLfTuU0QmdB9ZrW7jR2IpI5rpNM7i9MvAAlMAmTx5Zr7g3uu/aMvZAw==",
       "dev": true,
       "requires": {
         "babel-runtime": "6.x",
@@ -13338,13 +13325,14 @@
         "prop-types": "15.x",
         "rc-align": "^2.4.0",
         "rc-animate": "2.x",
-        "rc-util": "^4.4.0"
+        "rc-util": "^4.4.0",
+        "react-lifecycles-compat": "^3.0.4"
       }
     },
     "rc-upload": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/rc-upload/-/rc-upload-2.6.7.tgz",
-      "integrity": "sha512-i6roYvM31ue50r0w/MbxOdbbkZHqpJLT29JyjQC2W5i/7w0/lZJkWEmj/DG5WRRJCnVfIiKmXp2437oXnUFNuw==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/rc-upload/-/rc-upload-2.7.0.tgz",
+      "integrity": "sha512-Oh9EJB4xE8MQUZ2D0OUST3UMIBjHjnO2IjPNW/cbPredxZz+lzbLPCZxcxRwUwu1gt0LA968UWXAgT1EvZdFfA==",
       "dev": true,
       "requires": {
         "babel-runtime": "6.x",
@@ -13354,14 +13342,15 @@
       }
     },
     "rc-util": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/rc-util/-/rc-util-4.6.0.tgz",
-      "integrity": "sha512-rbgrzm1/i8mgfwOI4t1CwWK7wGe+OwX+dNa7PVMgxZYPBADGh86eD4OcJO1UKGeajIMDUUKMluaZxvgraQIOmw==",
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/rc-util/-/rc-util-4.11.0.tgz",
+      "integrity": "sha512-nB29kXOXsSVjBkWfH+Z1GVh6tRg7XGZtZ0Yfie+OI0stCDixGQ1cPrS6iYxlg+AV2St6COCK5MFrCmpTgghh0w==",
       "dev": true,
       "requires": {
         "add-dom-event-listener": "^1.1.0",
         "babel-runtime": "6.x",
         "prop-types": "^15.5.10",
+        "react-lifecycles-compat": "^3.0.4",
         "shallowequal": "^0.2.2"
       },
       "dependencies": {
@@ -13696,9 +13685,9 @@
       "dev": true
     },
     "react-slick": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/react-slick/-/react-slick-0.24.0.tgz",
-      "integrity": "sha512-Pvo0B74ohumQdYOf0qP+pdQpj9iUbAav7+2qiF3uTc5XeQp/Y/cnIeDBM2tB3txthfSe05jKIqLMJTS6qVvt5g==",
+      "version": "0.25.2",
+      "resolved": "https://registry.npmjs.org/react-slick/-/react-slick-0.25.2.tgz",
+      "integrity": "sha512-8MNH/NFX/R7zF6W/w+FS5VXNyDusF+XDW1OU0SzODEU7wqYB+ZTGAiNJ++zVNAVqCAHdyCybScaUB+FCZOmBBw==",
       "dev": true,
       "requires": {
         "classnames": "^2.2.5",

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "@babel/polyfill": "^7.4.4",
     "@babel/preset-env": "^7.5.0",
     "@babel/preset-react": "^7.0.0",
-    "antd": "^3.20.0",
+    "antd": "^3.23.2",
     "babel-eslint": "^10.0.2",
     "babel-jest": "^24.8.0",
     "babel-loader": "^8.0.6",

--- a/src/LayerTreeNode/LayerTreeNode.spec.jsx
+++ b/src/LayerTreeNode/LayerTreeNode.spec.jsx
@@ -1,7 +1,8 @@
 /*eslint-env jest*/
+import React from 'react';
 import LayerTreeNode from './LayerTreeNode';
-import TestUtil from '../Util/TestUtil';
-import PropTypes from 'prop-types';
+import Tree from 'rc-tree';
+import { mount } from 'enzyme';
 
 describe('<LayerTreeNode />', () => {
 
@@ -14,18 +15,14 @@ describe('<LayerTreeNode />', () => {
     expect(LayerTreeNode).not.toBeUndefined();
   });
 
-  it('can be rendered', () => {
-    const wrapper = TestUtil.mountComponent(LayerTreeNode, defaultProps, {
-      context: {
-        rcTree: {
-          prefixCls: '',
-          registerTreeNode: () => {}
-        }
-      },
-      childContextTypes: {
-        rcTree: PropTypes.object
-      }
-    });
+  it('can be rendered (inside a Tree component)', () => {
+    const Cmp = (
+      <Tree>
+        <LayerTreeNode {...defaultProps} />
+      </Tree>
+    );
+
+    const wrapper = mount(Cmp);
     expect(wrapper).not.toBeUndefined();
   });
 });


### PR DESCRIPTION
<!-- Please choose one of the categories and choose the corresponding label, too. -->
## DEPENDENCY UPDATE

### Description:
<!-- Please describe what this PR is about. -->
This updates `antd` to the latest version and fixes the failing `LayerTreeNode` test. It can't be rendered standalone without a context `Provider` (the `Tree` component) component anymore.

Closes #1220.
 
<!--- CHECKLIST
Fixes Issue?
Examples added?
Tests added?
Docs added?
Would a screenshot be helpful?
Do you want to mention someone?
-->
