### PR TITLE
Upgrade to OpenLayers v6 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12261,15 +12261,26 @@
       "dev": true
     },
     "ol": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/ol/-/ol-6.0.1.tgz",
-      "integrity": "sha512-gjTziZlJWwOhPkCFW9eT0uscrWnF7DlxPutmgorDE1lYGqpLF/XTnb/5f+2ikHXay7S1EDIi/9U3ccuMeY/4HQ==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/ol/-/ol-6.1.1.tgz",
+      "integrity": "sha512-0dL3i3eJqgOpqIjDKEY3grkeQnjAYfV5L/JCxhOu4SxiaizRwFrFgeas6LILRoxKa03jhQFbut2r2bbgcLGQeA==",
       "dev": true,
       "requires": {
         "@openlayers/pepjs": "^0.5.3",
-        "pbf": "3.2.0",
+        "pbf": "3.2.1",
         "pixelworks": "1.1.0",
-        "rbush": "^3.0.0"
+        "rbush": "^3.0.1"
+      },
+      "dependencies": {
+        "rbush": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/rbush/-/rbush-3.0.1.tgz",
+          "integrity": "sha512-XRaVO0YecOpEuIvbhbpTrZgoiI6xBlz6hnlr6EHhd+0x9ase6EmeN+hdwwUaJvLcsFFQ8iWVF1GAK1yB0BWi0w==",
+          "dev": true,
+          "requires": {
+            "quickselect": "^2.0.0"
+          }
+        }
       }
     },
     "omit.js": {
@@ -12805,9 +12816,9 @@
       }
     },
     "pbf": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/pbf/-/pbf-3.2.0.tgz",
-      "integrity": "sha512-98Eh7rsJNJF/Im6XYMLaOW3cLnNyedlOd6hu3iWMD5I7FZGgpw8yN3vQBrmLbLodu7G784Irb9Qsv2yFrxSAGw==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/pbf/-/pbf-3.2.1.tgz",
+      "integrity": "sha512-ClrV7pNOn7rtmoQVF4TS1vyU0WhYRnP92fzbfF75jAIwpnzdJXf8iTd4CMEqO4yUenH6NDqLiwjqlh6QgZzgLQ==",
       "dev": true,
       "requires": {
         "ieee754": "^1.1.12",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1535,6 +1535,12 @@
       "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==",
       "dev": true
     },
+    "@openlayers/pepjs": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@openlayers/pepjs/-/pepjs-0.5.3.tgz",
+      "integrity": "sha512-Bgvi5c14BS0FJWyYWWFstNEnXsB30nK8Jt8hkAAdqr7E0gDdBBWVDglF3Ub19wTxvgJ/CVHyTY6VuCtnyRzglg==",
+      "dev": true
+    },
     "@samverschueren/stream-to-observable": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz",
@@ -12255,31 +12261,15 @@
       "dev": true
     },
     "ol": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/ol/-/ol-5.3.3.tgz",
-      "integrity": "sha512-7eU4x8YMduNcED1D5wI+AMWDRe7/1HmGfsbV+kFFROI9RNABU/6n4osj6Q3trZbxxKnK2DSRIjIRGwRHT/Z+Ww==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/ol/-/ol-6.0.1.tgz",
+      "integrity": "sha512-gjTziZlJWwOhPkCFW9eT0uscrWnF7DlxPutmgorDE1lYGqpLF/XTnb/5f+2ikHXay7S1EDIi/9U3ccuMeY/4HQ==",
       "dev": true,
       "requires": {
-        "pbf": "3.1.0",
+        "@openlayers/pepjs": "^0.5.3",
+        "pbf": "3.2.0",
         "pixelworks": "1.1.0",
-        "rbush": "2.0.2"
-      },
-      "dependencies": {
-        "quickselect": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-1.1.1.tgz",
-          "integrity": "sha512-qN0Gqdw4c4KGPsBOQafj6yj/PA6c/L63f6CaZ/DCF/xF4Esu3jVmKLUDYxghFx8Kb/O7y9tI7x2RjTSXwdK1iQ==",
-          "dev": true
-        },
-        "rbush": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/rbush/-/rbush-2.0.2.tgz",
-          "integrity": "sha512-XBOuALcTm+O/H8G90b6pzu6nX6v2zCKiFG4BJho8a+bY6AER6t8uQUZdi5bomQc0AprCWhEGa7ncAbbRap0bRA==",
-          "dev": true,
-          "requires": {
-            "quickselect": "^1.0.1"
-          }
-        }
+        "rbush": "^3.0.0"
       }
     },
     "omit.js": {
@@ -12815,13 +12805,13 @@
       }
     },
     "pbf": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/pbf/-/pbf-3.1.0.tgz",
-      "integrity": "sha512-/hYJmIsTmh7fMkHAWWXJ5b8IKLWdjdlAFb3IHkRBn1XUhIYBChVGfVwmHEAV3UfXTxsP/AKfYTXTS/dCPxJd5w==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/pbf/-/pbf-3.2.0.tgz",
+      "integrity": "sha512-98Eh7rsJNJF/Im6XYMLaOW3cLnNyedlOd6hu3iWMD5I7FZGgpw8yN3vQBrmLbLodu7G784Irb9Qsv2yFrxSAGw==",
       "dev": true,
       "requires": {
-        "ieee754": "^1.1.6",
-        "resolve-protobuf-schema": "^2.0.0"
+        "ieee754": "^1.1.12",
+        "resolve-protobuf-schema": "^2.1.0"
       }
     },
     "pbkdf2": {

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "less": "^3.10.3",
     "less-loader": "^5.0.0",
     "np": "^5.0.3",
-    "ol": "^6.0.1",
+    "ol": "^6.1.1",
     "react": "^16.9.0",
     "react-styleguidist": "^9.1.16",
     "react-test-renderer": "^16.9.0",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
   },
   "peerDependencies": {
     "antd": "^3.0",
-    "ol": "^5.0",
+    "ol": "^6.0",
     "react": "^16.0"
   },
   "dependencies": {
@@ -123,7 +123,7 @@
     "less": "^3.10.3",
     "less-loader": "^5.0.0",
     "np": "^5.0.3",
-    "ol": "^5.3.3",
+    "ol": "^6.0.1",
     "react": "^16.9.0",
     "react-styleguidist": "^9.1.16",
     "react-test-renderer": "^16.9.0",

--- a/src/Button/DigitizeButton/DigitizeButton.jsx
+++ b/src/Button/DigitizeButton/DigitizeButton.jsx
@@ -866,9 +866,14 @@ class DigitizeButton extends React.Component {
    */
   onFeatureCopy = evt => {
     const {
+      map,
       onFeatureCopy,
       onFeatureSelect
     } = this.props;
+
+    const {
+      digitizeLayer
+    } = this.state;
 
     const feat = evt.selected[0];
 
@@ -889,11 +894,12 @@ class DigitizeButton extends React.Component {
     this._digitizeFeatures.push(copy);
 
     AnimateUtil.moveFeature(
-      this.props.map,
+      map,
+      digitizeLayer,
       copy,
       500,
       50,
-      feat.getStyle()
+      this.getDigitizeStyleFunction(feat)
     );
   }
 

--- a/src/Button/DigitizeButton/DigitizeButton.jsx
+++ b/src/Button/DigitizeButton/DigitizeButton.jsx
@@ -894,7 +894,8 @@ class DigitizeButton extends React.Component {
     }
 
     const copy = feat.clone();
-    copy.setStyle(feat.getStyle());
+
+    copy.setStyle(this.getDigitizeStyleFunction(feat));
     this._digitizeFeatures.push(copy);
 
     AnimateUtil.moveFeature(
@@ -923,12 +924,15 @@ class DigitizeButton extends React.Component {
     }
 
     const feature = evt.features.getArray()[0];
+
     if (feature.get('isLabel')) {
       this._digitizeTextFeature = feature;
       let textLabel = '';
 
-      if (feature.getStyle() && feature.getStyle().getText()) {
-        textLabel = feature.getStyle().getText().getText();
+      const featureStyle = this.getDigitizeStyleFunction(feature);
+
+      if (featureStyle && featureStyle.getText()) {
+        textLabel = featureStyle.getText().getText();
       } else if (feature.get('label')) {
         textLabel = feature.get('label');
       }

--- a/src/Button/DigitizeButton/DigitizeButton.jsx
+++ b/src/Button/DigitizeButton/DigitizeButton.jsx
@@ -598,6 +598,10 @@ class DigitizeButton extends React.Component {
 
     let styleObj;
 
+    if (!feature.getGeometry()) {
+      return;
+    }
+
     switch (feature.getGeometry().getType()) {
       case DigitizeButton.POINT_DRAW_TYPE: {
         if (!feature.get('isLabel')) {

--- a/src/Button/DigitizeButton/DigitizeButton.spec.jsx
+++ b/src/Button/DigitizeButton/DigitizeButton.spec.jsx
@@ -318,8 +318,8 @@ describe('<DigitizeButton />', () => {
         const wrapper = setupWrapper();
 
         wrapper.setProps({
-          selectFillColor: 'red',
-          selectStrokeColor: 'blue'
+          selectFillColor: '#ff0000',
+          selectStrokeColor: '#0000ff'
         });
 
         const expectedStyle = wrapper.instance().getSelectedStyleFunction(new OlFeature());

--- a/src/Button/ZoomToExtentButton/ZoomToExtentButton.jsx
+++ b/src/Button/ZoomToExtentButton/ZoomToExtentButton.jsx
@@ -52,7 +52,14 @@ class ZoomToExtentButton extends React.Component {
      * https://openlayers.org/en/latest/apidoc/module-ol_View-View.html#fit
      * @type {Object}
      */
-    fitOptions: PropTypes.object
+    fitOptions: PropTypes.object,
+
+    /**
+     * If true, the view will always animate to the closest zoom level after an interaction.
+     * False means intermediary zoom levels are allowed.
+     * Default is false.
+     */
+    constrainViewResolution: PropTypes.bool
 
   }
 
@@ -62,10 +69,10 @@ class ZoomToExtentButton extends React.Component {
    */
   static defaultProps = {
     fitOptions: {
-      constrainResolution: false,
       duration: 250,
       easing: easeOut
-    }
+    },
+    constrainViewResolution: false
   }
 
   /**
@@ -77,6 +84,7 @@ class ZoomToExtentButton extends React.Component {
     const{
       map,
       extent,
+      constrainViewResolution,
       fitOptions
     } = this.props;
     const view = map.getView();
@@ -89,6 +97,8 @@ class ZoomToExtentButton extends React.Component {
     if (view.getAnimating()) {
       view.cancelAnimations();
     }
+
+    view.setConstrainResolution(constrainViewResolution);
 
     const finalFitOptions = {
       ...defaultFitOptions,
@@ -105,6 +115,7 @@ class ZoomToExtentButton extends React.Component {
     const {
       className,
       fitOptions,
+      constrainViewResolution,
       ...passThroughProps
     } = this.props;
     const finalClassName = className ?

--- a/src/Field/WfsSearch/WfsSearch.spec.jsx
+++ b/src/Field/WfsSearch/WfsSearch.spec.jsx
@@ -138,7 +138,8 @@ describe('<WfsSearch />', () => {
         view: new OlView({
           projection: 'EPSG:4326',
           center: [37.40570, 8.81566],
-          zoom: 4
+          zoom: 4,
+          constrainResolution: true
         })
       });
       //SETUP END

--- a/src/Util/TestUtil.js
+++ b/src/Util/TestUtil.js
@@ -6,7 +6,6 @@ import OlSourceVector from 'ol/source/Vector';
 import OlLayerVector from 'ol/layer/Vector';
 import OlFeature from 'ol/Feature';
 import OlGeomPoint from 'ol/geom/Point';
-import OlPointerPointerEvent from 'ol/pointer/PointerEvent';
 import OlMapBrowserPointerEvent from 'ol/MapBrowserPointerEvent';
 
 /**
@@ -123,11 +122,11 @@ export class TestUtil {
     // Calculated in case body has top < 0 (test runner with small window).
     let position = viewport.getBoundingClientRect();
     let shiftKey = opt_shiftKey !== undefined ? opt_shiftKey : false;
-    let event = new OlPointerPointerEvent(type, {
-      clientX: position.left + x + TestUtil.mapDivWidth / 2,
-      clientY: position.top + y + TestUtil.mapDivHeight / 2,
-      shiftKey: shiftKey
-    });
+    const event = new Event();
+    event.type = type;
+    event.clientX = position.left + x + TestUtil.mapDivWidth / 2;
+    event.clientY = position.top + y + TestUtil.mapDivHeight / 2;
+    event.shiftKey = shiftKey;
     map.handleMapBrowserEvent(new OlMapBrowserPointerEvent(type, map, event, dragging));
   }
 


### PR DESCRIPTION
<!-- Please choose one of the categories and choose the corresponding label, too. -->
## BREAKING CHANGE

### Description:
Upgrade to `ol` version 6.x considering [release notes](https://github.com/openlayers/openlayers/releases/tag/v6.0.0) for release 6.0.0.

Depends on https://github.com/terrestris/ol-util/pull/147 and needs https://github.com/terrestris/ol-util/ release before merge.

Please review @terrestris/devs 