### PR TITLE
Removes node 8 from travis due to its end

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-- "8"
 - "10"
 - "12"
 script:


### PR DESCRIPTION
<!-- Please choose one of the categories and choose the corresponding label, too. -->
## DEVSETUP

### Description:
<!-- Please describe what this PR is about. -->
This removes node 8 from travis as [its end](https://github.com/nodejs/Release#nodejs-release-working-group) is near.
This will speed up the CI time.

<!--- CHECKLIST
Fixes Issue?
Examples added?
Tests added?
Docs added?
Would a screenshot be helpful?
Do you want to mention someone?
-->
