### PR TITLE
Use babel for transpilation of typescript

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "lint:fix": "npm run lint:styleguide -- --fix && npm run lint:src -- --fix",
     "start:styleguide": "styleguidist server",
     "build:styleguide": "npm run clean:build && styleguidist build",
-    "build:dist": "npm run clean:dist && BABEL_ENV=build tsc -p ./ && copyfiles \"./src/**/*.less\" dist --up 1",
+    "build:dist": "babel src --out-dir dist --copy-files --ignore spec.tsx,.md --extensions '.ts,.tsx'",
     "build:all": "npm run build:styleguide && npm run build:dist",
     "build": "npm run test -- --coverage && npm run build:all",
     "release": "np --no-yarn"
@@ -83,7 +83,7 @@
     "@turf/turf": "^5.1.6",
     "@types/lodash": "^4.14.146",
     "@types/moment": "^2.13.0",
-    "@types/node": "^12.12.6",
+    "@types/node": "^12.12.7",
     "@types/react-dom": "^16.9.3",
     "@types/react-rnd": "^8.0.0",
     "copyfiles": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "lint:fix": "npm run lint:styleguide -- --fix && npm run lint:src -- --fix",
     "start:styleguide": "styleguidist server",
     "build:styleguide": "npm run clean:build && styleguidist build",
-    "build:dist": "babel src --out-dir dist --copy-files --ignore spec.tsx,.md --extensions '.ts,.tsx'",
+    "build:dist": "npm run clean:dist && babel src --out-dir dist --copy-files --ignore spec.tsx,.md --extensions '.ts,.tsx'",
     "build:all": "npm run build:styleguide && npm run build:dist",
     "build": "npm run test -- --coverage && npm run build:all",
     "release": "np --no-yarn"

--- a/src/UserChip/UserChip.tsx
+++ b/src/UserChip/UserChip.tsx
@@ -1,10 +1,14 @@
 import * as React from 'react';
-import { Dropdown } from 'antd';
-import Avatar, { AvatarProps } from 'antd/lib/avatar';
+import {
+  Avatar,
+  Dropdown
+} from 'antd';
+
+import { AvatarProps } from 'antd/lib/avatar';
+
 import './UserChip.less';
 
 import { CSS_PREFIX } from '../constants';
-import { string } from 'prop-types';
 
 // non default props
 export interface UserChipProps extends AvatarProps {
@@ -68,7 +72,7 @@ class UserChip extends React.Component<UserChipProps> {
       userName
     } = this.props;
 
-    if (!(userName instanceof string || typeof userName === 'string')) {
+    if (!(userName instanceof String || typeof userName === 'string')) {
       return '??';
     }
 

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -43,10 +43,8 @@ module.exports = {
   require: [
     '@babel/polyfill',
     'whatwg-fetch',
-    'ol/ol.css',
-    'antd/dist/antd.css'
+    'ol/ol.css'
   ],
-  components: 'src/**/*.tsx',
   sections: [{
     name: 'Introduction',
     content: 'README.md'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,25 +1,27 @@
 {
   "compilerOptions": {
+    "allowJs": false,
+    "allowSyntheticDefaultImports": true,
     "baseUrl": ".",
     "declaration": true,
-    "outDir": "dist",
-    "module": "commonjs",
-    "target": "es5",
-    "lib": ["es7", "dom"],
-    "sourceMap": true,
-    "allowJs": false,
-    "jsx": "react",
-    "moduleResolution": "node",
-    "rootDir": "src",
+    "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
+    "jsx": "react",
+    "lib": ["es7", "dom"],
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "noEmit": true,
+    "noImplicitAny": false, //temporal
     "noImplicitReturns": true,
     "noImplicitThis": true,
-    "noImplicitAny": false, //temporal
+    "noUnusedLocals": true,
+    "outDir": "dist",
+    "resolveJsonModule": true,
+    "rootDir": "src",
+    "sourceMap": true,
     "strictNullChecks": false,
     "suppressImplicitAnyIndexErrors": true,
-    "noUnusedLocals": true,
-    "resolveJsonModule": true,
-    "allowSyntheticDefaultImports": true
+    "target": "es5"
   },
   "exclude": [
     "node_modules",

--- a/webpack.common.config.js
+++ b/webpack.common.config.js
@@ -24,15 +24,7 @@ module.exports = {
     // Compile .tsx?
     {
       test: /\.(ts|tsx)$/,
-      use: [
-        {
-          loader: require.resolve('ts-loader'),
-          options: {
-            // disable type checker - we will use it in fork plugin
-            transpileOnly: true
-          },
-        },
-      ],
+      use: 'babel-loader'
     }, {
       test: /\.css$/,
       use: [


### PR DESCRIPTION
<!-- Please choose one of the categories and choose the corresponding label, too. -->
## BUGFIX | DEVSETUP

### Description:
<!-- Please describe what this PR is about. -->
This reintroduces the usage of `babel` for the transpilation as `tsc` was not capbale of loading the correct style files.
This includes some changes to tsconfig, too.
It also fixes some issues with the `UserChip`.

<!--- CHECKLIST
Fixes Issue?
Examples added?
Tests added?
Docs added?
Would a screenshot be helpful?
Do you want to mention someone?
-->
