### PR TITLE
Further improvements to the HOC typings

### DIFF
--- a/src/HigherOrderComponent/DropTargetMap/DropTargetMap.tsx
+++ b/src/HigherOrderComponent/DropTargetMap/DropTargetMap.tsx
@@ -6,18 +6,18 @@ import { MapComponentProps } from '../../Map/MapComponent/MapComponent';
 /**
  * HOC that adds layers to the map if GeoJSON files or shapefile zip files are
  * dropped on it.
- * @param  {React.Component} WrappedComponent the map component
- * @return {React.Component} a time layer aware component
+ * @param WrappedComponent the map component
+ * @return a time layer aware component
  */
-export function onDropAware<P>(WrappedComponent: React.ComponentType<P>) {
+export function onDropAware(WrappedComponent: React.ComponentType<MapComponentProps>) {
 
-  return class DropTargetMap extends React.Component<P & MapComponentProps> {
+  return class DropTargetMap extends React.Component<MapComponentProps> {
 
     /**
      * Calls an appropriate addLayer method depending on the fileending.
      * Currently expects shapefiles for '*.zip' and geojson for all other
      * endings.
-     * @param  {Object} event the drop event
+     * @param event The drop event
      */
     onDrop(event: DragEvent) {
       const {
@@ -40,15 +40,15 @@ export function onDropAware<P>(WrappedComponent: React.ComponentType<P>) {
 
     /**
      * Prevents default in order to prevent browser navigation/opening the file.
-     * @param  {Object} event the dragover event
+     * @param event The dragover event
      */
-    onDragOver(event: DragEvent) {
+    onDragOver(event: React.DragEvent<HTMLDivElement>) {
       event.preventDefault();
     }
 
     /**
      * Injects the onDrop and onDragOver properties.
-     * @return {React.Component} the wrapped component
+     * @return the wrapped component
      */
     render = () => {
       return <WrappedComponent

--- a/src/HigherOrderComponent/LoadifiedComponent/LoadifiedComponent.tsx
+++ b/src/HigherOrderComponent/LoadifiedComponent/LoadifiedComponent.tsx
@@ -14,9 +14,9 @@ export interface LoadifiedComponentProps {
  * If the wrapped component is set to be loading the loader element
  * will be shown and if not it wont.
  *
- * @param {Component} WrappedComponent The component to wrap and enhance.
- * @param {Component} options The options to apply.
- * @return {Component} The wrapped component.
+ * @param WrappedComponent The component to wrap and enhance.
+ * @param options The options to apply.
+ * @return The wrapped component.
  */
 export function loadify<P>(WrappedComponent: React.ComponentType<any>, {
   withRef = false
@@ -34,8 +34,6 @@ export function loadify<P>(WrappedComponent: React.ComponentType<any>, {
 
     /**
      * The default properties.
-     *
-     * @type {Object}
      */
     static defaultProps = {
       spinning: false
@@ -51,7 +49,6 @@ export function loadify<P>(WrappedComponent: React.ComponentType<any>, {
 
       /**
        * The wrapped instance.
-       * @type {Element}
        */
       this._wrappedInstance = null;
     }
@@ -59,7 +56,7 @@ export function loadify<P>(WrappedComponent: React.ComponentType<any>, {
     /**
      * Returns the wrapped instance. Only applicable if withRef is set to true.
      *
-     * @return {Element} The wrappend instance.
+     * @return The wrappend instance.
      */
     getWrappedInstance = (): React.ReactElement | void => {
       if (withRef) {
@@ -73,7 +70,7 @@ export function loadify<P>(WrappedComponent: React.ComponentType<any>, {
     /**
      * Sets the wrapped instance.
      *
-     * @param {Element} instance The instance to set.
+     * @param instance The instance to set.
      */
     setWrappedInstance = (instance) => {
       if (withRef) {

--- a/src/HigherOrderComponent/MappifiedComponent/MappifiedComponent.tsx
+++ b/src/HigherOrderComponent/MappifiedComponent/MappifiedComponent.tsx
@@ -13,10 +13,10 @@ interface MappifiedComponentProps {
  *
  * Wrapped components will receive the map from the context as a prop.
  *
- * @param {Component} WrappedComponent The component to wrap and enhance.
- * @return {Component} The wrapped component.
+ * @param WrappedComponent The component to wrap and enhance.
+ * @return The wrapped component.
  */
-export function mappify<P extends Omit<P, 'map'>>(WrappedComponent: React.ComponentType<P>,  {
+export function mappify<P>(WrappedComponent: React.ComponentType<P>,  {
   withRef = false
 }: MappifiedComponentProps = {}) {
 
@@ -26,13 +26,12 @@ export function mappify<P extends Omit<P, 'map'>>(WrappedComponent: React.Compon
    * @class The MappifiedComponent
    * @extends React.Component
    */
-  return class MappifiedComponent extends React.Component<P & MappifiedComponentProps> {
+  return class MappifiedComponent extends React.Component<Omit<P, 'map'> & MappifiedComponentProps> {
 
     _wrappedInstance?: React.ReactElement;
 
     /**
      * The context types.
-     * @type {Object}
      */
     static contextTypes = {
       map: PropTypes.instanceOf(OlMap).isRequired
@@ -48,7 +47,6 @@ export function mappify<P extends Omit<P, 'map'>>(WrappedComponent: React.Compon
 
       /**
        * The wrapped instance.
-       * @type {Element}
        */
       this._wrappedInstance = null;
     }
@@ -56,7 +54,7 @@ export function mappify<P extends Omit<P, 'map'>>(WrappedComponent: React.Compon
     /**
      * Returns the wrapped instance. Only applicable if withRef is set to true.
      *
-     * @return {Element} The wrapped instance.
+     * @return The wrapped instance.
      */
     getWrappedInstance = (): React.ReactElement | void => {
       if (withRef) {
@@ -70,7 +68,7 @@ export function mappify<P extends Omit<P, 'map'>>(WrappedComponent: React.Compon
     /**
      * Sets the wrapped instance.
      *
-     * @param {Element} instance The instance to set.
+     * @param instance The instance to set.
      */
     setWrappedInstance = (instance) => {
       if (withRef) {
@@ -95,7 +93,7 @@ export function mappify<P extends Omit<P, 'map'>>(WrappedComponent: React.Compon
         <WrappedComponent
           ref={this.setWrappedInstance}
           map={map}
-          {...this.props}
+          {...this.props as P}
         />
       );
 

--- a/src/HigherOrderComponent/TimeLayerAware/TimeLayerAware.tsx
+++ b/src/HigherOrderComponent/TimeLayerAware/TimeLayerAware.tsx
@@ -7,9 +7,9 @@ const _isArray = require('lodash/isArray');
  * Finds the key time in the passed object regardless of upper- or lowercase
  * characters. Will return `TIME` (all uppercase) as a fallback.
  *
- * @param {Object} params The object to find the key in, basically the params of
+ * @param params The object to find the key in, basically the params of
  *   a WMS source that will end up as URL parameters.
- * @return {String} The key for the time parameter, in the actual spelling.
+ * @return The key for the time parameter, in the actual spelling.
  */
 const findTimeParam = (params: Object) => {
   const keys = Object.keys(params);
@@ -28,13 +28,13 @@ const findTimeParam = (params: Object) => {
 /**
  * HOC that updates layers based on the wrapped components time instant or
  * interval. Can for example be used with the TimeSlider component.
- * @param  {React.Component} WrappedComponent a component with an onChange prop
- * @param  {Array} layers array of layer configurations
- * @return {React.Component} a time layer aware component
+ * @param WrappedComponent A component with an onChange prop
+ * @param layers Array of layer configurations
+ * @return A time layer aware component
  */
 export function timeLayerAware<P extends object>(WrappedComponent: React.ComponentType<P>, layers: OlLayerBase[]) {
 
-  return class TimeLayerAware extends React.Component<P> {
+  return class TimeLayerAware extends React.Component<Omit<P, 'onChange'>> {
 
     timeChanged = newValues => {
       layers.forEach(config => {
@@ -56,12 +56,12 @@ export function timeLayerAware<P extends object>(WrappedComponent: React.Compone
 
     /**
      * Injects the onChange property.
-     * @return {React.Component} the wrapped component
+     * @return The wrapped component
      */
     render = () => {
       return <WrappedComponent
         onChange={this.timeChanged}
-        {...this.props}
+        {...this.props as P}
       />;
     }
 


### PR DESCRIPTION
<!-- Please choose one of the categories and choose the corresponding label, too. -->
## BUGFIX

### Description:
<!-- Please describe what this PR is about. -->
This PR includes further improvements for the HOC typing.
E.g.: A Wrapped `MapComponent` no longer needs a map property as it is passed by the `MappifiedComponent` HOC.

<!--- CHECKLIST
Fixes Issue?
Examples added?
Tests added?
Docs added?
Would a screenshot be helpful?
Do you want to mention someone?
-->
