### PR TITLE
Avoids adding ref to wrapped functional components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8231,9 +8231,9 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.1.tgz",
-      "integrity": "sha512-C29UoFzHe9yM61lOsIlCE5/mQVGrnIOrOq7maQl76L7tYPCgC1og0Ajt6uWnX4ZTxBPnjw+CUvawphwCfJgUnA==",
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.3.tgz",
+      "integrity": "sha512-3yPecJoJHK/4c6aZhSvxOyG4vJKDshV36VHp0iVCDVh7o9w2vwi3NSnL2MMPj3YdduqaBcu7cGbggJQM0br9xA==",
       "dev": true,
       "requires": {
         "neo-async": "^2.6.0",
@@ -17071,9 +17071,9 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.6.8",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.8.tgz",
-      "integrity": "sha512-XhHJ3S3ZyMwP8kY1Gkugqx3CJh2C3O0y8NPiSxtm1tyD/pktLAkFZsFGpuNfTZddKDQ/bbDBLAd2YyA1pbi8HQ==",
+      "version": "3.6.9",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.9.tgz",
+      "integrity": "sha512-pcnnhaoG6RtrvHJ1dFncAe8Od6Nuy30oaJ82ts6//sGSXOP5UjBMEthiProjXmMNHOfd93sqlkztifFMcb+4yw==",
       "dev": true,
       "optional": true,
       "requires": {

--- a/src/HigherOrderComponent/LoadifiedComponent/LoadifiedComponent.tsx
+++ b/src/HigherOrderComponent/LoadifiedComponent/LoadifiedComponent.tsx
@@ -102,10 +102,14 @@ export function loadify<P>(WrappedComponent: React.ComponentType<any>, {
         spinning
       };
 
+      // Check if WrappedComponent is a ReactComponent (class) as functional components
+      // can't have a ref
+      const isReactComponent = WrappedComponent.prototype.isReactComponent;
+
       return (
         <Spin {...passToLoader} >
           <WrappedComponent
-            ref={this.setWrappedInstance}
+            ref={isReactComponent && this.setWrappedInstance}
             {...passThroughProps}
           />
         </Spin>

--- a/src/HigherOrderComponent/MappifiedComponent/MappifiedComponent.tsx
+++ b/src/HigherOrderComponent/MappifiedComponent/MappifiedComponent.tsx
@@ -16,7 +16,7 @@ interface MappifiedComponentProps {
  * @param WrappedComponent The component to wrap and enhance.
  * @return The wrapped component.
  */
-export function mappify<P>(WrappedComponent: React.ComponentType<P>,  {
+export function mappify<P>(WrappedComponent: React.ComponentType<P>, {
   withRef = false
 }: MappifiedComponentProps = {}) {
 
@@ -89,9 +89,13 @@ export function mappify<P>(WrappedComponent: React.ComponentType<P>,  {
         'context. Did you implement the MapProvider?');
       }
 
+      // Check if WrappedComponent is a ReactComponent (class) as functional components
+      // can't have a ref
+      const isReactComponent = WrappedComponent.prototype.isReactComponent;
+
       return (
         <WrappedComponent
-          ref={this.setWrappedInstance}
+          ref={isReactComponent && this.setWrappedInstance}
           map={map}
           {...this.props as P}
         />

--- a/src/HigherOrderComponent/VisibleComponent/VisibleComponent.tsx
+++ b/src/HigherOrderComponent/VisibleComponent/VisibleComponent.tsx
@@ -107,14 +107,18 @@ export function isVisibleComponent<P extends VisibleComponentProps>(WrappedCompo
       } = this.props;
 
       // Check if the current component should be visible or not.
-      let isVisible = this.isVisibleComponent(this.props.name);
+      const isVisible = this.isVisibleComponent(this.props.name);
+
+      // Check if WrappedComponent is a ReactComponent (class) as functional components
+      // can't have a ref
+      const isReactComponent = WrappedComponent.prototype.isReactComponent;
 
       // Inject props into the wrapped component. These are usually state
       // values or instance methods.
       return (
         isVisible ?
           <WrappedComponent
-            ref={this.setWrappedInstance}
+            ref={isReactComponent && this.setWrappedInstance}
             {...passThroughProps as P}
           /> :
           null


### PR DESCRIPTION
<!-- Please choose one of the categories and choose the corresponding label, too. -->
## BUGFIX

### Description:
<!-- Please describe what this PR is about. -->
As functional components can't have refs a Warning is thrown when using the HOC with these.
To avoid this a check is added to the HOCs.

<!--- CHECKLIST
Fixes Issue?
Examples added?
Tests added?
Docs added?
Would a screenshot be helpful?
Do you want to mention someone?
-->
