### PR TITLE
Introduces LayerSwitcher

### DIFF
--- a/src/LayerSwitcher/LayerSwitcher.example.md
+++ b/src/LayerSwitcher/LayerSwitcher.example.md
@@ -1,0 +1,75 @@
+This example shows the LayerSwitcher component.
+Just click on the switcher to change the layer.
+The passed layers are handled like only one of it can be visible.
+
+```jsx
+import * as React from 'react';
+
+import OlMap from 'ol/Map';
+import OlView from 'ol/View';
+import OlLayerTile from 'ol/layer/Tile';
+import OlSourceStamen from 'ol/source/Stamen';
+import OlSourceOsm from 'ol/source/OSM';
+
+import LayerSwitcher from '@terrestris/react-geo/LayerSwitcher/LayerSwitcher';
+
+class LayerSwitcherExample extends React.Component {
+
+  constructor(props) {
+
+    super(props);
+
+    this.mapDivId = `map-${Math.random()}`;
+
+    this.layers = [
+      new OlLayerTile({
+        name: 'OSM',
+        source: new OlSourceOsm()
+      }),
+      new OlLayerTile({
+        name: 'Stamen',
+        source: new OlSourceStamen({
+          layer: 'watercolor'
+        })
+      }),
+    ];
+
+    this.map = new OlMap({
+      view: new OlView({
+        center: [801045, 6577113],
+        zoom: 9
+      }),
+      layers: this.layers
+    });
+  }
+
+  componentDidMount() {
+    this.map.setTarget(this.mapDivId);
+  }
+
+  render() {
+    return(
+      <div
+        id={this.mapDivId}
+        style={{
+          position: 'relative',
+          height: '200px'
+        }}
+      >
+        <LayerSwitcher
+          style={{
+            position: 'absolute',
+            bottom: 0,
+            left: '10px',
+            zIndex: 2
+          }}
+          map={this.map}
+          layers={this.layers}
+        />
+      </div>
+    )
+  }
+}
+
+<LayerSwitcherExample />
+```

--- a/src/LayerSwitcher/LayerSwitcher.less
+++ b/src/LayerSwitcher/LayerSwitcher.less
@@ -19,11 +19,17 @@
   }
 
   .layer-title {
+    font-size: 0.8em;
     position: absolute;
     width: 100%;
     bottom: 0;
-    padding: 3px;
+    left: 0;
+    padding: 3px 6px;
+    border-radius: 0 0 4px 4px;
     color: white;
-    background-image: linear-gradient(transparent,rgba(0,0,0,0.6));
+    background-image: linear-gradient(rgba(0,0,0,0.01),rgba(0,0,0,0.7));
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 }

--- a/src/LayerSwitcher/LayerSwitcher.less
+++ b/src/LayerSwitcher/LayerSwitcher.less
@@ -1,0 +1,29 @@
+.react-geo-layer-switcher {
+  .clip {
+    width: 80px;
+    height: 80px;
+    background-color: white;
+    border: 2px solid black;
+    border-radius: 4px;
+    overflow: hidden;
+    cursor: pointer;
+  }
+
+  #layer-switcher-map {
+    width: 256px;
+    height: 256px;
+    position: relative;
+    left: -68px;
+    top: -68px;
+    pointer-events: none;
+  }
+
+  .layer-title {
+    position: absolute;
+    width: 100%;
+    bottom: 0;
+    padding: 3px;
+    color: white;
+    background-image: linear-gradient(transparent,rgba(0,0,0,0.6));
+  }
+}

--- a/src/LayerSwitcher/LayerSwitcher.spec.tsx
+++ b/src/LayerSwitcher/LayerSwitcher.spec.tsx
@@ -1,0 +1,103 @@
+/*eslint-env jest*/
+
+import TestUtil from '../Util/TestUtil';
+
+import LayerSwitcher from './LayerSwitcher';
+import OlLayerTile from 'ol/layer/Tile';
+import OlSourceStamen from 'ol/source/Stamen';
+import OlSourceOsm from 'ol/source/OSM';
+
+const fakeEvent = {
+  stopPropagation: () => undefined
+};
+
+describe('<LayerSwitcher />', () => {
+  let wrapper;
+  let map;
+  let layers;
+
+  beforeEach(() => {
+    layers = [
+      new OlLayerTile({
+        name: 'OSM',
+        source: new OlSourceOsm()
+      }),
+      new OlLayerTile({
+        name: 'Stamen',
+        source: new OlSourceStamen({
+          layer: 'watercolor'
+        })
+      }),
+    ];
+    map = TestUtil.createMap();
+    map.addLayer(layers[0]);
+    map.addLayer(layers[1]);
+    let props = {
+      map: map,
+      layers: layers
+    };
+    wrapper = TestUtil.mountComponent(LayerSwitcher, props);
+  });
+
+  afterEach(() => {
+    TestUtil.removeMap(map);
+    layers = null;
+    map = null;
+  });
+
+  it('is defined', () => {
+    expect(LayerSwitcher).not.toBeUndefined();
+  });
+
+  it('can be rendered', () => {
+    expect(wrapper).not.toBeUndefined();
+  });
+
+  it('contains map element', () => {
+    let mapElement = wrapper.find('div#layer-switcher-map');
+    expect(mapElement).not.toBeUndefined();
+  });
+
+  it('adds a custom className', () => {
+    let props = {
+      className: 'peter',
+      map: map,
+      layers: layers
+    };
+    wrapper = TestUtil.mountComponent(LayerSwitcher, props);
+    const elementClass = wrapper.find('div').get(0).props.className;
+    expect(elementClass).toContain('peter');
+    expect(elementClass).toContain(wrapper.instance()._className);
+  });
+
+  it('passes style prop', () => {
+    let props = {
+      style: {
+        backgroundColor: 'yellow',
+        position: 'inherit'
+      },
+      map: map,
+      layers: layers
+    };
+    wrapper = TestUtil.mountComponent(LayerSwitcher, props);
+    expect(wrapper.props().style.backgroundColor).toBe('yellow');
+    expect(wrapper.props().style.position).toBe('inherit');
+  });
+
+  it('sets all but one layer to invisible', () => {
+    const layer0visibile = layers[0].getVisible();
+    const layer1visibile = layers[1].getVisible();
+    expect(layer0visibile && layer1visibile).toBe(false);
+    expect(layer0visibile || layer1visibile).toBe(true);
+  });
+
+  it('switches the visible layer on click', () => {
+    const instance = wrapper.instance();
+    const layer0visibile = layers[0].getVisible();
+    const layer1visibile = layers[1].getVisible();
+    instance.onSwitcherClick(fakeEvent);
+    expect(layers[0].getVisible()).toBe(!layer0visibile);
+    expect(layers[1].getVisible()).toBe(!layer1visibile);
+  });
+
+});

--- a/src/LayerSwitcher/LayerSwitcher.tsx
+++ b/src/LayerSwitcher/LayerSwitcher.tsx
@@ -75,7 +75,7 @@ export class LayerSwitcher extends React.Component<LayerSwitcherProps, LayerSwit
    * The className added to this component.
    * @private
    */
-  className = `${CSS_PREFIX}layer-switcher`;
+  _className = `${CSS_PREFIX}layer-switcher`;
 
   /**
    * Creates the LayerSwitcher.
@@ -216,7 +216,7 @@ export class LayerSwitcher extends React.Component<LayerSwitcherProps, LayerSwit
    */
   onSwitcherClick = (evt: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
     evt.stopPropagation();
-    this._map.getLayers().getArray().forEach((layer, index) => {
+    this._map.getLayers().getArray().forEach((layer, index: number) => {
       if (layer.getVisible()) {
         this._visibleLayerIndex = index;
       }
@@ -234,8 +234,8 @@ export class LayerSwitcher extends React.Component<LayerSwitcherProps, LayerSwit
     } = this.props;
 
     const finalClassName = className
-      ? `${className} ${this.className}`
-      : this.className;
+      ? `${className} ${this._className}`
+      : this._className;
 
     return (
       <div

--- a/src/LayerSwitcher/LayerSwitcher.tsx
+++ b/src/LayerSwitcher/LayerSwitcher.tsx
@@ -1,0 +1,248 @@
+import * as React from 'react';
+const _isEqual = require('lodash/isEqual');
+import Logger from '@terrestris/base-util/dist/Logger';
+
+import OlMap from 'ol/Map';
+
+import OlLayerGroup from 'ol/layer/Group';
+import OlLayerTile from 'ol/layer/Tile';
+
+import { CSS_PREFIX } from '../constants';
+import MapComponent from '../Map/MapComponent/MapComponent';
+
+import './LayerSwitcher.less';
+
+type ArrayTwoOrMore<T> = {
+  0: T
+  1: T
+} & Array<T>;
+
+/**
+ * @export
+ * @interface LayerSwitcherProps
+ * @extends {React.HTMLAttributes<HTMLDivElement>}
+ */
+export interface LayerSwitcherProps extends React.HTMLAttributes<HTMLDivElement> {
+  /**
+   * An optional CSS class which should be added.
+   */
+  className?: string;
+  /**
+   * The layer you want to display the legend of.
+   */
+  layers: ArrayTwoOrMore<OlLayerTile | OlLayerGroup>;
+  /**
+   *
+   */
+  map: OlMap;
+}
+
+interface LayerSwitcherState {
+  previewLayer: OlLayerTile | OlLayerGroup;
+}
+
+/**
+ * Class representing the LayerSwitcher.
+ *
+ * @class LayerSwitcher
+ * @extends React.Component
+ */
+export class LayerSwitcher extends React.Component<LayerSwitcherProps, LayerSwitcherState> {
+
+  /**
+   * The internal map of the LayerSwitcher
+   * @private
+   */
+  _map: OlMap = null;
+
+  /**
+   *
+   *
+   * @private
+   */
+  _visibleLayerIndex: number = null;
+
+  /**
+   *
+   *
+   * @private
+   */
+  _layerClones: Array<OlLayerTile | OlLayerGroup> = [];
+
+  /**
+   * The className added to this component.
+   * @private
+   */
+  className = `${CSS_PREFIX}layer-switcher`;
+
+  /**
+   * Create the Legend.
+   *
+   * @constructs Legend
+   */
+  constructor(props: LayerSwitcherProps) {
+    super(props);
+    this._map = this.getMap();
+    this.state = {
+      previewLayer: null
+    };
+  }
+
+  /**
+   * A react lifecycle method called when the component did mount.
+   */
+  componentDidMount() {
+    this.setMapLayers();
+    this.updateLayerVisibilty();
+  }
+
+  /**
+   * Invoked immediately after updating occurs. This method is not called for
+   * the initial render.
+   *
+   * @param prevProps The previous props.
+   */
+  componentDidUpdate(prevProps: LayerSwitcherProps) {
+    if (!(_isEqual(this.props.layers, prevProps.layers))) {
+      this.setMapLayers();
+      this.updateLayerVisibilty();
+    }
+  }
+
+  /**
+   * Clones a layer
+   *
+   * @param layer The layer to clone.
+   * @returns The cloned layer.
+   */
+  cloneLayer = (layer: OlLayerTile | OlLayerGroup) => {
+    let layerClone: OlLayerTile | OlLayerGroup;
+    if (layer.getLayers) {
+      layerClone = new OlLayerGroup({
+        layers: layer.getLayers().getArray().map(this.cloneLayer),
+        originalLayer: layer,
+        ...layer.getProperties()
+      });
+    } else {
+      layerClone = new OlLayerTile({
+        source: layer.getSource(),
+        originalLayer: layer,
+        ...layer.getProperties()
+      });
+    }
+    return layerClone;
+  }
+
+  /**
+   * (Re-)adds the layers to the preview map and sets the visibleLayerIndex.
+   *
+   */
+  setMapLayers = () => {
+    const {
+      layers
+    } = this.props;
+    if (layers.length < 2) {
+      Logger.warn(`LayerSwitcher requires two or more layers.`);
+    }
+    this._map.getLayers().clear();
+    this._layerClones = layers.map((layer, index) => {
+      const layerClone = this.cloneLayer(layer);
+      if (layerClone.getVisible()) {
+        this._visibleLayerIndex = index;
+      }
+      this._map.addLayer(layerClone);
+      return layerClone;
+    });
+  }
+
+  /**
+   * Sets the visiblity of the layers in the props.map and this._map.
+   * Also sets the previewLayer in the state.
+   *
+   */
+  updateLayerVisibilty = () => {
+    const {
+      layers
+    } = this.props;
+    layers.forEach((l, i) => {
+      if (this._visibleLayerIndex === i) {
+        l.setVisible(true);
+      } else {
+        l.setVisible(false);
+      }
+    });
+    this._layerClones.forEach((l, i) => {
+      if (this._visibleLayerIndex === this._layerClones.length - 1 && i === 0) {
+        l.setVisible(true);
+        this.setState({ previewLayer: l });
+      } else if (this._visibleLayerIndex + 1 === i) {
+        l.setVisible(true);
+        this.setState({ previewLayer: l });
+      } else {
+        l.setVisible(false);
+      }
+    });
+  }
+
+  /**
+   * Constructs this._map
+   */
+  getMap = (): OlMap => {
+    const {
+      map
+    } = this.props;
+    return new OlMap({
+      view: map.getView(),
+      controls: []
+    });
+  }
+
+  /**
+   * Clickhandler for the overview switch.
+   *
+   */
+  onSwitcherClick = (evt: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
+    evt.stopPropagation();
+    this._map.getLayers().getArray().forEach((layer, index) => {
+      if (layer.getVisible()) {
+        this._visibleLayerIndex = index;
+      }
+    });
+    this.updateLayerVisibilty();
+  }
+
+  /**
+   * The render function.
+   */
+  render() {
+    const {
+      className
+    } = this.props;
+
+    const finalClassName = className
+      ? `${className} ${this.className}`
+      : this.className;
+
+    return (
+      <div className={finalClassName}>
+        <div
+          className="clip"
+          onClick={this.onSwitcherClick}
+        >
+          <MapComponent
+            mapDivId="layer-switcher-map"
+            map={this._map}
+          />
+          {
+            this.state.previewLayer &&
+            <span className="layer-title">
+              {this.state.previewLayer.get('name')}
+            </span>
+          }
+        </div>
+      </div>
+    );
+  }
+}
+
+export default LayerSwitcher;

--- a/src/LayerSwitcher/LayerSwitcher.tsx
+++ b/src/LayerSwitcher/LayerSwitcher.tsx
@@ -43,6 +43,8 @@ interface LayerSwitcherState {
 
 /**
  * Class representing the LayerSwitcher.
+ * A basic component to switch between the passed layers.
+ * This is most likely to be used for the backgroundlayer.
  *
  * @class LayerSwitcher
  * @extends React.Component
@@ -93,7 +95,7 @@ export class LayerSwitcher extends React.Component<LayerSwitcherProps, LayerSwit
    */
   componentDidMount() {
     this.setMapLayers();
-    this.updateLayerVisibilty();
+    this.updateLayerVisibility();
   }
 
   /**
@@ -116,7 +118,7 @@ export class LayerSwitcher extends React.Component<LayerSwitcherProps, LayerSwit
   componentDidUpdate(prevProps: LayerSwitcherProps) {
     if (!(_isEqual(this.props.layers, prevProps.layers))) {
       this.setMapLayers();
-      this.updateLayerVisibilty();
+      this.updateLayerVisibility();
     }
   }
 
@@ -171,7 +173,7 @@ export class LayerSwitcher extends React.Component<LayerSwitcherProps, LayerSwit
    * Also sets the previewLayer in the state.
    *
    */
-  updateLayerVisibilty = () => {
+  updateLayerVisibility = () => {
     const {
       layers
     } = this.props;
@@ -219,7 +221,7 @@ export class LayerSwitcher extends React.Component<LayerSwitcherProps, LayerSwit
         this._visibleLayerIndex = index;
       }
     });
-    this.updateLayerVisibilty();
+    this.updateLayerVisibility();
   }
 
   /**
@@ -227,7 +229,8 @@ export class LayerSwitcher extends React.Component<LayerSwitcherProps, LayerSwit
    */
   render() {
     const {
-      className
+      className,
+      ...passThroughProps
     } = this.props;
 
     const finalClassName = className
@@ -235,7 +238,10 @@ export class LayerSwitcher extends React.Component<LayerSwitcherProps, LayerSwit
       : this.className;
 
     return (
-      <div className={finalClassName}>
+      <div
+        className={finalClassName}
+        {...passThroughProps}
+      >
         <div
           className="clip"
           onClick={this.onSwitcherClick}

--- a/src/LayerSwitcher/LayerSwitcher.tsx
+++ b/src/LayerSwitcher/LayerSwitcher.tsx
@@ -24,15 +24,15 @@ type ArrayTwoOrMore<T> = {
  */
 export interface LayerSwitcherProps extends React.HTMLAttributes<HTMLDivElement> {
   /**
-   * An optional CSS class which should be added.
+   * An optional CSS class which will be added to the wrapping div Element.
    */
   className?: string;
   /**
-   * The layer you want to display the legend of.
+   * The layers to be available in the switcher.
    */
   layers: ArrayTwoOrMore<OlLayerTile | OlLayerGroup>;
   /**
-   *
+   * The main map the layers should be synced with.
    */
   map: OlMap;
 }
@@ -76,9 +76,9 @@ export class LayerSwitcher extends React.Component<LayerSwitcherProps, LayerSwit
   className = `${CSS_PREFIX}layer-switcher`;
 
   /**
-   * Create the Legend.
+   * Creates the LayerSwitcher.
    *
-   * @constructs Legend
+   * @constructs LayerSwitcher
    */
   constructor(props: LayerSwitcherProps) {
     super(props);
@@ -94,6 +94,17 @@ export class LayerSwitcher extends React.Component<LayerSwitcherProps, LayerSwit
   componentDidMount() {
     this.setMapLayers();
     this.updateLayerVisibilty();
+  }
+
+  /**
+   * Destroy all map specific stuff when umounting the component.
+   *
+   * @memberof LayerSwitcher
+   */
+  componentWillUnMount() {
+    this._map.getLayers().clear();
+    this._map.setTarget(null);
+    this._map = null;
   }
 
   /**

--- a/src/Util/TestUtil.tsx
+++ b/src/Util/TestUtil.tsx
@@ -71,10 +71,10 @@ export class TestUtil {
   /**
    * Creates an ol map.
    *
-   * @param {Object} [mapOpts] Additional options for the map to create.
-   * @return {ol.Map} The ol map.
+   * @param [mapOpts] Additional options for the map to create.
+   * @return The ol map.
    */
-  static createMap = (mapOpts?) => {
+  static createMap = (mapOpts?: any) => {
     let source = new OlSourceVector();
     let layer = new OlLayerVector({source: source});
     let targetDiv = TestUtil.mountMapDiv();
@@ -100,7 +100,7 @@ export class TestUtil {
   /**
    * Removes the map.
    */
-  static removeMap = (map) => {
+  static removeMap =  (map: OlMap) => {
     if (map instanceof OlMap) {
       map.dispose();
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import NominatimSearch from './Field/NominatimSearch/NominatimSearch';
 import WfsSearch from './Field/WfsSearch/WfsSearch';
 import WfsSearchInput from './Field/WfsSearchInput/WfsSearchInput';
 import ScaleCombo from './Field/ScaleCombo/ScaleCombo';
+import LayerSwitcher from './LayerSwitcher/LayerSwitcher';
 import LayerTree from './LayerTree/LayerTree';
 import LayerTreeNode from './LayerTreeNode/LayerTreeNode';
 import Legend from './Legend/Legend';
@@ -51,6 +52,7 @@ export {
   DigitizeButton,
   ZoomButton,
   ZoomToExtentButton,
+  LayerSwitcher,
   LayerTree,
   LayerTreeNode,
   Legend,

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -68,6 +68,9 @@ module.exports = {
     }, {
       name: 'HigherOrderComponents',
       components: 'src/HigherOrderComponent/**/*.tsx'
+    },{
+      name: 'LayerSwitcher',
+      components: 'src/LayerSwitcher/**/*.tsx'
     }, {
       name: 'LayerTree',
       components: 'src/LayerTree/**/*.tsx'


### PR DESCRIPTION
<!-- Please choose one of the categories and choose the corresponding label, too. -->
## FEATURE

### Description:
<!-- Please describe what this PR is about. -->
This introduces the `LayerSwitcher`.
A component designed to be used for switching between two (or more) backgroundlayers.

The view of the `LayerSwitcher` is synched with the maps view.

![localhost_9090_portal_tools=identify-connect,organise-implement](https://user-images.githubusercontent.com/1849416/69256576-f5dd5580-0bb9-11ea-8c77-228cc4a95821.png)


<!--- CHECKLIST
Fixes Issue?
Examples added?
Tests added?
Docs added?
Would a screenshot be helpful?
Do you want to mention someone?
-->
