### PR TITLE
Remove with withRef option in high order components

### DIFF
--- a/src/HigherOrderComponent/LoadifiedComponent/LoadifiedComponent.spec.tsx
+++ b/src/HigherOrderComponent/LoadifiedComponent/LoadifiedComponent.spec.tsx
@@ -17,9 +17,7 @@ describe('loadify', () => {
   /* eslint-enable require-jsdoc */
 
   beforeEach(() => {
-    EnhancedComponent = loadify(MockComponent, {
-      withRef: true
-    });
+    EnhancedComponent = loadify(MockComponent);
   });
 
   describe('Basics', () => {
@@ -44,25 +42,9 @@ describe('loadify', () => {
         otherProp: 'ppp'
       };
       const wrapper = TestUtil.mountComponent(EnhancedComponent, props);
-      const wrappedInstance = wrapper.instance().getWrappedInstance();
+      const wrappedInstance = wrapper.childAt(0).prop('children');
+
       expect(wrappedInstance.props).toEqual(expectedProps);
-    });
-
-    it('saves a reference to the wrapped instance if requested', () => {
-      const props = {
-        name: 'load',
-        prop: 'isprop'
-      };
-      const wrapper = TestUtil.mountComponent(EnhancedComponent, props);
-      const wrappedInstance = wrapper.instance().getWrappedInstance();
-      expect(wrappedInstance).toBeInstanceOf(MockComponent);
-
-      const EnhancedComponentNoRef = loadify(MockComponent, {
-        withRef: false
-      });
-      const wrapperNoRef = TestUtil.mountComponent(EnhancedComponentNoRef, props);
-      const wrappedInstanceNoRef = wrapperNoRef.instance().getWrappedInstance();
-      expect(wrappedInstanceNoRef).toBeUndefined();
     });
 
     it('shows or hides the Loading component based on the spinning prop', () => {

--- a/src/HigherOrderComponent/LoadifiedComponent/LoadifiedComponent.tsx
+++ b/src/HigherOrderComponent/LoadifiedComponent/LoadifiedComponent.tsx
@@ -1,11 +1,6 @@
 import * as React from 'react';
 import { Spin } from 'antd';
-import Logger from '@terrestris/base-util/dist/Logger';
 import { SpinProps } from 'antd/lib/spin';
-
-export interface LoadifiedComponentProps {
-  withRef?: boolean;
-}
 
 /**
  * The HOC factory function.
@@ -15,12 +10,9 @@ export interface LoadifiedComponentProps {
  * will be shown and if not it wont.
  *
  * @param WrappedComponent The component to wrap and enhance.
- * @param options The options to apply.
  * @return The wrapped component.
  */
-export function loadify<P>(WrappedComponent: React.ComponentType<any>, {
-  withRef = false
-}: LoadifiedComponentProps = {}) {
+export function loadify<P>(WrappedComponent: React.ComponentType<any>) {
 
   /**
    * The wrapper class for the given component.
@@ -29,8 +21,6 @@ export function loadify<P>(WrappedComponent: React.ComponentType<any>, {
    * @extends React.Component
    */
   return class LoadifiedComponent extends React.Component<P & Partial<SpinProps>> {
-
-    _wrappedInstance?: React.ReactElement;
 
     /**
      * The default properties.
@@ -46,36 +36,6 @@ export function loadify<P>(WrappedComponent: React.ComponentType<any>, {
      */
     constructor(props: P) {
       super(props);
-
-      /**
-       * The wrapped instance.
-       */
-      this._wrappedInstance = null;
-    }
-
-    /**
-     * Returns the wrapped instance. Only applicable if withRef is set to true.
-     *
-     * @return The wrappend instance.
-     */
-    getWrappedInstance = (): React.ReactElement | void => {
-      if (withRef) {
-        return this._wrappedInstance;
-      } else {
-        Logger.debug('No wrapped instance referenced, please call the '
-          + 'Loadify with option withRef = true.');
-      }
-    }
-
-    /**
-     * Sets the wrapped instance.
-     *
-     * @param instance The instance to set.
-     */
-    setWrappedInstance = (instance) => {
-      if (withRef) {
-        this._wrappedInstance = instance;
-      }
     }
 
     /**
@@ -102,14 +62,9 @@ export function loadify<P>(WrappedComponent: React.ComponentType<any>, {
         spinning
       };
 
-      // Check if WrappedComponent is a ReactComponent (class) as functional components
-      // can't have a ref
-      const isReactComponent = WrappedComponent.prototype.isReactComponent;
-
       return (
         <Spin {...passToLoader} >
           <WrappedComponent
-            ref={isReactComponent && this.setWrappedInstance}
             {...passThroughProps}
           />
         </Spin>

--- a/src/HigherOrderComponent/MappifiedComponent/MappifiedComponent.spec.tsx
+++ b/src/HigherOrderComponent/MappifiedComponent/MappifiedComponent.spec.tsx
@@ -23,9 +23,7 @@ describe('mappify', () => {
 
   beforeEach(() => {
     map = TestUtil.createMap();
-    EnhancedComponent = mappify(MockComponent, {
-      withRef: true
-    });
+    EnhancedComponent = mappify(MockComponent);
   });
 
   describe('Basics', () => {
@@ -42,7 +40,7 @@ describe('mappify', () => {
 
     it('adds the map from the context as a prop', () => {
       const wrapper = TestUtil.mountComponent(EnhancedComponent, {}, {context: {map}});
-      const wrappedInstance = wrapper.instance().getWrappedInstance();
+      const wrappedInstance = wrapper.childAt(0).instance();
 
       expect(wrappedInstance.props.map).toBe(map);
     });
@@ -51,7 +49,7 @@ describe('mappify', () => {
       const loggerSpy = jest.spyOn(Logger, 'warn');
       TestUtil.mountComponent(EnhancedComponent);
       expect(loggerSpy).toHaveBeenCalled();
-      expect(loggerSpy).toHaveBeenCalledWith('You trying to mappify a ' +
+      expect(loggerSpy).toHaveBeenCalledWith('You\'re trying to mappify a ' +
         'component without any map in the context. Did you implement ' +
         'the MapProvider?');
       loggerSpy.mockRestore();
@@ -68,28 +66,9 @@ describe('mappify', () => {
         map: map
       };
       const wrapper = TestUtil.mountComponent(EnhancedComponent, props, {context: {map}});
-      const wrappedInstance = wrapper.instance().getWrappedInstance();
+      const wrappedInstance = wrapper.childAt(0).instance();
 
       expect(wrappedInstance.props).toEqual(expectedProps);
-    });
-
-    it('saves a reference to the wrapped instance if requested', () => {
-      const props = {
-        name: 'Podolski'
-      };
-      const wrapper = TestUtil.mountComponent(EnhancedComponent, props, {context: {map}});
-      const wrappedInstance = wrapper.instance().getWrappedInstance();
-
-      expect(wrappedInstance).toBeInstanceOf(MockComponent);
-
-      const EnhancedComponentNoRef = mappify(MockComponent, {
-        withRef: false
-      });
-
-      const wrapperNoRef = TestUtil.mountComponent(EnhancedComponentNoRef, props, {context: {map}});
-      const wrappedInstanceNoRef = wrapperNoRef.instance().getWrappedInstance();
-
-      expect(wrappedInstanceNoRef).toBeUndefined();
     });
 
   });

--- a/src/HigherOrderComponent/MappifiedComponent/MappifiedComponent.tsx
+++ b/src/HigherOrderComponent/MappifiedComponent/MappifiedComponent.tsx
@@ -4,10 +4,6 @@ import OlMap from 'ol/Map';
 
 import Logger from '@terrestris/base-util/dist/Logger';
 
-interface MappifiedComponentProps {
-  withRef?: boolean;
-}
-
 /**
  * The HOC factory function.
  *
@@ -16,9 +12,7 @@ interface MappifiedComponentProps {
  * @param WrappedComponent The component to wrap and enhance.
  * @return The wrapped component.
  */
-export function mappify<P>(WrappedComponent: React.ComponentType<P>, {
-  withRef = false
-}: MappifiedComponentProps = {}) {
+export function mappify<P>(WrappedComponent: React.ComponentType<P>) {
 
   /**
    * The wrapper class for the given component.
@@ -26,9 +20,7 @@ export function mappify<P>(WrappedComponent: React.ComponentType<P>, {
    * @class The MappifiedComponent
    * @extends React.Component
    */
-  return class MappifiedComponent extends React.Component<Omit<P, 'map'> & MappifiedComponentProps> {
-
-    _wrappedInstance?: React.ReactElement;
+  return class MappifiedComponent extends React.Component<Omit<P, 'map'>> {
 
     /**
      * The context types.
@@ -42,38 +34,8 @@ export function mappify<P>(WrappedComponent: React.ComponentType<P>, {
      *
      * @constructs MappifiedComponent
      */
-    constructor(props: P & MappifiedComponentProps) {
+    constructor(props: P) {
       super(props);
-
-      /**
-       * The wrapped instance.
-       */
-      this._wrappedInstance = null;
-    }
-
-    /**
-     * Returns the wrapped instance. Only applicable if withRef is set to true.
-     *
-     * @return The wrapped instance.
-     */
-    getWrappedInstance = (): React.ReactElement | void => {
-      if (withRef) {
-        return this._wrappedInstance;
-      } else {
-        Logger.warn('No wrapped instance referenced, please call the '
-          + 'mappify with option withRef = true.');
-      }
-    }
-
-    /**
-     * Sets the wrapped instance.
-     *
-     * @param instance The instance to set.
-     */
-    setWrappedInstance = (instance) => {
-      if (withRef) {
-        this._wrappedInstance = instance;
-      }
     }
 
     /**
@@ -85,17 +47,12 @@ export function mappify<P>(WrappedComponent: React.ComponentType<P>, {
       } = this.context;
 
       if (!map) {
-        Logger.warn('You trying to mappify a component without any map in the ' +
-        'context. Did you implement the MapProvider?');
+        Logger.warn('You\'re trying to mappify a component without any map ' +
+          'in the context. Did you implement the MapProvider?');
       }
-
-      // Check if WrappedComponent is a ReactComponent (class) as functional components
-      // can't have a ref
-      const isReactComponent = WrappedComponent.prototype.isReactComponent;
 
       return (
         <WrappedComponent
-          ref={isReactComponent && this.setWrappedInstance}
           map={map}
           {...this.props as P}
         />

--- a/src/HigherOrderComponent/VisibleComponent/VisibleComponent.spec.tsx
+++ b/src/HigherOrderComponent/VisibleComponent/VisibleComponent.spec.tsx
@@ -20,9 +20,7 @@ describe('isVisibleComponent', () => {
   /* eslint-enable require-jsdoc */
 
   beforeEach(() => {
-    EnhancedComponent = isVisibleComponent(MockComponent, {
-      withRef: true
-    });
+    EnhancedComponent = isVisibleComponent(MockComponent);
   });
 
   describe('Basics', () => {
@@ -50,31 +48,9 @@ describe('isVisibleComponent', () => {
         name: 'shinjiKagawaModule'
       };
       const wrapper = TestUtil.mountComponent(EnhancedComponent, props);
-      const wrappedInstance = wrapper.instance().getWrappedInstance();
+      const wrappedInstance = wrapper.childAt(0).instance();
 
       expect(wrappedInstance.props).toEqual(expectedProps);
-    });
-
-    it('saves a reference to the wrapped instance if requested', () => {
-      const props = {
-        name: 'shinjiKagawaModule',
-        activeModules: [{
-          name: 'shinjiKagawaModule'
-        }]
-      };
-      const wrapper = TestUtil.mountComponent(EnhancedComponent, props);
-      const wrappedInstance = wrapper.instance().getWrappedInstance();
-
-      expect(wrappedInstance).toBeInstanceOf(MockComponent);
-
-      const EnhancedComponentNoRef = isVisibleComponent(MockComponent, {
-        withRef: false
-      });
-
-      const wrapperNoRef = TestUtil.mountComponent(EnhancedComponentNoRef, props);
-      const wrappedInstanceNoRef = wrapperNoRef.instance().getWrappedInstance();
-
-      expect(wrappedInstanceNoRef).toBeUndefined();
     });
 
     it('shows or hides the wrapped component in relation to it\'s representation in the activeModules prop', () => {

--- a/src/HigherOrderComponent/VisibleComponent/VisibleComponent.tsx
+++ b/src/HigherOrderComponent/VisibleComponent/VisibleComponent.tsx
@@ -1,11 +1,5 @@
 import * as React from 'react';
 
-import Logger from '@terrestris/base-util/dist/Logger';
-
-export interface IsVisibleComponentProps {
-  withRef?: boolean;
-}
-
 export interface VisibleComponentProps {
   activeModules: any[];
   name: string;
@@ -19,12 +13,10 @@ export interface VisibleComponentProps {
  * in the state, it will be rendered, if not, it wont.
  *
  * @param {Component} WrappedComponent The component to wrap and enhance.
- * @param {Object} options The options to apply.
  * @return {Component} The wrapped component.
  */
-export function isVisibleComponent<P extends VisibleComponentProps>(WrappedComponent: React.ComponentType<any>, {
-  withRef = false
-}: IsVisibleComponentProps = {}): React.ComponentType {
+export function isVisibleComponent<P extends VisibleComponentProps>(
+  WrappedComponent: React.ComponentType<any>): React.ComponentType {
 
   /**
    * The wrapper class for the given component.
@@ -34,46 +26,13 @@ export function isVisibleComponent<P extends VisibleComponentProps>(WrappedCompo
    */
   return class VisibleComponent extends React.Component<P> {
 
-    _wrappedInstance?: React.ReactElement;
-
     /**
      * Create the VisibleComponent.
      *
      * @constructs VisibleComponent
      */
-    constructor(props: P & IsVisibleComponentProps) {
+    constructor(props: P) {
       super(props);
-
-      /**
-       * The wrapped instance.
-       * @type {Element}
-       */
-      this._wrappedInstance = null;
-    }
-
-    /**
-     * Returns the wrapped instance. Only applicable if withRef is set to true.
-     *
-     * @return {Element} The wrappend instance.
-     */
-    getWrappedInstance = (): React.ReactElement | void => {
-      if (withRef) {
-        return this._wrappedInstance;
-      } else {
-        Logger.debug('No wrapped instance referenced, please call the '
-          + 'isVisibleComponent with option withRef = true.');
-      }
-    }
-
-    /**
-     * Sets the wrapped instance.
-     *
-     * @param {Element} instance The instance to set.
-     */
-    setWrappedInstance = (instance) => {
-      if (withRef) {
-        this._wrappedInstance = instance;
-      }
     }
 
     /**
@@ -109,16 +68,11 @@ export function isVisibleComponent<P extends VisibleComponentProps>(WrappedCompo
       // Check if the current component should be visible or not.
       const isVisible = this.isVisibleComponent(this.props.name);
 
-      // Check if WrappedComponent is a ReactComponent (class) as functional components
-      // can't have a ref
-      const isReactComponent = WrappedComponent.prototype.isReactComponent;
-
       // Inject props into the wrapped component. These are usually state
       // values or instance methods.
       return (
         isVisible ?
           <WrappedComponent
-            ref={isReactComponent && this.setWrappedInstance}
             {...passThroughProps as P}
           /> :
           null

--- a/src/Util/TestUtil.tsx
+++ b/src/Util/TestUtil.tsx
@@ -74,7 +74,7 @@ export class TestUtil {
    * @param {Object} [mapOpts] Additional options for the map to create.
    * @return {ol.Map} The ol map.
    */
-  static createMap = (mapOpts) => {
+  static createMap = (mapOpts?) => {
     let source = new OlSourceVector();
     let layer = new OlLayerVector({source: source});
     let targetDiv = TestUtil.mountMapDiv();


### PR DESCRIPTION
<!-- Please choose one of the categories and choose the corresponding label, too. -->
## BREAKING CHANGE | BUGFIX

### Description:
<!-- Please describe what this PR is about. -->
Removes the `withRef` option in some HOCs. It's not clear (except for the tests) why it's needed overall and it isn't working with function components or already wrapped components anyway. One should use `React.forwardRef()` instead if really needed.

Please review @KaiVolland.

<!--- CHECKLIST
Fixes Issue?
Examples added?
Tests added?
Docs added?
Would a screenshot be helpful?
Do you want to mention someone?
-->
