### PR TITLE
Introduces the TimeLayerSliderPanel for WMS-T layer

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -21,7 +21,7 @@ module.exports = {
     '<rootDir>/dist/'
   ],
   transformIgnorePatterns: [
-    'node_modules/(?!(ol|antd|(rc-*[a-z]*)|css-animation)/)'
+    'node_modules/(?!(ol|antd|(rc-[a-z-]*)|css-animation)/)'
   ],
   setupFiles: [
     '<rootDir>/jest/__mocks__/shim.js',

--- a/src/Panel/TimeLayerSliderPanel/TimeLayerSliderPanel.example.md
+++ b/src/Panel/TimeLayerSliderPanel/TimeLayerSliderPanel.example.md
@@ -12,7 +12,7 @@ import OlLayerTile from 'ol/layer/Tile';
 import OlSourceOSM from 'ol/source/OSM';
 import OlSourceTileWMS from 'ol/source/TileWMS';
 import { transformExtent } from 'ol/proj';
-import {getCenter} from 'ol/extent';
+import { getCenter } from 'ol/extent';
 
 import TimeLayerSliderPanel from '@terrestris/react-geo/Panel/TimeLayerSliderPanel/TimeLayerSliderPanel';
 

--- a/src/Panel/TimeLayerSliderPanel/TimeLayerSliderPanel.example.md
+++ b/src/Panel/TimeLayerSliderPanel/TimeLayerSliderPanel.example.md
@@ -35,7 +35,7 @@ class TimeLayerSliderPanelExample extends React.Component {
           params: {'LAYERS': 'nexrad-n0r-wmst'}
         })
       })
-    ]
+    ];
 
     this.map = new OlMap({
       layers: [

--- a/src/Panel/TimeLayerSliderPanel/TimeLayerSliderPanel.example.md
+++ b/src/Panel/TimeLayerSliderPanel/TimeLayerSliderPanel.example.md
@@ -29,6 +29,7 @@ class TimeLayerSliderPanelExample extends React.Component {
         extent: extent,
         type: 'WMSTime',
         timeFormat: 'YYYY-MM-DDTHH:mm:ss.sssZ',
+        roundToFullHours: true,
         source: new OlSourceTileWMS({
           attributions: ['Iowa State University'],
           url: '//mesonet.agron.iastate.edu/cgi-bin/wms/nexrad/n0r-t.cgi',
@@ -57,7 +58,6 @@ class TimeLayerSliderPanelExample extends React.Component {
   }
 
   render() {
-
     const tooltips = {
       setToNow: 'Set to now',
       hours: 'Hours',
@@ -76,13 +76,13 @@ class TimeLayerSliderPanelExample extends React.Component {
             height: '400px'
           }}
         />
-
         <TimeLayerSliderPanel
           map={this.map}
           initStartDate={moment().subtract(3, 'hours')}
           initEndDate={moment()}
           timeAwareLayers={this.layers}
           tooltips={tooltips}
+          autoPlaySpeedOptions={[0.5, 1, 2, 3, 4, 5, 600]}
         />
       </div>
     )

--- a/src/Panel/TimeLayerSliderPanel/TimeLayerSliderPanel.example.md
+++ b/src/Panel/TimeLayerSliderPanel/TimeLayerSliderPanel.example.md
@@ -24,7 +24,7 @@ class TimeLayerSliderPanelExample extends React.Component {
 
     this.mapDivId = `map-${Math.random()}`;
     var extent = transformExtent([-126, 24, -66, 50], 'EPSG:4326', 'EPSG:3857');
-    this.layers =  [
+    this.layers = [
       new OlLayerTile({
         extent: extent,
         type: 'WMSTime',

--- a/src/Panel/TimeLayerSliderPanel/TimeLayerSliderPanel.example.md
+++ b/src/Panel/TimeLayerSliderPanel/TimeLayerSliderPanel.example.md
@@ -56,10 +56,6 @@ class TimeLayerSliderPanelExample extends React.Component {
     this.map.setTarget(this.mapDivId);
   }
 
-  threeHoursAgo() {
-    return new Date(Math.round(Date.now() / 3600000) * 3600000 - 3600000 * 3);
-  }
-
   render() {
 
     const tooltips = {
@@ -83,7 +79,7 @@ class TimeLayerSliderPanelExample extends React.Component {
 
         <TimeLayerSliderPanel
           map={this.map}
-          initStartDate={moment(this.threeHoursAgo())}
+          initStartDate={moment().subtract(3, 'hours')}
           initEndDate={moment()}
           timeAwareLayers={this.layers}
           tooltips={tooltips}

--- a/src/Panel/TimeLayerSliderPanel/TimeLayerSliderPanel.example.md
+++ b/src/Panel/TimeLayerSliderPanel/TimeLayerSliderPanel.example.md
@@ -1,4 +1,4 @@
-This example demonstrates the use of TimeLayerSliderPanel  
+This example demonstrates the usage of the TimeLayerSliderPanel  
 (Data: IEM generated CONUS composite of NWS NEXRAD WSR-88D level III base reflectivity, Iowa State University)
 
 ```jsx

--- a/src/Panel/TimeLayerSliderPanel/TimeLayerSliderPanel.example.md
+++ b/src/Panel/TimeLayerSliderPanel/TimeLayerSliderPanel.example.md
@@ -1,0 +1,97 @@
+This example demonstrates the use of TimeLayerSliderPanel  
+(Data: IEM generated CONUS composite of NWS NEXRAD WSR-88D level III base reflectivity, Iowa State University)
+
+```jsx
+import * as React from 'react';
+
+import moment from 'moment';
+
+import OlMap from 'ol/Map';
+import OlView from 'ol/View';
+import OlLayerTile from 'ol/layer/Tile';
+import OlSourceOSM from 'ol/source/OSM';
+import OlSourceTileWMS from 'ol/source/TileWMS';
+import { transformExtent } from 'ol/proj';
+import {getCenter} from 'ol/extent';
+
+import TimeLayerSliderPanel from '@terrestris/react-geo/Panel/TimeLayerSliderPanel/TimeLayerSliderPanel';
+
+class TimeLayerSliderPanelExample extends React.Component {
+
+  constructor(props) {
+
+    super(props);
+
+    this.mapDivId = `map-${Math.random()}`;
+    var extent = transformExtent([-126, 24, -66, 50], 'EPSG:4326', 'EPSG:3857');
+    this.layers =  [
+      new OlLayerTile({
+        extent: extent,
+        type: 'WMSTime',
+        timeFormat: 'YYYY-MM-DDTHH:mm:ss.sssZ',
+        source: new OlSourceTileWMS({
+          attributions: ['Iowa State University'],
+          url: '//mesonet.agron.iastate.edu/cgi-bin/wms/nexrad/n0r-t.cgi',
+          params: {'LAYERS': 'nexrad-n0r-wmst'}
+        })
+      })
+    ]
+
+    this.map = new OlMap({
+      layers: [
+        new OlLayerTile({
+          name: 'OSM',
+          source: new OlSourceOSM()
+        }),
+        ...this.layers
+      ],
+      view: new OlView({
+        center: getCenter(extent),
+        zoom: 4
+      })
+    });
+  }
+
+  componentDidMount() {
+    this.map.setTarget(this.mapDivId);
+  }
+
+  threeHoursAgo() {
+    return new Date(Math.round(Date.now() / 3600000) * 3600000 - 3600000 * 3);
+  }
+
+  render() {
+
+    const tooltips = {
+      setToNow: 'Set to now',
+      hours: 'Hours',
+      days: 'Days',
+      weeks: 'Weeks',
+      months: 'Months',
+      years: 'Years',
+      dataRange: 'Set data range'
+    };
+
+    return(
+      <div>
+        <div
+          id={this.mapDivId}
+          style={{
+            height: '400px'
+          }}
+        />
+
+        <TimeLayerSliderPanel
+          map={this.map}
+          initStartDate={moment(this.threeHoursAgo())}
+          initEndDate={moment()}
+          timeAwareLayers={this.layers}
+          tooltips={tooltips}
+        />
+      </div>
+    )
+  }
+}
+
+<TimeLayerSliderPanelExample />
+```

--- a/src/Panel/TimeLayerSliderPanel/TimeLayerSliderPanel.less
+++ b/src/Panel/TimeLayerSliderPanel/TimeLayerSliderPanel.less
@@ -1,0 +1,59 @@
+.time-layer-slider {
+  bottom: 35px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  background-color: white;
+  border-bottom: 1px solid lightgray;
+
+  button {
+    margin-left: 5px;
+  }
+
+  .timeslider {
+    flex: 1;
+    margin: 10px;
+
+    &.ant-slider-with-marks {
+      margin: 10px 60px 20px 60px;
+    }
+  }
+
+  :not(.timeslider-in-future) {
+    .ant-slider-handle {
+      background-color: #4baeff;
+    }
+  }
+
+  .playback {
+    border-radius: 2px 0 0 2px;
+  }
+
+  .ant-select-selection {
+    background-color: white;
+    width: 150px;
+    margin-right: 5px;
+    border-radius: 0 4px 4px 0;
+  }
+
+  .time-value {
+    text-align: center;
+    width: 100px;
+    padding: 0 10px;
+    font-weight: bold;
+  }
+
+  &.no-layers-available {
+    pointer-events: none;
+    opacity: .8;
+    color: rgba(0, 0, 0, 0.35);
+    .ant-slider-mark span,
+    .ant-select {
+     color: rgba(0, 0, 0, 0.35);
+    }
+    button {
+      opacity: .5;
+    }
+  }
+}

--- a/src/Panel/TimeLayerSliderPanel/TimeLayerSliderPanel.spec.tsx
+++ b/src/Panel/TimeLayerSliderPanel/TimeLayerSliderPanel.spec.tsx
@@ -1,35 +1,19 @@
 /*eslint-env jest*/
 
-import TestUtils from '../../Util/TestUtil';
-
-import TimeLayerSliderPanel from './TimeLayerSliderPanel';
+import TestUtil from '../../Util/TestUtil';
+import moment from 'moment';
+import TimeLayerSliderPanel from '../TimeLayerSliderPanel/TimeLayerSliderPanel';
 
 describe('<TimeLayerSliderPanel />', () => {
-  let map;
-  let wrapper: any;
-
-  beforeEach(() => {
-    map = TestUtils.createMap({});
-    const defaultProps = {
-      t: () => { },
-      map: map,
-      dispatch: jest.fn()
-    };
-    wrapper = TestUtils.shallowConnectedComponentRoot(TimeLayerSliderPanel, defaultProps, null);
+  it('is defined', () => {
+    expect(TimeLayerSliderPanel).not.toBeUndefined();
   });
 
-  afterEach(() => {
-    wrapper.unmount();
-    TestUtils.unmountMapDiv();
-  });
-
-  describe('Basics', () => {
-    it('is defined', () => {
-      expect(TimeLayerSliderPanel).not.toBe(undefined);
+  it('can be rendered', () => {
+    const wrapper = TestUtil.mountComponent(TimeLayerSliderPanel, {
+      initStartDate: moment().subtract(3, 'hours'),
+      initEndDate: moment()
     });
-
-    it('can be rendered', () => {
-      expect(wrapper).not.toBe(undefined);
-    });
+    expect(wrapper).not.toBeUndefined();
   });
 });

--- a/src/Panel/TimeLayerSliderPanel/TimeLayerSliderPanel.spec.tsx
+++ b/src/Panel/TimeLayerSliderPanel/TimeLayerSliderPanel.spec.tsx
@@ -1,0 +1,35 @@
+/*eslint-env jest*/
+
+import TestUtils from '../../Util/TestUtil';
+
+import TimeLayerSliderPanel from './TimeLayerSliderPanel';
+
+describe('<TimeLayerSliderPanel />', () => {
+  let map;
+  let wrapper: any;
+
+  beforeEach(() => {
+    map = TestUtils.createMap({});
+    const defaultProps = {
+      t: () => { },
+      map: map,
+      dispatch: jest.fn()
+    };
+    wrapper = TestUtils.shallowConnectedComponentRoot(TimeLayerSliderPanel, defaultProps, null);
+  });
+
+  afterEach(() => {
+    wrapper.unmount();
+    TestUtils.unmountMapDiv();
+  });
+
+  describe('Basics', () => {
+    it('is defined', () => {
+      expect(TimeLayerSliderPanel).not.toBe(undefined);
+    });
+
+    it('can be rendered', () => {
+      expect(wrapper).not.toBe(undefined);
+    });
+  });
+});

--- a/src/Panel/TimeLayerSliderPanel/TimeLayerSliderPanel.tsx
+++ b/src/Panel/TimeLayerSliderPanel/TimeLayerSliderPanel.tsx
@@ -139,7 +139,7 @@ export class TimeLayerSliderPanel extends React.Component<TimeLayerSliderPanelPr
   componentDidUpdate(prevProps: TimeLayerSliderPanelProps) {
     // TODO: this deep check may impact performance..
     if (!(_isEqual(prevProps.timeAwareLayers, this.props.timeAwareLayers))) {
-      // update slider properties if some another layer set was chosen
+      // update slider properties if layers were updated
       this.wrapTimeSlider();
       this.findRangeForLayers();
     }

--- a/src/Panel/TimeLayerSliderPanel/TimeLayerSliderPanel.tsx
+++ b/src/Panel/TimeLayerSliderPanel/TimeLayerSliderPanel.tsx
@@ -81,7 +81,6 @@ export class TimeLayerSliderPanel extends React.Component<TimeLayerSliderPanelPr
    * The default props of LayerSetBaseMapChooser
    *
    * @static
-   * @type {DefaultLayerSetBaseMapChooserProps}
    * @memberof LayerSetBaseMapChooser
    */
   public static defaultProps: DefaultTimeLayerSliderPanelProps = {

--- a/src/Panel/TimeLayerSliderPanel/TimeLayerSliderPanel.tsx
+++ b/src/Panel/TimeLayerSliderPanel/TimeLayerSliderPanel.tsx
@@ -1,0 +1,487 @@
+import * as React from 'react';
+
+import moment from 'moment';
+
+const _isFinite = require('lodash/isFinite');
+const _isEqual = require('lodash/isEqual');
+
+import {
+  TimeSlider,
+  timeLayerAware,
+  ToggleButton,
+  SimpleButton
+} from '../../index';
+
+import {
+  Select,
+  DatePicker,
+  Popover
+} from 'antd';
+const { RangePicker } = DatePicker;
+const Option = Select.Option;
+
+import './TimeLayerSliderPanel.less';
+
+type timeRange = [moment.Moment, moment.Moment];
+
+export interface DefaultTimeLayerSliderPanelProps {
+  className: string;
+  onChange: (arg: moment.Moment) => void;
+  timeAwareLayers: any[];
+  value: moment.Moment;
+  dateFormat: string;
+  tooltips: object;
+}
+
+export interface TimeLayerSliderPanelProps extends Partial<DefaultTimeLayerSliderPanelProps> {
+  map: any;
+  initStartDate: moment.Moment;
+  initEndDate: moment.Moment;
+}
+
+export interface TimeLayerSliderPanelState {
+  value: moment.Moment;
+  playbackSpeed: string;
+  autoPlayActive: boolean;
+  startDate: moment.Moment;
+  endDate: moment.Moment;
+}
+
+/**
+ * mapStateToProps - mapping state to props of Map Component.
+ *
+ * @param {Object} state current state
+ * @return {Object} mapped props
+ */
+
+/**
+ * The panel combining all time slider related parts.
+ */
+export class TimeLayerSliderPanel extends React.Component<TimeLayerSliderPanelProps, TimeLayerSliderPanelState> {
+
+  private _TimeLayerAwareSlider: any;
+  private _wmsTimeLayers: any[];
+  private _interval: number;
+
+  /**
+   * The default props of LayerSetBaseMapChooser
+   *
+   * @static
+   * @type {DefaultLayerSetBaseMapChooserProps}
+   * @memberof LayerSetBaseMapChooser
+   */
+  public static defaultProps: DefaultTimeLayerSliderPanelProps = {
+    className: '',
+    onChange: () => {/* empty */},
+    timeAwareLayers: [],
+    value: moment(moment.now()),
+    dateFormat: 'YYYY-MM-DD',
+    tooltips: {
+      setToNow: 'Set to now',
+      hours: 'Hours',
+      days: 'Days',
+      weeks: 'Weeks',
+      months: 'Months',
+      years: 'Years',
+      dataRange: 'Set data range'
+    }
+  };
+
+  /**
+   * Constructs time panel.
+   */
+  constructor(props: TimeLayerSliderPanelProps) {
+    super(props);
+
+    this.state = {
+      value: moment().milliseconds(0),
+      playbackSpeed: '1',
+      autoPlayActive: false,
+      startDate: moment().milliseconds(0),
+      endDate: moment().milliseconds(0),
+    };
+    this._interval = 1000;
+
+    this.wrapTimeSlider();
+
+    // binds
+    this.onTimeChanged = this.onTimeChanged.bind(this);
+    this.autoPlay = this.autoPlay.bind(this);
+    this.updateDataRange = this.updateDataRange.bind(this);
+  }
+
+  componentDidMount() {
+    const {
+      initStartDate,
+      initEndDate
+    } = this.props;
+
+    this.setState({
+      startDate: initStartDate,
+      endDate: initEndDate
+    });
+  }
+
+  componentDidUpdate(prevProps: TimeLayerSliderPanelProps) {
+    // TODO this deep check may impact performance..
+    if (!(_isEqual(prevProps.timeAwareLayers, this.props.timeAwareLayers))) {
+      // update slider properties if some another layer set was chosen
+      this.wrapTimeSlider();
+      this.findRangeForLayers();
+    }
+  }
+
+  /**
+   *
+   * @param nextProps
+   * @param nextState
+   */
+  shouldComponentUpdate(nextProps: TimeLayerSliderPanelProps, nextState: TimeLayerSliderPanelState) {
+    const {
+      value,
+      autoPlayActive,
+      startDate,
+      endDate
+    } = this.state;
+    const {
+      timeAwareLayers
+    } = this.props;
+
+    if (nextState.value !== value) {
+      return true;
+    }
+    if (nextState.autoPlayActive !== autoPlayActive) {
+      return true;
+    }
+    if (nextState.startDate !== startDate) {
+      return true;
+    }
+    if (nextState.endDate !== endDate) {
+      return true;
+    }
+    if (!(_isEqual(nextProps.timeAwareLayers, timeAwareLayers))) {
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * Wraps the TimeSlider component in timeLayerAware.
+   */
+  wrapTimeSlider = () => {
+    this._wmsTimeLayers = [];
+    this.props.timeAwareLayers!.forEach((l: any) => {
+      if (l.get('type') === 'WMSTime') {
+        this._wmsTimeLayers.push({
+          layer: l
+        });
+      }
+    });
+    // make sure an initial value is set
+    this.wmsTimeHandler(this.state.value);
+    // @ts-ignore
+    this._TimeLayerAwareSlider = timeLayerAware(TimeSlider, this._wmsTimeLayers);
+  }
+
+  /**
+   * Updates slider time range depending on chosen layer set.
+   */
+  findRangeForLayers = () => {
+    const {
+      timeAwareLayers
+    } = this.props;
+    const {
+      startDate,
+      endDate,
+    } = this.state;
+
+    if (timeAwareLayers.length === 0) {
+      return;
+    }
+
+    let newStartDate: moment.Moment;
+    let newEndDate: moment.Moment;
+    let startDatesFromLayers: moment.Moment[] = [];
+    let endDatesFromLayers: moment.Moment[] = [];
+
+    this._wmsTimeLayers.forEach((l: any) => {
+      const layerStartDate = l.layer.get('startDate');
+      const layerEndDate = l.layer.get('endDate');
+      let sdm;
+      let edm;
+      if (layerStartDate) {
+        sdm = moment(l.layer.get('startDate'));
+      }
+      if (layerEndDate) {
+        edm = moment(l.layer.get('endDate'));
+      }
+      if (sdm) {
+        startDatesFromLayers.push(sdm);
+      }
+      if (edm) {
+        endDatesFromLayers.push(edm);
+      }
+    });
+    newStartDate = startDatesFromLayers.length > 0 ? moment.min(startDatesFromLayers) : startDate;
+    newEndDate = endDatesFromLayers.length > 0 ? moment.max(endDatesFromLayers) : endDate;
+    this.updateDataRange([newStartDate, newEndDate]);
+  }
+
+  /**
+   * Handler for the time slider change behaviour
+   */
+  timeSliderCustomHandler = (value: any) => {
+    const currentMoment = moment(value).milliseconds(0);
+    const newValue = currentMoment.clone();
+    this.setState({
+      value: newValue
+    });
+    if (this.props.onChange) {
+      this.props.onChange(newValue);
+    }
+  }
+
+  /**
+   * makes sure that the appended time parameter in GetMap calls
+   * is rounded to full hours to receive a valid response
+   */
+  wmsTimeHandler = (value?: any) => {
+    this._wmsTimeLayers.forEach(config => {
+      if (config.layer && config.layer.get('type') === 'WMSTime') {
+        const params = config.layer.getSource().getParams();
+        let time;
+        if (Array.isArray(value)) {
+          time = value[0];
+        } else {
+          time = value;
+        }
+        if (!moment.isMoment(time)) {
+          time = moment(time);
+        }
+        time.set('minute', 0);
+        time.set('second', 0);
+        const timeFormat = config.layer.get('timeFormat');
+        if (timeFormat.toLowerCase().indexOf('hh') > 0) {
+          params.TIME = time.toISOString();
+        } else {
+          params.TIME = time.format(timeFormat);
+        }
+        config.layer.getSource().updateParams(params);
+      }
+    });
+  }
+
+  /**
+   * start or stop auto playback
+   * TODO: we should do the request for new features less aggresive,
+   * e.g. a precache would be helpful
+   */
+  autoPlay(pressed: boolean) {
+    if (pressed) {
+      window.clearInterval(this._interval);
+      this._interval = window.setInterval(() => {
+        const {
+          endDate
+        } = this.state;
+        const {
+          value,
+          playbackSpeed
+        } = this.state;
+        if (value >= endDate!) {
+          window.clearInterval(this._interval);
+          this.setState({
+            autoPlayActive: false
+          });
+          return;
+        }
+
+        let newValue;
+        if (_isFinite(parseFloat(playbackSpeed))) {
+          newValue = value.clone().add(playbackSpeed, 'seconds');
+        } else {
+          newValue = value.clone().add(1, playbackSpeed as moment.DurationInputArg2);
+        }
+        this.timeSliderCustomHandler(newValue);
+        this.wmsTimeHandler(newValue);
+        // value is handled in timeSliderCustomHandler
+        this.setState({
+          autoPlayActive: true
+        });
+      }, 1000, this);
+    } else {
+      window.clearInterval(this._interval);
+      this.setState({
+        autoPlayActive: false
+      });
+    }
+  }
+
+  /**
+   * handle playback speed change
+   */
+  onPlaybackSpeedChange = (val: string) => {
+    this.setState({
+      playbackSpeed: val
+    }, () => {
+      if (this.state.autoPlayActive) {
+        this.autoPlay(true);
+      }
+    });
+  }
+
+  /**
+   * Sets the slider to the current time of the user
+   */
+  setSliderToNow = () => {
+    const now = moment().milliseconds(0);
+    this.setState({
+      value: now,
+      endDate: now
+    }, () => {
+      this.timeSliderCustomHandler(now);
+      this.wmsTimeHandler(now);
+    });
+  }
+
+  /**
+   *
+   */
+  updateDataRange([startDate, endDate]: timeRange) {
+    this.setState({
+      startDate,
+      endDate
+    });
+  }
+
+  /**
+   *
+   * @param val
+   */
+  onTimeChanged(val: string) {
+    this.setState({
+      value: moment(val)
+    }, () => {
+      this.wmsTimeHandler(this.state.value);
+    });
+  }
+
+  /**
+   *
+   *
+   * @memberof TimeLayerSliderPanel
+   */
+  render = () => {
+    const {
+      className,
+      timeAwareLayers,
+      dateFormat,
+      tooltips
+    } = this.props;
+    const {
+      autoPlayActive,
+      value,
+      startDate,
+      endDate
+    } = this.state;
+
+    const resetVisible = true;
+
+    const startDateString = startDate ? startDate.toISOString() : undefined;
+    const endDateString = endDate ? endDate.toISOString() : undefined;
+    const valueString = value ? value.toISOString() : undefined;
+    const mid = startDate!.clone().add(endDate!.diff(startDate) / 2);
+    const marks = {};
+    const futureClass = moment().isBefore(value) ? ' timeslider-in-future' : '';
+    const extraCls = className ? className : '';
+    const disabledCls = timeAwareLayers.length < 1 ? 'no-layers-available' : '';
+
+    marks[startDateString] = {
+      label: startDate!.format(dateFormat)
+    };
+    marks[endDateString] = {
+      label: endDate!.format(dateFormat),
+      style: {
+        left: 'unset',
+        right: 0,
+        transform: 'translate(50%)'
+      }
+    };
+    marks[mid.toISOString()] = {
+      label: mid.format(dateFormat)
+    };
+
+    return (
+      <div className={`time-layer-slider ${disabledCls}`.trim()}>
+
+        <Popover
+          placement="topRight"
+          title={tooltips['dataRange']}
+          trigger="click"
+          content={
+            <RangePicker
+              showTime={{ format: 'HH:mm' }}
+              defaultValue={[startDate, endDate]}
+              onOk={this.updateDataRange}
+            />
+          }
+        >
+          <SimpleButton
+            className="change-datarange-button"
+            icon="calendar-o"
+          />
+        </Popover>
+        {
+          resetVisible ?
+            <SimpleButton
+              type="primary"
+              icon="refresh"
+              onClick={this.setSliderToNow}
+              tooltip={tooltips['setToNow']}
+            /> : null
+        }
+        <this._TimeLayerAwareSlider
+          className={`${extraCls} timeslider ${futureClass}`.trim()}
+          formatString={dateFormat}
+          defaultValue={startDateString}
+          min={startDateString}
+          max={endDateString}
+          value={valueString}
+          marks={marks}
+          onChange={this.onTimeChanged}
+        />
+        <div className="time-value">
+          {value.format('DD.MM.YYYY HH:mm:ss')}
+        </div>
+        <ToggleButton
+          type="primary"
+          icon="play-circle-o"
+          className={extraCls + ' playback'}
+          pressed={autoPlayActive}
+          onToggle={this.autoPlay}
+          tooltip={autoPlayActive ? 'Pause' : 'Autoplay'}
+          pressedIcon="pause-circle-o"
+        />
+        <Select
+          defaultValue={'1'}
+          className={extraCls + ' speed-picker'}
+          onChange={this.onPlaybackSpeedChange}
+        >
+          <Option value="0.5">0.5x</Option>
+          <Option value="1">1x</Option>
+          <Option value="2">2x</Option>
+          <Option value="5">5x</Option>
+          <Option value="10">10x</Option>
+          <Option value="100">100x</Option>
+          <Option value="300">300x</Option>
+          <Option value="hours">{tooltips['hours']}</Option>
+          <Option value="days">{tooltips['days']}</Option>
+          <Option value="weeks">{tooltips['weeks']}</Option>
+          <Option value="months">{tooltips['months']}</Option>
+          <Option value="years">{tooltips['years']}</Option>
+        </Select>
+      </div>
+    );
+  }
+}
+
+export default TimeLayerSliderPanel;

--- a/src/Panel/TimeLayerSliderPanel/TimeLayerSliderPanel.tsx
+++ b/src/Panel/TimeLayerSliderPanel/TimeLayerSliderPanel.tsx
@@ -37,7 +37,9 @@ export interface Tooltips {
 export interface DefaultTimeLayerSliderPanelProps {
   className: string;
   onChange: (arg: moment.Moment) => void;
-  timeAwareLayers: any[];
+  import OlLayer from 'ol/layer/OlLayer';
+  (…)
+  timeAwareLayers: OlLayer[];
   value: moment.Moment;
   dateFormat: string;
   tooltips: Tooltips;

--- a/src/Panel/TimeLayerSliderPanel/TimeLayerSliderPanel.tsx
+++ b/src/Panel/TimeLayerSliderPanel/TimeLayerSliderPanel.tsx
@@ -17,12 +17,22 @@ import {
   DatePicker,
   Popover
 } from 'antd';
-const { RangePicker } = DatePicker;
+const RangePicker = DatePicker.RangePicker;
 const Option = Select.Option;
 
 import './TimeLayerSliderPanel.less';
 
 type timeRange = [moment.Moment, moment.Moment];
+
+export interface Tooltips {
+  hours: string;
+  days: string;
+  weeks: string;
+  months: string;
+  years: string;
+  setToNow: string;
+  dataRange: string;
+}
 
 export interface DefaultTimeLayerSliderPanelProps {
   className: string;
@@ -30,7 +40,7 @@ export interface DefaultTimeLayerSliderPanelProps {
   timeAwareLayers: any[];
   value: moment.Moment;
   dateFormat: string;
-  tooltips: object;
+  tooltips: Tooltips;
 }
 
 export interface TimeLayerSliderPanelProps extends Partial<DefaultTimeLayerSliderPanelProps> {
@@ -123,7 +133,7 @@ export class TimeLayerSliderPanel extends React.Component<TimeLayerSliderPanelPr
   }
 
   componentDidUpdate(prevProps: TimeLayerSliderPanelProps) {
-    // TODO this deep check may impact performance..
+    // TODO: this deep check may impact performance..
     if (!(_isEqual(prevProps.timeAwareLayers, this.props.timeAwareLayers))) {
       // update slider properties if some another layer set was chosen
       this.wrapTimeSlider();
@@ -179,7 +189,6 @@ export class TimeLayerSliderPanel extends React.Component<TimeLayerSliderPanelPr
     });
     // make sure an initial value is set
     this.wmsTimeHandler(this.state.value);
-    // @ts-ignore
     this._TimeLayerAwareSlider = timeLayerAware(TimeSlider, this._wmsTimeLayers);
   }
 
@@ -415,7 +424,7 @@ export class TimeLayerSliderPanel extends React.Component<TimeLayerSliderPanelPr
 
         <Popover
           placement="topRight"
-          title={tooltips['dataRange']}
+          title={tooltips.dataRange}
           trigger="click"
           content={
             <RangePicker
@@ -436,7 +445,7 @@ export class TimeLayerSliderPanel extends React.Component<TimeLayerSliderPanelPr
               type="primary"
               icon="refresh"
               onClick={this.setSliderToNow}
-              tooltip={tooltips['setToNow']}
+              tooltip={tooltips.setToNow}
             /> : null
         }
         <this._TimeLayerAwareSlider
@@ -473,11 +482,11 @@ export class TimeLayerSliderPanel extends React.Component<TimeLayerSliderPanelPr
           <Option value="10">10x</Option>
           <Option value="100">100x</Option>
           <Option value="300">300x</Option>
-          <Option value="hours">{tooltips['hours']}</Option>
-          <Option value="days">{tooltips['days']}</Option>
-          <Option value="weeks">{tooltips['weeks']}</Option>
-          <Option value="months">{tooltips['months']}</Option>
-          <Option value="years">{tooltips['years']}</Option>
+          <Option value="hours">{tooltips.hours}</Option>
+          <Option value="days">{tooltips.days}</Option>
+          <Option value="weeks">{tooltips.weeks}</Option>
+          <Option value="months">{tooltips.months}</Option>
+          <Option value="years">{tooltips.years}</Option>
         </Select>
       </div>
     );

--- a/src/Panel/TimeLayerSliderPanel/TimeLayerSliderPanel.tsx
+++ b/src/Panel/TimeLayerSliderPanel/TimeLayerSliderPanel.tsx
@@ -46,7 +46,9 @@ export interface DefaultTimeLayerSliderPanelProps {
 }
 
 export interface TimeLayerSliderPanelProps extends Partial<DefaultTimeLayerSliderPanelProps> {
-  map: any;
+  import OlMap from 'ol/Map';
+  (…)
+  map: OlMap;
   initStartDate: moment.Moment;
   initEndDate: moment.Moment;
 }

--- a/src/Slider/TimeSlider/TimeSlider.tsx
+++ b/src/Slider/TimeSlider/TimeSlider.tsx
@@ -5,7 +5,7 @@ import { Slider } from 'antd';
 
 const isArray = require('lodash/isArray');
 const isObject = require('lodash/isObject');
-import { SliderMarks, SliderValue, SliderProps } from 'antd/lib/slider';
+import { SliderMarks, SliderValue } from 'antd/lib/slider';
 
 import { CSS_PREFIX } from '../../constants';
 
@@ -52,7 +52,7 @@ export interface BaseProps {
   marks?: SliderMarks;
 }
 
-export type TimeSliderProps = BaseProps & Partial<DefaultProps> & SliderProps;
+export type TimeSliderProps = BaseProps & Partial<DefaultProps>;
 
 /**
  * Customized slider that uses ISO 8601 time strings as input.

--- a/src/Slider/TimeSlider/TimeSlider.tsx
+++ b/src/Slider/TimeSlider/TimeSlider.tsx
@@ -5,7 +5,7 @@ import { Slider } from 'antd';
 
 const isArray = require('lodash/isArray');
 const isObject = require('lodash/isObject');
-import { SliderMarks, SliderValue } from 'antd/lib/slider';
+import { SliderMarks, SliderValue, SliderProps } from 'antd/lib/slider';
 
 import { CSS_PREFIX } from '../../constants';
 
@@ -52,7 +52,8 @@ export interface BaseProps {
   marks?: SliderMarks;
 }
 
-export type TimeSliderProps = BaseProps & Partial<DefaultProps>;
+export type TimeSliderProps = BaseProps & Partial<DefaultProps> &
+  Omit<SliderProps, 'value' | 'defaultValue' | 'min' | 'max' | 'onChange'>;
 
 /**
  * Customized slider that uses ISO 8601 time strings as input.

--- a/tslint.json
+++ b/tslint.json
@@ -38,7 +38,7 @@
     "no-construct": true,
     "no-debugger": false,
     "no-duplicate-variable": true,
-    "no-empty": true,
+    "no-empty": [true, "allow-empty-functions"],
     "no-eval": true,
     "no-shadowed-variable": true,
     "no-string-literal": true,


### PR DESCRIPTION
<!-- Please choose one of the categories and choose the corresponding label, too. -->
# FEATURE

## Description
<!-- Please describe what this PR is about. -->
This merges the existing `TimeSlider` and `TimeLayerAware` components into the new panel component `TimeLayerSliderPanel`.

![timelayersliderpanel](https://user-images.githubusercontent.com/43119593/70331771-78177c00-1840-11ea-8e4f-730dd7aaf10e.png)

Some points are still open:

* [x] [tooltips](https://github.com/terrestris/react-geo/compare/master...mholthausen:introduce-timelayersliderpanel?expand=1#diff-0e03078ed2beb0b1d78fb55d39828718R476): object access via string literals is disallowed
* [x] [ts-ignore](https://github.com/terrestris/react-geo/compare/master...mholthausen:introduce-timelayersliderpanel?expand=1#diff-0e03078ed2beb0b1d78fb55d39828718R183): When removed, the application fails to compile `Argument of type 'typeof TimeSlider' is not assignable to parameter of type 'ComponentType<TimeSliderProps>'.`
* [x] Tests: no working tests included until yet

Maybe another rect-geo @terrestris/devs can help me out here soon.

<!--- CHECKLIST
Fixes Issue?
Examples added?
Tests added?
Docs added?
Would a screenshot be helpful?
Do you want to mention someone?
-->
