### PR TITLE
Fix for different feature types in a single response

### DIFF
--- a/src/CoordinateInfo/CoordinateInfo.tsx
+++ b/src/CoordinateInfo/CoordinateInfo.tsx
@@ -12,7 +12,6 @@ import OlFeature from 'ol/Feature';
 
 import _cloneDeep from 'lodash/cloneDeep';
 
-import UrlUtil from '@terrestris/base-util/dist/UrlUtil/UrlUtil';
 import Logger from '@terrestris/base-util/dist/Logger';
 
 import './CoordinateInfo.less';
@@ -136,7 +135,7 @@ export class CoordinateInfo extends React.Component<CoordinateInfoProps, Coordin
     const pixel = map.getEventPixel(olEvt.originalEvent);
     const coordinate = olEvt.coordinate;
 
-    let featureInfoUrls = [];
+    let promises = [];
 
     map.forEachLayerAtPixel(pixel, (layer: OlLayerBase) => {
       const layerSource = layer.getSource();
@@ -150,7 +149,7 @@ export class CoordinateInfo extends React.Component<CoordinateInfoProps, Coordin
         }
       );
 
-      featureInfoUrls.push(featureInfoUrl);
+      promises.push(fetch(featureInfoUrl));
 
       if (!drillDown) {
         return true;
@@ -160,13 +159,6 @@ export class CoordinateInfo extends React.Component<CoordinateInfoProps, Coordin
     }, {
       layerFilter: this.layerFilter,
       hitTolerance: hitTolerance
-    });
-
-    const combinedFeatureInfoUrls = UrlUtil.bundleOgcRequests(featureInfoUrls, true);
-
-    let promises = [];
-    Object.keys(combinedFeatureInfoUrls).forEach((key: string) => {
-      promises.push(fetch(combinedFeatureInfoUrls[key]));
     });
 
     map.getTargetElement().style.cursor = 'wait';


### PR DESCRIPTION
<!-- Please choose one of the categories and choose the corresponding label, too. -->
## BUGFIX

### Description:
<!-- Please describe what this PR is about. -->
Don't bundle requests in the `CoordinateInfo` component, the ol format parser can't handle different feature types in a single response.

Please review @terrestris/devs.

<!--- CHECKLIST
Fixes Issue?
Examples added?
Tests added?
Docs added?
Would a screenshot be helpful?
Do you want to mention someone?
-->
