### PR TITLE
Revert "Bump ol from 6.2.1 to 6.3.0"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24230,9 +24230,9 @@
       "dev": true
     },
     "ol": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/ol/-/ol-6.3.0.tgz",
-      "integrity": "sha512-ldgzOrWRuH0UGSGn8qvP7FXezSB90Vs1zn8HSpmqnS6iyaAV21qR5kbBfDChk1S+hj//43Zgd/ed8DvtPc4reA==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/ol/-/ol-6.2.1.tgz",
+      "integrity": "sha512-CT2szew/COd7Zf9Bls+pdzewBYZNgyfxFivJ3L4Jv9Th7JdWjcQAT+pqMPH25L9SbVT+T17RCMq2H2m9uBCl1A==",
       "dev": true,
       "requires": {
         "elm-pep": "^1.0.4",


### PR DESCRIPTION
This reverts terrestris/react-geo#1366 since the build is failing afterwards. See [here](https://github.com/openlayers/openlayers/issues/10871) for details why.