### PR TITLE
Fixes a type definition error for OlCoordinate (master v14)

### DIFF
--- a/src/Button/MeasureButton/MeasureButton.tsx
+++ b/src/Button/MeasureButton/MeasureButton.tsx
@@ -10,7 +10,6 @@ import OlStyleStyle from 'ol/style/Style';
 import OlStyleStroke from 'ol/style/Stroke';
 import OlStyleFill from 'ol/style/Fill';
 import OlStyleCircle from 'ol/style/Circle';
-import OlCoordinate from 'ol/coordinate';
 import OlInteractionDraw from 'ol/interaction/Draw';
 import { unByKey } from 'ol/Observable';
 import OlOverlay from 'ol/Overlay';
@@ -545,7 +544,7 @@ class MeasureButton extends React.Component<MeasureButtonProps> {
    *
    * @param coordinate The coordinate for the tooltip.
    */
-  addMeasureStopTooltip(coordinate: OlCoordinate) {
+  addMeasureStopTooltip(coordinate: Array<number>) {
     const {
       measureType,
       decimalPlacesInTooltips,


### PR DESCRIPTION
<!-- Please choose one of the categories and choose the corresponding label, too. -->
## BUGFIX

### Description:
Fixes an error for type definition of `olCoordinate`.  
`olCoordinate` is a module and not a type.  

This is a request to update the current master (v14)!

@terrestris/devs please review

<!--- CHECKLIST
Fixes Issue?
Examples added?
Tests added?
Docs added?
Would a screenshot be helpful?
Do you want to mention someone?
-->
