### PR TITLE
Bugfix/1717 pressed icon name pressed icon property of toggle button

### DIFF
--- a/src/Button/ToggleButton/ToggleButton.less
+++ b/src/Button/ToggleButton/ToggleButton.less
@@ -20,6 +20,11 @@ button.react-geo-togglebutton {
     border-color: darken(@component-background, 10);
   }
 
+  // overrides the ant-btn:empty style, that is setting the button to hidden if no text or icon are given
+  &:empty {
+    visibility: visible;
+  }
+
   &.btn-pressed {
     background-color: darken(@primary-color, 20);
     border-color: darken(@primary-color, 25);

--- a/src/Button/ToggleButton/ToggleButton.spec.tsx
+++ b/src/Button/ToggleButton/ToggleButton.spec.tsx
@@ -223,6 +223,6 @@ describe('<ToggleButton />', () => {
       pressedIconName: undefined,
       pressed: true
     });
-    expect(wrapper).not.toBeUndefined();
+    expect(wrapper.find('button')).toBeDefined();
   });
 });

--- a/src/Button/ToggleButton/ToggleButton.spec.tsx
+++ b/src/Button/ToggleButton/ToggleButton.spec.tsx
@@ -215,4 +215,14 @@ describe('<ToggleButton />', () => {
     wrapper.find('button').simulate('click');
     expect(wrapper.state('overallPressed')).toBe(true);
   });
+
+  it('can be rendered if iconName has been set and not text or icon is set with the property pressed set to true', () => {
+    const wrapper = TestUtil.mountComponent(ToggleButton);
+    wrapper.setProps({
+      iconName: 'some-icon-name',
+      pressedIconName: undefined,
+      pressed: true
+    });
+    expect(wrapper).not.toBeUndefined();
+  });
 });

--- a/src/Button/ToggleButton/ToggleButton.spec.tsx
+++ b/src/Button/ToggleButton/ToggleButton.spec.tsx
@@ -216,7 +216,7 @@ describe('<ToggleButton />', () => {
     expect(wrapper.state('overallPressed')).toBe(true);
   });
 
-  it('can be rendered if iconName has been set and not text or icon is set with the property pressed set to true', () => {
+  it('can be rendered if iconName is set and no text or icon is set with the property pressed set to true', () => {
     const wrapper = TestUtil.mountComponent(ToggleButton);
     wrapper.setProps({
       iconName: 'some-icon-name',


### PR DESCRIPTION
<!-- Please choose one of the categories and choose the corresponding label, too. -->
## BUGFIX

### Description:
<!-- Please describe what this PR is about. -->
if one of `iconName` or icon is set as prop on `ToggleButton`, one of `pressedIconName` or `pressedIcon` must be set as well. Otherwise the button turns invisible (`ant-btn:empty` class will be added) after the button was toggled.
Altough it makes sense in general to provide both a pressed icon and a default icon, or maybe a text, making the button not always empty, sometimes our code logic may required otherwise. For this reason, I am setting a new class in the `react-geo-togglebutton` style that will override the `ant-btn:empty`.

## CHECKLIST
Fixes Issue: #1717 
Examples added? No (No need to)
Tests added? Yes
Docs added? No (no need to)
Would a screenshot be helpful? No
Do you want to mention someone: @annarieger 

