### PR TITLE
Added notes to documentation on ToogleGroup and ToogleButton

### DIFF
--- a/src/Button/ToggleButton/ToggleButton.tsx
+++ b/src/Button/ToggleButton/ToggleButton.tsx
@@ -26,7 +26,7 @@ interface DefaultProps {
   tooltipProps: AbstractTooltipProps;
   /**
    * The initial pressed state of the ToggleButton
-   * Note: If ToggleButton is set inside a ToggleGroup, this prop will be controlled by selectedName prop on
+   * Note: If a ToggleButton is inside a ToggleGroup, the pressed state will be controlled by the selectedName property of the
    * ToggleGroup. Setting in in Toggle button will not work.
    */
   pressed: boolean;

--- a/src/Button/ToggleButton/ToggleButton.tsx
+++ b/src/Button/ToggleButton/ToggleButton.tsx
@@ -26,8 +26,8 @@ interface DefaultProps {
   tooltipProps: AbstractTooltipProps;
   /**
    * The initial pressed state of the ToggleButton
-   * Note: If a ToggleButton is inside a ToggleGroup, the pressed state will be controlled by the selectedName property of the
-   * ToggleGroup and this property will be ignored.
+   * Note: If a ToggleButton is inside a ToggleGroup, the pressed state will be controlled by the selectedName property
+   * of the ToggleGroup and this property will be ignored.
    */
   pressed: boolean;
   /**

--- a/src/Button/ToggleButton/ToggleButton.tsx
+++ b/src/Button/ToggleButton/ToggleButton.tsx
@@ -27,7 +27,7 @@ interface DefaultProps {
   /**
    * The initial pressed state of the ToggleButton
    * Note: If a ToggleButton is inside a ToggleGroup, the pressed state will be controlled by the selectedName property of the
-   * ToggleGroup. Setting in in Toggle button will not work.
+   * ToggleGroup and this property will be ignored.
    */
   pressed: boolean;
   /**

--- a/src/Button/ToggleButton/ToggleButton.tsx
+++ b/src/Button/ToggleButton/ToggleButton.tsx
@@ -26,6 +26,8 @@ interface DefaultProps {
   tooltipProps: AbstractTooltipProps;
   /**
    * The initial pressed state of the ToggleButton
+   * Note: If ToggleButton is set inside a ToggleGroup, this prop will be controlled by selectedName prop on
+   * ToggleGroup. Setting in in Toggle button will not work.
    */
   pressed: boolean;
   /**
@@ -229,7 +231,7 @@ class ToggleButton extends React.Component<ToggleButtonProps, ToggleButtonState>
         // when used with ToggleGroup. Since the ToggleGroup changes the
         // pressed prop for its child components the click event dose not need to
         // change the pressed property.
-        this.setState({overallPressed: !this.state.overallPressed});
+        this.setState({ overallPressed: !this.state.overallPressed });
       }
     });
   }

--- a/src/Button/ToggleGroup/ToggleGroup.tsx
+++ b/src/Button/ToggleGroup/ToggleGroup.tsx
@@ -31,7 +31,7 @@ interface BaseProps {
    * The value fo the `name` attribute of the children to select/press
    * initially.
    * Note: This prop will have full control over the pressed prop on its children. Setting select/pressed on the
-   * children props directly, will have no effect.
+   * children props directly will have no effect.
    */
   selectedName?: string;
   /**

--- a/src/Button/ToggleGroup/ToggleGroup.tsx
+++ b/src/Button/ToggleGroup/ToggleGroup.tsx
@@ -30,6 +30,8 @@ interface BaseProps {
   /**
    * The value fo the `name` attribute of the children to select/press
    * initially.
+   * Note: This prop will have full control over the pressed prop on its children. Setting select/pressed on the
+   * children props directly, will have no effect.
    */
   selectedName?: string;
   /**
@@ -119,9 +121,9 @@ class ToggleGroup extends React.Component<ToggleGroupProps, ToggleGroupState> {
     }
     // Allow deselect.
     if (this.props.allowDeselect && (childProps.name === this.state.selectedName)) {
-      this.setState({selectedName: null});
+      this.setState({ selectedName: null });
     } else {
-      this.setState({selectedName: childProps.name});
+      this.setState({ selectedName: childProps.name });
     }
   }
 
@@ -129,7 +131,7 @@ class ToggleGroup extends React.Component<ToggleGroupProps, ToggleGroupState> {
    * The render function.
    */
   render() {
-    const {orientation, children} = this.props;
+    const { orientation, children } = this.props;
     const className = this.props.className
       ? `${this.props.className} ${this._className}`
       : this._className;


### PR DESCRIPTION
<!-- Please choose one of the categories and choose the corresponding label, too. -->
DOCUMENTATION

### Description:
<!-- Please describe what this PR is about. -->
`ToggleButton` has a property called `pressed` that is overridden by the property `selectedName` from `ToogleGroup`. This appears to cause some confusion on some users, so a note to the documentation has been added.

Fixes Issue? #1710 
Examples added? No (not needed)
Tests added? No (not needed)
Docs added? Yes
Would a screenshot be helpful? No

