### PR TITLE
DigitizeButton interaction handling

### DIFF
--- a/src/Button/DigitizeButton/DigitizeButton.spec.tsx
+++ b/src/Button/DigitizeButton/DigitizeButton.spec.tsx
@@ -4,6 +4,8 @@ import Logger from '@terrestris/base-util/dist/Logger';
 import OlSourceVector from 'ol/source/Vector';
 import OlInteractionDraw from 'ol/interaction/Draw';
 import OlInteractionSelect from 'ol/interaction/Select';
+import OlInteractionModify from 'ol/interaction/Modify';
+import OlInteractionTranslate from 'ol/interaction/Translate';
 import OlStyleStyle from 'ol/style/Style';
 import OlStyleStroke from 'ol/style/Stroke';
 import OlStyleFill from 'ol/style/Fill';
@@ -37,12 +39,17 @@ describe('<DigitizeButton />', () => {
    *
    * @return {Object} The wrapped component.
    */
-  const setupWrapper = () => {
+  const setupWrapper = (shallow: boolean = false) => {
     const defaultProps = {
       map: map,
       drawType: 'Point'
     };
-    return TestUtil.mountComponent(DigitizeButton, defaultProps);
+
+    if (shallow) {
+      return TestUtil.shallowComponent(DigitizeButton, defaultProps);
+    } else {
+      return TestUtil.mountComponent(DigitizeButton, defaultProps);
+    }
   };
 
   /**
@@ -62,23 +69,6 @@ describe('<DigitizeButton />', () => {
       })
     });
   };
-
-  /**
-   * Returns a mock OlInteractionSelect .
-   *
-   * @return {Object} The mocked interaction.
-   */
-  const getMockSelectInteraction = () => {
-    return new OlInteractionSelect({
-      style: new OlStyleStyle({
-        stroke: new OlStyleStroke({
-          color: 'red',
-          width: 2
-        })
-      })
-    });
-  };
-
 
   describe('#Basics', () => {
 
@@ -134,45 +124,86 @@ describe('<DigitizeButton />', () => {
         });
       });
 
-      // eslint-disable-next-line max-len
-      it ('calls a createDrawInteraction method if button was pressed and valid drawType was provided', () => {
-        const wrapper = setupWrapper();
+      it ('creates a draw interaction on mount', () => {
+        const wrapper = setupWrapper(true);
         const createDrawInteraction = jest.spyOn(wrapper.instance(), 'createDrawInteraction');
 
-        wrapper.instance().onToggle(true);
+        expect(createDrawInteraction).toHaveBeenCalledTimes(0);
+
+        wrapper.instance().componentDidMount();
         expect(createDrawInteraction).toHaveBeenCalledTimes(1);
+
+        expect(wrapper.instance()._drawInteraction).toBeInstanceOf(OlInteractionDraw);
+        expect(wrapper.instance()._drawInteraction.getActive()).toBeFalsy();
 
         createDrawInteraction.mockRestore();
       });
 
-      // eslint-disable-next-line max-len
-      it ('calls a createSelectOrModifyInteraction method if button was pressed and valid editType was provided', () => {
-        const wrapper = setupWrapper();
+      it ('creates a select interaction on mount', () => {
+        const wrapper = setupWrapper(true);
         wrapper.setProps({
           drawType: null,
           editType: 'Edit'
         });
-        const createSelectOrModifyInteraction = jest.spyOn(wrapper.instance(), 'createSelectOrModifyInteraction');
+        const createSelectInteraction = jest.spyOn(wrapper.instance(), 'createSelectInteraction');
 
-        wrapper.instance().onToggle(true);
-        expect(createSelectOrModifyInteraction).toHaveBeenCalledTimes(1);
+        expect(createSelectInteraction).toHaveBeenCalledTimes(0);
 
-        createSelectOrModifyInteraction.mockRestore();
+        wrapper.instance().componentDidMount();
+        expect(createSelectInteraction).toHaveBeenCalledTimes(1);
+
+        expect(wrapper.instance()._selectInteraction).toBeInstanceOf(OlInteractionSelect);
+        expect(wrapper.instance()._selectInteraction.getActive()).toBeFalsy();
+
+        createSelectInteraction.mockRestore();
       });
 
-      // eslint-disable-next-line max-len
-      it ('removes all draw/select interactions created by component from the map if the button was untoggled', () => {
-        const wrapper = setupWrapper();
+      it ('creates a modify interaction on mount', () => {
+        const wrapper = setupWrapper(true);
+        wrapper.setProps({
+          drawType: null,
+          editType: 'Edit'
+        });
+        const createModifyInteraction = jest.spyOn(wrapper.instance(), 'createModifyInteraction');
 
-        const mockInteraction = getMockDrawPointInteraction();
+        expect(createModifyInteraction).toHaveBeenCalledTimes(0);
+
+        wrapper.instance().componentDidMount();
+        expect(createModifyInteraction).toHaveBeenCalledTimes(1);
+
+        expect(wrapper.instance()._modifyInteraction).toBeInstanceOf(OlInteractionModify);
+        expect(wrapper.instance()._modifyInteraction.getActive()).toBeFalsy();
+
+        createModifyInteraction.mockRestore();
+      });
+
+      it ('creates a translate interaction on mount', () => {
+        const wrapper = setupWrapper(true);
+        wrapper.setProps({
+          drawType: null,
+          editType: 'Edit'
+        });
+        const createTranslateInteraction = jest.spyOn(wrapper.instance(), 'createTranslateInteraction');
+
+        expect(createTranslateInteraction).toHaveBeenCalledTimes(0);
+
+        wrapper.instance().componentDidMount();
+        expect(createTranslateInteraction).toHaveBeenCalledTimes(1);
+
+        expect(wrapper.instance()._translateInteraction).toBeInstanceOf(OlInteractionTranslate);
+        expect(wrapper.instance()._translateInteraction.getActive()).toBeFalsy();
+
+        createTranslateInteraction.mockRestore();
+      });
+
+      it ('removes all interactions and map listeners from the map on unmount', () => {
+        const wrapper = setupWrapper();
 
         const defaultMapInteractionsLength = map.getInteractions().getLength();
         map.addInteraction(getMockDrawPointInteraction());
         map.on('pointermove', wrapper.instance().onPointerMove);
 
-        wrapper.setState({
-          interactions: [mockInteraction]
-        });
+        wrapper.instance().componentDidMount();
 
         expect(map.getInteractions().getLength()).toBe(defaultMapInteractionsLength + 1);
         // Warning: using of private properties such `listeners_` could be
@@ -180,87 +211,45 @@ describe('<DigitizeButton />', () => {
         // appropriate value.
         expect(map.listeners_.pointermove).toBeDefined();
 
-        wrapper.instance().onToggle(false);
+        wrapper.instance().componentWillUnmount();
 
         expect(map.listeners_.pointermove).toBeUndefined();
+
+        expect(map.getInteractions().getLength()).toBe(defaultMapInteractionsLength);
       });
 
-      // eslint-disable-next-line max-len
-      it ('unregisters `add` listener on digitize feature collection if drawType is Text and button was untoggled', () => {
+      it ('activates the draw interaction on toggle', () => {
         const wrapper = setupWrapper();
-        wrapper.setProps({
-          drawType: 'Text'
-        });
-        const mockInteraction = getMockDrawPointInteraction();
-
         const instance = wrapper.instance();
-        instance.createDigitizeLayer();
-        instance._digitizeFeatures = instance._digitizeLayer.getSource().getFeaturesCollection();
 
-        map.addInteraction(mockInteraction);
-        instance._digitizeFeatures.on('add', wrapper.instance().handleTextAdding);
+        expect(instance._drawInteraction.getActive()).toBeFalsy();
 
-        expect(instance._digitizeFeatures.listeners_.add.length).toBe(2);
+        instance.onToggle(true);
 
-        wrapper.setState({
-          interactions: [mockInteraction]
-        });
-
-        instance.onToggle(false);
-
-        expect(instance._digitizeFeatures.listeners_.add.length).toBe(1);
+        expect(instance._drawInteraction.getActive()).toBeTruthy();
       });
 
-      // eslint-disable-next-line max-len
-      it ('unregisters `select` listener on select interaction if editType is Delete and button was untoggled', () => {
+      it ('activates the edit interactions on toggle', () => {
         const wrapper = setupWrapper();
+
         wrapper.setProps({
           drawType: null,
-          editType: 'Delete'
+          editType: 'Edit'
         });
-        const mockInteraction = getMockSelectInteraction();
 
         const instance = wrapper.instance();
-        instance._selectInteraction = mockInteraction;
 
-        map.addInteraction(mockInteraction);
-        instance._selectInteraction.on('select', wrapper.instance().onFeatureRemove);
+        instance.componentDidMount();
 
-        expect(instance._selectInteraction.listeners_.select.length).toBe(1);
+        expect(instance._selectInteraction.getActive()).toBeFalsy();
+        expect(instance._modifyInteraction.getActive()).toBeFalsy();
+        expect(instance._translateInteraction.getActive()).toBeFalsy();
 
-        wrapper.setState({
-          interactions: [mockInteraction]
-        });
+        instance.onToggle(true);
 
-        instance.onToggle(false);
-
-        expect(instance._selectInteraction.listeners_.select).toBeUndefined();
-      });
-
-      // eslint-disable-next-line max-len
-      it ('unregisters `select` listener on select interaction if editType is Copy and button was untoggled', () => {
-        const wrapper = setupWrapper();
-        wrapper.setProps({
-          drawType: null,
-          editType: 'Copy'
-        });
-        const mockInteraction = getMockSelectInteraction();
-
-        const instance = wrapper.instance();
-        instance._selectInteraction = mockInteraction;
-
-        map.addInteraction(mockInteraction);
-        instance._selectInteraction.on('select', wrapper.instance().onFeatureCopy);
-
-        expect(instance._selectInteraction.listeners_.select.length).toBe(1);
-
-        wrapper.setState({
-          interactions: [mockInteraction]
-        });
-
-        instance.onToggle(false);
-
-        expect(instance._selectInteraction.listeners_.select).toBeUndefined();
+        expect(instance._selectInteraction.getActive()).toBeTruthy();
+        expect(instance._modifyInteraction.getActive()).toBeTruthy();
+        expect(instance._translateInteraction.getActive()).toBeTruthy();
       });
     });
 
@@ -336,57 +325,48 @@ describe('<DigitizeButton />', () => {
           drawType: 'Rectangle'
         });
 
-        wrapper.instance().createDrawInteraction(true);
+        wrapper.instance().createDrawInteraction();
 
-        expect(wrapper.instance()._interactions.length).toBe(1);
-        expect(wrapper.instance()._interactions[0].type_).toBe('Circle');
+        expect(wrapper.instance()._drawInteraction.type_).toBe('Circle');
 
-        wrapper.setState({
-          interactions: []
-        });
         wrapper.setProps({
           drawType: 'Text'
         });
 
-        wrapper.instance()._digitizeFeatures = new OlCollection();
-        wrapper.instance().createDrawInteraction(true);
+        wrapper.instance().createDrawInteraction();
 
-        expect(wrapper.instance()._interactions.length).toBe(1);
-        expect(wrapper.instance()._interactions[0].type_).toBe('Point');
+        expect(wrapper.instance()._drawInteraction.type_).toBe('Point');
       });
     });
 
     describe('#createSelectOrModifyInteraction', () => {
 
       // eslint-disable-next-line max-len
-      it ('creates OL select or modify interaction depending on provided editType and sets its value(s) to state', () => {
+      it ('creates OL select/modify/translate interaction depending on provided editType and sets its value(s) to state', () => {
         const wrapper = setupWrapper();
 
         wrapper.setProps({
           drawType: null,
-          editType: 'Delete'
-        });
-
-        expect(wrapper.instance()._selectInteraction).toBeNull();
-
-        wrapper.instance().createSelectOrModifyInteraction();
-
-        expect(wrapper.instance()._selectInteraction).toBeDefined();
-        expect(wrapper.instance()._selectInteraction.listeners_.select).toBeDefined();
-
-        expect(wrapper.instance()._interactions.length).toBe(1);
-
-        wrapper.setState({
-          interactions: null
-        });
-
-        wrapper.setProps({
           editType: 'Edit'
         });
 
-        wrapper.instance().createSelectOrModifyInteraction();
+        expect(wrapper.instance()._selectInteraction).toBeUndefined();
 
-        expect(wrapper.instance()._interactions.length).toBe(3);
+        wrapper.instance().createSelectInteraction();
+
+        expect(wrapper.instance()._selectInteraction).toBeInstanceOf(OlInteractionSelect);
+
+        expect(wrapper.instance()._modifyInteraction).toBeUndefined();
+
+        wrapper.instance().createModifyInteraction();
+
+        expect(wrapper.instance()._modifyInteraction).toBeInstanceOf(OlInteractionModify);
+
+        expect(wrapper.instance()._translateInteraction).toBeUndefined();
+
+        wrapper.instance().createTranslateInteraction();
+
+        expect(wrapper.instance()._translateInteraction).toBeInstanceOf(OlInteractionTranslate);
       });
     });
 
@@ -394,13 +374,17 @@ describe('<DigitizeButton />', () => {
 
       it ('removes selected feature from the map', () => {
         const wrapper = setupWrapper();
+        wrapper.setProps({
+          drawType: null,
+          editType: 'Edit'
+        });
         const feat = new OlFeature();
         const mockEvt = {
           selected: [feat]
         };
 
         wrapper.instance().createDigitizeLayer();
-        wrapper.instance().createSelectOrModifyInteraction();
+        wrapper.instance().createSelectInteraction();
 
         wrapper.instance()._digitizeLayer.getSource().addFeature(feat);
         wrapper.instance()._selectInteraction.getFeatures().push(feat);
@@ -463,12 +447,12 @@ describe('<DigitizeButton />', () => {
         const wrapper = setupWrapper();
         const feat = new OlFeature();
         const mockEvt = {
-          element: feat
+          feature: feat
         };
 
         wrapper.instance().handleTextAdding(mockEvt);
 
-        expect(wrapper.instance()._digitizeTextFeature).toEqual(mockEvt.element);
+        expect(wrapper.instance()._digitizeTextFeature).toEqual(mockEvt.feature);
         expect(wrapper.instance()._digitizeTextFeature.get('isLabel')).toBeTruthy();
         expect(wrapper.state().showLabelPrompt).toBeTruthy();
       });
@@ -520,8 +504,6 @@ describe('<DigitizeButton />', () => {
         wrapper.instance().onModalLabelCancel();
 
         expect(wrapper.state().showLabelPrompt).toBeFalsy();
-        expect(wrapper.instance()._digitizeFeatures.getLength()).toBe(0);
-        expect(wrapper.instance()._digitizeTextFeature).toBeNull();
       });
     });
 

--- a/src/Button/DigitizeButton/DigitizeButton.tsx
+++ b/src/Button/DigitizeButton/DigitizeButton.tsx
@@ -456,6 +456,8 @@ class DigitizeButton extends React.Component<DigitizeButtonProps, DigitizeButton
     map.removeInteraction(this._selectInteraction);
     map.removeInteraction(this._modifyInteraction);
     map.removeInteraction(this._translateInteraction);
+
+    map.un('pointermove', this.onPointerMove);
   }
 
   /**
@@ -665,7 +667,6 @@ class DigitizeButton extends React.Component<DigitizeButtonProps, DigitizeButton
       map,
       onDrawEnd,
       onDrawStart,
-      // digitizeLayerName,
       drawInteractionConfig
     } = this.props;
 

--- a/src/Button/DigitizeButton/DigitizeButton.tsx
+++ b/src/Button/DigitizeButton/DigitizeButton.tsx
@@ -511,11 +511,13 @@ class DigitizeButton extends React.Component<DigitizeButtonProps, DigitizeButton
 
     if (!digitizeLayer) {
       digitizeLayer = new OlLayerVector({
-        name: digitizeLayerName,
         source: new OlSourceVector({
-          features: new OlCollection(),
+          features: new OlCollection()
         })
       });
+
+      digitizeLayer.set('name', digitizeLayerName);
+
       map.addLayer(digitizeLayer);
     }
 

--- a/src/Button/DigitizeButton/DigitizeButton.tsx
+++ b/src/Button/DigitizeButton/DigitizeButton.tsx
@@ -853,10 +853,6 @@ class DigitizeButton extends React.Component<DigitizeButtonProps, DigitizeButton
       onFeatureSelect
     } = this.props;
 
-    if (_isFunction(onFeatureRemove)) {
-      onFeatureRemove(evt);
-    }
-
     if (_isFunction(onFeatureSelect)) {
       onFeatureSelect(evt);
     }
@@ -865,6 +861,10 @@ class DigitizeButton extends React.Component<DigitizeButtonProps, DigitizeButton
 
     this._selectInteraction.getFeatures().remove(feat);
     this._digitizeLayer.getSource().removeFeature(feat);
+
+    if (_isFunction(onFeatureRemove)) {
+      onFeatureRemove(evt);
+    }
 
     this.props.map.renderSync();
   };

--- a/src/Button/DigitizeButton/DigitizeButton.tsx
+++ b/src/Button/DigitizeButton/DigitizeButton.tsx
@@ -248,16 +248,28 @@ class DigitizeButton extends React.Component<DigitizeButtonProps, DigitizeButton
   _digitizeTextFeature = null;
 
   /**
-   * Reference to OL select interaction which will be used in edit mode.
+   * The draw interaction.
+   * @private
+   */
+  _drawInteraction?: OlInteraction;
+
+  /**
+   * The select interaction.
    * @private
    */
   _selectInteraction = null;
 
   /**
-   * The interactions.
+   * The modify interaction.
    * @private
    */
-  _interactions?: OlInteraction[] = [];
+  _modifyInteraction?: OlInteraction;
+
+  /**
+   * The translate interaction.
+   * @private
+   */
+  _translateInteraction?: OlInteraction;
 
   /**
    * Name of point draw type.
@@ -421,11 +433,15 @@ class DigitizeButton extends React.Component<DigitizeButtonProps, DigitizeButton
   }
 
   /**
-   * `componentDidMount` method of the DigitizeButton. Just calls
-   * `createDigitizeLayer` method.
+   * `componentDidMount` method of the DigitizeButton.
    */
   componentDidMount() {
     this.createDigitizeLayer();
+
+    this.createDrawInteraction();
+    this.createSelectInteraction();
+    this.createModifyInteraction();
+    this.createTranslateInteraction();
   }
 
   /**
@@ -436,7 +452,10 @@ class DigitizeButton extends React.Component<DigitizeButtonProps, DigitizeButton
       map
     } = this.props;
 
-    this._interactions.forEach(i => map.removeInteraction(i));
+    map.removeInteraction(this._drawInteraction);
+    map.removeInteraction(this._selectInteraction);
+    map.removeInteraction(this._modifyInteraction);
+    map.removeInteraction(this._translateInteraction);
   }
 
   /**
@@ -452,45 +471,29 @@ class DigitizeButton extends React.Component<DigitizeButtonProps, DigitizeButton
       map,
       drawType,
       editType,
-      drawStyle,
-      onFeatureSelect
     } = this.props;
 
-    this.props.onToggle(pressed);
-
-    if (this._digitizeLayer) {
-      this._digitizeFeatures = this._digitizeLayer.getSource().getFeaturesCollection();
-    }
-
-    if (pressed) {
-      if (drawStyle) {
-        this._digitizeLayer.setStyle(this.getDigitizeStyleFunction);
+    if (drawType) {
+      this._drawInteraction.setActive(pressed);
+    } else if (editType) {
+      if (this._selectInteraction) {
+        this._selectInteraction.setActive(pressed);
       }
-      if (drawType) {
-        this.createDrawInteraction(pressed);
-      } else if (editType) {
-        this.createSelectOrModifyInteraction();
+      if (this._modifyInteraction) {
+        this._modifyInteraction.setActive(pressed);
       }
-    } else {
-      this._interactions.forEach(i => map.removeInteraction(i));
-      if (drawType === DigitizeButton.TEXT_DRAW_TYPE) {
-        this._digitizeFeatures.un('add', this.handleTextAdding);
+      if (this._translateInteraction) {
+        this._translateInteraction.setActive(pressed);
+      }
+
+      if (pressed) {
+        map.on('pointermove', this.onPointerMove);
       } else {
-        if (this._selectInteraction) {
-          this._selectInteraction.getFeatures().clear();
-        }
-        if (editType === DigitizeButton.DELETE_EDIT_TYPE) {
-          this._selectInteraction.un('select', this.onFeatureRemove);
-        }
-        if (editType === DigitizeButton.COPY_EDIT_TYPE) {
-          this._selectInteraction.un('select', this.onFeatureCopy);
-        }
-        if (_isFunction(onFeatureSelect) && editType === DigitizeButton.EDIT_EDIT_TYPE) {
-          this._selectInteraction.un('select', onFeatureSelect);
-        }
         map.un('pointermove', this.onPointerMove);
       }
     }
+
+    this.props.onToggle(pressed);
   };
 
   /**
@@ -501,7 +504,9 @@ class DigitizeButton extends React.Component<DigitizeButtonProps, DigitizeButton
       digitizeLayerName,
       map
     } = this.props;
+
     let digitizeLayer = MapUtil.getLayerByName(map, digitizeLayerName);
+
     if (!digitizeLayer) {
       digitizeLayer = new OlLayerVector({
         name: digitizeLayerName,
@@ -511,8 +516,12 @@ class DigitizeButton extends React.Component<DigitizeButtonProps, DigitizeButton
       });
       map.addLayer(digitizeLayer);
     }
+
     digitizeLayer.setStyle(this.getDigitizeStyleFunction);
+
     this._digitizeLayer = digitizeLayer;
+
+    this._digitizeFeatures = digitizeLayer.getSource().getFeaturesCollection();
   };
 
   /**
@@ -650,76 +659,101 @@ class DigitizeButton extends React.Component<DigitizeButtonProps, DigitizeButton
    * @param pressed Whether the digitize button is pressed or not.
    * Will be used to handle active state of the draw interaction.
    */
-  createDrawInteraction = pressed => {
+  createDrawInteraction = () => {
     const {
       drawType,
       map,
       onDrawEnd,
       onDrawStart,
-      digitizeLayerName,
+      // digitizeLayerName,
       drawInteractionConfig
     } = this.props;
 
     let geometryFunction;
-    let type = drawType;
 
-    // check whether the digitizeLayer is in map and set it from state if not
-    const digitizeLayer = MapUtil.getLayerByName(map, digitizeLayerName);
-    if (!digitizeLayer) {
-      map.addLayer(this._digitizeLayer);
+    if (!drawType) {
+      return;
     }
 
-    if (drawType === DigitizeButton.RECTANGLE_DRAW_TYPE) {
-      geometryFunction = createBox();
-      type = DigitizeButton.CIRCLE_DRAW_TYPE as DrawType;
-    } else if (drawType === DigitizeButton.TEXT_DRAW_TYPE) {
-      type = DigitizeButton.POINT_DRAW_TYPE as DrawType;
-      this._digitizeFeatures.on('add', this.handleTextAdding);
+    const drawInteractionName = `react-geo-draw-interaction-${drawType}`;
+    let drawInteraction = MapUtil.getInteractionsByName(map, drawInteractionName)[0];
+
+    if (!drawInteraction) {
+      let type = drawType;
+
+      if (drawType === DigitizeButton.RECTANGLE_DRAW_TYPE) {
+        geometryFunction = createBox();
+        type = DigitizeButton.CIRCLE_DRAW_TYPE as DrawType;
+      } else if (drawType === DigitizeButton.TEXT_DRAW_TYPE) {
+        type = DigitizeButton.POINT_DRAW_TYPE as DrawType;
+      }
+
+      drawInteraction = new OlInteractionDraw({
+        source: this._digitizeLayer.getSource(),
+        type: type,
+        geometryFunction: geometryFunction,
+        style: this.getDigitizeStyleFunction,
+        freehandCondition: never,
+        ...drawInteractionConfig
+      });
+
+      drawInteraction.set('name', drawInteractionName);
+
+      if (drawType === DigitizeButton.TEXT_DRAW_TYPE) {
+        drawInteraction.on('drawend', this.handleTextAdding);
+      }
+
+      if (onDrawEnd) {
+        drawInteraction.on('drawend', onDrawEnd);
+      }
+
+      if (onDrawStart) {
+        drawInteraction.on('drawstart', onDrawStart);
+      }
+
+      drawInteraction.setActive(false);
+
+      map.addInteraction(drawInteraction);
     }
 
-    const drawInteraction = new OlInteractionDraw({
-      source: this._digitizeLayer.getSource(),
-      type: type,
-      geometryFunction: geometryFunction,
-      style: this.getDigitizeStyleFunction,
-      freehandCondition: never,
-      ...drawInteractionConfig
-    });
-
-    if (onDrawEnd) {
-      drawInteraction.on('drawend', onDrawEnd);
-    }
-
-    if (onDrawStart) {
-      drawInteraction.on('drawstart', onDrawStart);
-    }
-
-    map.addInteraction(drawInteraction);
-
-    this._interactions = [drawInteraction];
-    drawInteraction.setActive(pressed);
+    this._drawInteraction = drawInteraction;
   };
 
   /**
    * Creates a correctly configured OL select and/or modify and/or translate
    * interaction(s) depending on given editType and adds this/these to the map.
    */
-  createSelectOrModifyInteraction = () => {
+  createSelectInteraction = () => {
     const {
       editType,
       map,
       selectInteractionConfig,
-      modifyInteractionConfig,
-      translateInteractionConfig,
       onFeatureSelect
     } = this.props;
 
-    this._selectInteraction = new OlInteractionSelect({
-      condition: singleClick,
-      hitTolerance: DigitizeButton.HIT_TOLERANCE,
-      style: this.getSelectedStyleFunction,
-      ...selectInteractionConfig
-    });
+    if (!editType) {
+      return;
+    }
+
+    const selectInteractionName = `react-geo-select-interaction-${editType}`;
+    let selectInteraction = MapUtil.getInteractionsByName(map, selectInteractionName)[0];
+
+    if (!selectInteraction) {
+      selectInteraction = new OlInteractionSelect({
+        condition: singleClick,
+        hitTolerance: DigitizeButton.HIT_TOLERANCE,
+        style: this.getSelectedStyleFunction,
+        ...selectInteractionConfig
+      });
+
+      selectInteraction.set('name', selectInteractionName);
+
+      selectInteraction.setActive(false);
+
+      map.addInteraction(selectInteraction);
+    }
+
+    this._selectInteraction = selectInteraction;
 
     if (editType === DigitizeButton.DELETE_EDIT_TYPE) {
       this._selectInteraction.on('select', this.onFeatureRemove);
@@ -730,37 +764,81 @@ class DigitizeButton extends React.Component<DigitizeButtonProps, DigitizeButton
     if (_isFunction(onFeatureSelect) && editType === DigitizeButton.EDIT_EDIT_TYPE) {
       this._selectInteraction.on('select', onFeatureSelect);
     }
+  };
 
-    const interactions = [this._selectInteraction];
+  /**
+   *
+   */
+  createModifyInteraction = () => {
+    const {
+      editType,
+      map,
+      modifyInteractionConfig,
+    } = this.props;
 
-    if (editType === DigitizeButton.EDIT_EDIT_TYPE) {
-      const edit = new OlInteractionModify({
+    if (!editType || editType !== DigitizeButton.EDIT_EDIT_TYPE) {
+      return;
+    }
+
+    const modifyInteractionName = `react-geo-modify-interaction-${editType}`;
+    let modifyInteraction = MapUtil.getInteractionsByName(map, modifyInteractionName)[0];
+
+    if (!modifyInteraction) {
+      modifyInteraction = new OlInteractionModify({
         features: this._selectInteraction.getFeatures(),
         deleteCondition: singleClick,
         style: this.getSelectedStyleFunction,
         ...modifyInteractionConfig
       });
 
-      edit.on('modifystart', this.onModifyStart);
-      edit.on('modifyend', this.onModifyEnd);
+      modifyInteraction.set('name', modifyInteractionName);
 
-      const translate = new OlInteractionTranslate({
+      modifyInteraction.on('modifystart', this.onModifyStart);
+      modifyInteraction.on('modifyend', this.onModifyEnd);
+
+      modifyInteraction.setActive(false);
+
+      map.addInteraction(modifyInteraction);
+    }
+
+    this._modifyInteraction = modifyInteraction;
+  };
+
+  /**
+   *
+   */
+  createTranslateInteraction = () => {
+    const {
+      editType,
+      map,
+      translateInteractionConfig
+    } = this.props;
+
+    if (!editType || editType !== DigitizeButton.EDIT_EDIT_TYPE) {
+      return;
+    }
+
+    const translateInteractionName = `react-geo-translate-interaction-${editType}`;
+    let translateInteraction = MapUtil.getInteractionsByName(map, translateInteractionName)[0];
+
+    if (!translateInteraction) {
+      translateInteraction = new OlInteractionTranslate({
         features: this._selectInteraction.getFeatures(),
         ...translateInteractionConfig
       });
 
-      translate.on('translatestart', this.onTranslateStart);
-      translate.on('translateend', this.onTranslateEnd);
-      translate.on('translating', this.onTranslating);
+      translateInteraction.set('name', translateInteractionName);
 
-      interactions.push(edit, translate);
+      translateInteraction.on('translatestart', this.onTranslateStart);
+      translateInteraction.on('translateend', this.onTranslateEnd);
+      translateInteraction.on('translating', this.onTranslating);
+
+      translateInteraction.setActive(false);
+
+      map.addInteraction(translateInteraction);
     }
 
-    interactions.forEach(i => map.addInteraction(i));
-
-    map.on('pointermove', this.onPointerMove);
-
-    this._interactions = interactions;
+    this._translateInteraction = translateInteraction;
   };
 
   /**
@@ -784,10 +862,13 @@ class DigitizeButton extends React.Component<DigitizeButtonProps, DigitizeButton
     }
 
     const feat = evt.selected[0];
+
     this._selectInteraction.getFeatures().remove(feat);
     this._digitizeLayer.getSource().removeFeature(feat);
+
     this.props.map.renderSync();
   };
+
   /**
    * Listener for `select` event of OL select interaction in `Copy` mode.
    * Creates a clone of selected feature and calls utility method to move it
@@ -819,6 +900,7 @@ class DigitizeButton extends React.Component<DigitizeButtonProps, DigitizeButton
     const copy = feat.clone();
 
     copy.setStyle(this.getDigitizeStyleFunction(feat));
+
     this._digitizeFeatures.push(copy);
 
     AnimateUtil.moveFeature(
@@ -938,7 +1020,8 @@ class DigitizeButton extends React.Component<DigitizeButtonProps, DigitizeButton
     this.setState({
       showLabelPrompt: true
     });
-    this._digitizeTextFeature = evt.element;
+
+    this._digitizeTextFeature = evt.feature;
     this._digitizeTextFeature.set('isLabel', true);
   };
 
@@ -972,10 +1055,6 @@ class DigitizeButton extends React.Component<DigitizeButtonProps, DigitizeButton
       showLabelPrompt: false,
       textLabel: ''
     }, () => {
-      if (!(this._interactions.length > 1)) {
-        this._digitizeFeatures.remove(this._digitizeTextFeature);
-        this._digitizeTextFeature = null;
-      }
       if (_isFunction(onModalLabelCancel)) {
         onModalLabelCancel(event);
       }

--- a/src/Button/DigitizeButton/DigitizeButton.tsx
+++ b/src/Button/DigitizeButton/DigitizeButton.tsx
@@ -257,7 +257,7 @@ class DigitizeButton extends React.Component<DigitizeButtonProps, DigitizeButton
    * The select interaction.
    * @private
    */
-  _selectInteraction = null;
+  _selectInteraction?: OlInteraction;
 
   /**
    * The modify interaction.

--- a/src/Util/TestUtil.tsx
+++ b/src/Util/TestUtil.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { mount, ShallowWrapper, ReactWrapper, MountRendererProps } from 'enzyme';
+import { mount, shallow, ShallowWrapper, ReactWrapper, MountRendererProps } from 'enzyme';
 import OlView from 'ol/View';
 import OlMap from 'ol/Map';
 import OlSourceVector from 'ol/source/Vector';
@@ -30,6 +30,17 @@ export class TestUtil {
    */
   static mountComponent = (Component: any, props?: any, options?: MountRendererProps): Wrapper => {
     return mount(<Component {...props}/>, options);
+  };
+
+  /**
+   * Mounts the given component (shallowly).
+   *
+   * @param Component The Component to render.
+   * @param props The props to be used.
+   * @param options The options to be set.
+   */
+  static shallowComponent = (Component: any, props?: any, options?: MountRendererProps): Wrapper => {
+    return shallow(<Component {...props}/>, options);
   };
 
   /**


### PR DESCRIPTION
<!-- Please choose one of the categories and choose the corresponding label, too. -->
## REFACTORING

### Description:
<!-- Please describe what this PR is about. -->

This suggests to create all required interactions by the `DigitizeButton` on mount and to toggle the active state instead of recreating them on toggle.

Please review @terrestris/devs.

<!--- CHECKLIST
Fixes Issue?
Examples added?
Tests added?
Docs added?
Would a screenshot be helpful?
Do you want to mention someone?
-->
