### PR TITLE
handle child null case

### DIFF
--- a/src/Button/ToggleGroup/ToggleGroup.tsx
+++ b/src/Button/ToggleGroup/ToggleGroup.tsx
@@ -139,9 +139,9 @@ class ToggleGroup extends React.Component<ToggleGroupProps, ToggleGroupState> {
 
     const childrenWithProps = React.Children.map(children, (child) => {
       // pass the press state through to child components
-      return React.cloneElement(child, {
+      return child ? React.cloneElement(child, {
         pressed: this.state.selectedName === child.props.name
-      });
+      }) : child;
     });
 
     return (


### PR DESCRIPTION
<!-- Please choose one of the categories and choose the corresponding label, too. -->
## BUGFIX

### Description:
react-geo was failing if child was null. This fixes this issue.

<!--- CHECKLIST
Fixes Issue?
Examples added?
Tests added?
Docs added?
Would a screenshot be helpful?
Do you want to mention someone?
-->
