### PR TITLE
Use center and zoom for zoomToExtent Button

### DIFF
--- a/src/Button/ZoomToExtentButton/ZoomToExtentButton.example.md
+++ b/src/Button/ZoomToExtentButton/ZoomToExtentButton.example.md
@@ -75,6 +75,13 @@ class ZoomToExtentButtonExample extends React.Component {
         >
           Zoom to extent (slow animation)
         </ZoomToExtentButton>
+        <ZoomToExtentButton
+          map={this.map}
+          center={fromLonLat([36.40570, 10.81566])}
+          zoom={8}
+        >
+          Zoom to extent providing center and zoom (standard, animated)
+        </ZoomToExtentButton>
       </div>
     );
   }

--- a/src/Button/ZoomToExtentButton/ZoomToExtentButton.spec.tsx
+++ b/src/Button/ZoomToExtentButton/ZoomToExtentButton.spec.tsx
@@ -85,12 +85,14 @@ describe('<ZoomToExtentButton />', () => {
       setTimeout(resolve, 1200);
     });
 
-    expect.assertions(2);
+    expect.assertions(3);
     return promise.then(() => {
       const newExtent = map.getView().calculateExtent();
       const newCenter = getCenter(newExtent);
+      const newZoom = map.getView().getZoom();
       expect(newCenter).toEqual(mockExtentCenter);
       expect(containsExtent(newExtent, mockExtent)).toBe(true);
+      expect(newZoom).toEqual(mockZoom);
     });
   });
 });

--- a/src/Button/ZoomToExtentButton/ZoomToExtentButton.spec.tsx
+++ b/src/Button/ZoomToExtentButton/ZoomToExtentButton.spec.tsx
@@ -13,6 +13,7 @@ describe('<ZoomToExtentButton />', () => {
   const mockGeometryCenter = [5000, 5000];
   const mockExtent = [0, 0, 10000, 10000];
   const mockExtentCenter = [5000, 5000];
+  const mockZoom = 7;
 
   beforeEach(() => {
     map = TestUtil.createMap();
@@ -70,5 +71,26 @@ describe('<ZoomToExtentButton />', () => {
       expect(containsExtent(newExtent, mockExtent)).toBe(true);
     });
 
+  });
+
+  it('zooms to extent when clicked providing center and zoom', () => {
+    const wrapper = TestUtil.mountComponent(ZoomToExtentButton, {
+      map,
+      center: mockExtentCenter,
+      zoom: mockZoom
+    });
+    wrapper.instance().onClick();
+
+    const promise = new Promise(resolve => {
+      setTimeout(resolve, 1200);
+    });
+
+    expect.assertions(2);
+    return promise.then(() => {
+      const newExtent = map.getView().calculateExtent();
+      const newCenter = getCenter(newExtent);
+      expect(newCenter).toEqual(mockExtentCenter);
+      expect(containsExtent(newExtent, mockExtent)).toBe(true);
+    });
   });
 });

--- a/src/Button/ZoomToExtentButton/ZoomToExtentButton.tsx
+++ b/src/Button/ZoomToExtentButton/ZoomToExtentButton.tsx
@@ -131,7 +131,7 @@ class ZoomToExtentButton extends React.Component<ZoomToExtentButtonProps> {
     if (extent) {
       view.fit(extent, finalFitOptions);
     }
-    else if (!extent && (center && zoom)) {
+    else if (center && zoom) {
       view.setCenter(center);
       view.setZoom(zoom);
     }

--- a/src/Button/ZoomToExtentButton/ZoomToExtentButton.tsx
+++ b/src/Button/ZoomToExtentButton/ZoomToExtentButton.tsx
@@ -35,16 +35,16 @@ interface DefaultProps {
    * The extent `[minx, miny, maxx, maxy]` in the maps coordinate system or an
    * instance of ol.geom.SimpleGeometry that the map should zoom to.
    */
-  extent: number[] | OlSimpleGeometry;
+  extent?: number[] | OlSimpleGeometry;
   /**
    * The center `[x,y]` in the maps coordinate system or an
    * instance of ol.coordinate that the map should zoom to if no extent is given.
    */
-  center: OlCoordinate;
+  center?: OlCoordinate;
   /**
-   *  The zoom level 'x' the map should zoom to  if no extent is given.
+   *  The zoom level 'x' the map should zoom to if no extent is given.
    */
-  zoom: number;
+  zoom?: number;
 }
 
 interface BaseProps {

--- a/src/Button/ZoomToExtentButton/ZoomToExtentButton.tsx
+++ b/src/Button/ZoomToExtentButton/ZoomToExtentButton.tsx
@@ -40,7 +40,7 @@ interface DefaultProps {
    * The center `[x,y]` in the maps coordinate system or an
    * instance of ol.coordinate that the map should zoom to if no extent is given.
    */
-  center?: OlCoordinate;
+  center?: number[] | OlCoordinate;
   /**
    *  The zoom level 'x' the map should zoom to if no extent is given.
    */
@@ -110,8 +110,9 @@ class ZoomToExtentButton extends React.Component<ZoomToExtentButtonProps> {
     if (!view) { // no view, no zooming
       return;
     }
-    if (!extent && (!center && !zoom)) {
-      logger.warn('Provide either an extent or a center and a zoom.');
+    if (!extent && (!center || !zoom)) {
+      logger.error('zoomToExtentButton: You need to provide either an extent or a center and a zoom.');
+      return;
     }
     if (view.getAnimating()) {
       view.cancelAnimations();


### PR DESCRIPTION
## Enhancement of zoomToExtent
### Description:

- Adds option to define the extent via _center_ and _zoom_
- Change _extent_ to be an optional prop, same as _center_ and _zoom_
- Adds notification if none of the necessary props are provided

Background: Since a fixed extent is mostly dependant on screen ratio / size, this offers a different way.

@terrestris/devs please review.

<!--- CHECKLIST
Fixes Issue?
Examples added?
Tests added?
Docs added?
Would a screenshot be helpful?
Do you want to mention someone?
-->
