### PR TITLE
zoomToExtent improve property checking

### DIFF
--- a/src/Button/ZoomToExtentButton/ZoomToExtentButton.tsx
+++ b/src/Button/ZoomToExtentButton/ZoomToExtentButton.tsx
@@ -127,8 +127,8 @@ class ZoomToExtentButton extends React.Component<ZoomToExtentButtonProps> {
     };
 
     if (extent && (center && _isFinite(zoom))) {
-      logger.warn('Provide either an extent or a center and a zoom.' +
-      'If both are provided the extent will be used.');
+      logger.warn('zoomToExtentButton: Both extent and center / zoom are provided. ' +
+      'Extent will be used in favor of center / zoom');
     }
     if (extent) {
       view.fit(extent, finalFitOptions);

--- a/src/Button/ZoomToExtentButton/ZoomToExtentButton.tsx
+++ b/src/Button/ZoomToExtentButton/ZoomToExtentButton.tsx
@@ -9,8 +9,7 @@ import SimpleButton, { SimpleButtonProps } from '../SimpleButton/SimpleButton';
 import { CSS_PREFIX } from '../../constants';
 
 import logger from '@terrestris/base-util/dist/Logger';
-
-const _isFinite = require('lodash/isFinite');
+import _isFinite from 'lodash/isFinite';
 
 interface DefaultProps {
   /**

--- a/src/Button/ZoomToExtentButton/ZoomToExtentButton.tsx
+++ b/src/Button/ZoomToExtentButton/ZoomToExtentButton.tsx
@@ -10,6 +10,8 @@ import { CSS_PREFIX } from '../../constants';
 
 import logger from '@terrestris/base-util/dist/Logger';
 
+const _isFinite = require('lodash/isFinite');
+
 interface DefaultProps {
   /**
    * Options for fitting to the given extent. See
@@ -110,7 +112,7 @@ class ZoomToExtentButton extends React.Component<ZoomToExtentButtonProps> {
     if (!view) { // no view, no zooming
       return;
     }
-    if (!extent && (!center || !zoom)) {
+    if (!extent && (!center || !_isFinite(zoom))) {
       logger.error('zoomToExtentButton: You need to provide either an extent or a center and a zoom.');
       return;
     }
@@ -125,14 +127,14 @@ class ZoomToExtentButton extends React.Component<ZoomToExtentButtonProps> {
       ...fitOptions
     };
 
-    if (extent && (center && zoom)) {
+    if (extent && (center && _isFinite(zoom))) {
       logger.warn('Provide either an extent or a center and a zoom.' +
       'If both are provided the extent will be used.');
     }
     if (extent) {
       view.fit(extent, finalFitOptions);
     }
-    else if (center && zoom) {
+    else if (center && _isFinite(zoom)) {
       view.setCenter(center);
       view.setZoom(zoom);
     }


### PR DESCRIPTION
<!-- Please choose one of the categories and choose the corresponding label, too. -->
## BUGFIX
Improve property checking for  `zoom`. A valid `zoom` of `0` must be accepted. Thanks @marcjansen @LukasLohoff 

@terrestris/devs please review!
<!-- Please describe what this PR is about. -->

<!--- CHECKLIST
Fixes Issue?
Examples added?
Tests added?
Docs added?
Would a screenshot be helpful?
Do you want to mention someone?
-->
