### PR TITLE
Fix import statement zoomToExtentButton

### DIFF
--- a/src/Button/ZoomToExtentButton/ZoomToExtentButton.tsx
+++ b/src/Button/ZoomToExtentButton/ZoomToExtentButton.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import OlMap from 'ol/Map';
 import OlSimpleGeometry from 'ol/geom/SimpleGeometry';
-import OlCoordinate from 'ol/coordinate';
+import { Coordinate as OlCoordinate } from 'ol/coordinate';
 import { easeOut } from 'ol/easing';
 
 import SimpleButton, { SimpleButtonProps } from '../SimpleButton/SimpleButton';


### PR DESCRIPTION
<!-- Please choose one of the categories and choose the corresponding label, too. -->
## MINOR BUGFIX
- zoomToExtentButton: Fix import of `olCoordinate`

Background: First noticed, by using react-geo within react-geo-baseclient.

@terrestris/devs please check.

<!-- Please describe what this PR is about. -->

<!--- CHECKLIST
Fixes Issue?
Examples added?
Tests added?
Docs added?
Would a screenshot be helpful?
Do you want to mention someone?
-->
