### PR TITLE
Fix deploy path and version variable

### DIFF
--- a/.github/workflows/on-publish.yml
+++ b/.github/workflows/on-publish.yml
@@ -38,18 +38,18 @@ jobs:
       run: |
         echo "VERSION=$(node -pe "require('./package.json').version")" >> $GITHUB_ENV
 
-    - name: Deploy (to docs/v$VERSION) 🚀
+    - name: Deploy (to docs/v${{ env.VERSION }}) 🚀
       uses: JamesIves/github-pages-deploy-action@3.7.1
       with:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         BRANCH: gh-pages
-        FOLDER: build
-        TARGET_FOLDER: docs/v$VERSION
+        FOLDER: build/styleguide
+        TARGET_FOLDER: docs/v${{ env.VERSION }}
 
     - name: Deploy (to docs/latest) 🚀
       uses: JamesIves/github-pages-deploy-action@3.7.1
       with:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         BRANCH: gh-pages
-        FOLDER: build
+        FOLDER: build/styleguide
         TARGET_FOLDER: docs/latest


### PR DESCRIPTION
<!-- Please choose one of the categories and choose the corresponding label, too. -->
## DEVSETUP

### Description:
<!-- Please describe what this PR is about. -->

This should fix the target path in the `gh-pages` branch (`docs/latest` instead of `docs/latest/styleguide`) and the version number.

Please note @terrestris/devs.

<!--- CHECKLIST
Fixes Issue?
Examples added?
Tests added?
Docs added?
Would a screenshot be helpful?
Do you want to mention someone?
-->
