### PR TITLE
Fix conflicting events in Panel titlebar

### DIFF
--- a/src/Panel/Panel/Panel.tsx
+++ b/src/Panel/Panel/Panel.tsx
@@ -419,6 +419,7 @@ export class Panel extends React.Component<PanelProps, PanelState> {
         onResize={this.onResize.bind(this)}
         onResizeStart={this.onResizeStart.bind(this)}
         onResizeStop={this.onResizeStop.bind(this)}
+        cancel='.react-geo-titlebar .controls'
         {...rndOpts}
       >
         {titleBar}


### PR DESCRIPTION
<!-- Please choose one of the categories and choose the corresponding label, too. -->
##   BUGFIX

### Description:
<!-- Please describe what this PR is about. -->
This fixes conflicts between drag and click events in mobile mode.  
Controls within a `Panel` titlebar weren't working when dragging is enabled in mobile mode.

Thanks to @LukasLohoff for the right hint.

Please note @terrestris/devs 

<!--- CHECKLIST
Fixes Issue?
Examples added?
Tests added?
Docs added?
Would a screenshot be helpful?
Do you want to mention someone?
-->
