### PR TITLE
Omit onSelect as the typing differs from the base component

### DIFF
--- a/src/Field/NominatimSearch/NominatimSearch.tsx
+++ b/src/Field/NominatimSearch/NominatimSearch.tsx
@@ -131,7 +131,7 @@ interface NominatimSearchState {
   dataSource: NominatimPlace[];
 }
 
-export type NominatimSearchProps = BaseProps & Partial<DefaultProps> & AutoCompleteProps;
+export type NominatimSearchProps = BaseProps & Partial<DefaultProps> & Omit<AutoCompleteProps, 'onSelect'>;
 
 /**
  * The NominatimSearch.


### PR DESCRIPTION
<!-- Please choose one of the categories and choose the corresponding label, too. -->
## BUGFIX

### Description:

This omits the `onSelect` type from the base component as the type differs from the one defined in our component.

Please review @terrestris/devs.

<!--- CHECKLIST
Fixes Issue?
Examples added?
Tests added?
Docs added?
Would a screenshot be helpful?
Do you want to mention someone?
-->
