### PR TITLE
Ensure that measure button is properly deactivated on unmount

### DIFF
--- a/src/Button/MeasureButton/MeasureButton.tsx
+++ b/src/Button/MeasureButton/MeasureButton.tsx
@@ -274,6 +274,15 @@ class MeasureButton extends React.Component<MeasureButtonProps> {
   }
 
   /**
+   * Ensures that component is properly cleaned up on unmount.
+   */
+  componentWillUnmount() {
+    if (this.props.pressed) {
+      this.onToggle(false);
+    }
+  }
+
+  /**
    * Called when the button is toggled, this method ensures that everything
    * is cleaned up when unpressed, and that measuring can start when pressed.
    *


### PR DESCRIPTION
<!-- Please choose one of the categories and choose the corresponding label, too. -->
## BUGFIX

### Description:
Deactivates drawInteraction and removes all measurements from the map if some measure button component will unmount.

Please review @terrestris/devs  

