### PR TITLE
ci: Add prefix to dependabot commit messages

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -3,6 +3,9 @@ update_configs:
   - package_manager: "javascript"
     directory: "/"
     update_schedule: "daily"
+    commit_message:
+      prefix: "build"
+      include_scope: true
     automerged_updates:
       - match:
           dependency_type: "development"


### PR DESCRIPTION
<!-- Please choose one of the categories and choose the corresponding label, too. -->
## CI

### Description:
This adds a prefix to the dependabot commit messages so they conform the [angular commit message convention](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-format).
