### PR TITLE
Add deprecation note in DigitizeButton

### DIFF
--- a/src/Button/DigitizeButton/DigitizeButton.example.md
+++ b/src/Button/DigitizeButton/DigitizeButton.example.md
@@ -1,5 +1,7 @@
 This demonstrates the use of DigitizeButton with different interactions.
 
+**Note:** The `DigitizeButton` is deprecated and might be removed in future versions. Please make use of the `DrawButton` instead.
+
 ```jsx
 import * as React from 'react';
 

--- a/src/Button/DigitizeButton/DigitizeButton.tsx
+++ b/src/Button/DigitizeButton/DigitizeButton.tsx
@@ -216,7 +216,7 @@ export type DigitizeButtonProps = BaseProps & Partial<DefaultProps> & ToggleButt
  *
  * @class The DigitizeButton
  * @extends React.Component
- *
+ * @deprecated Please make use of the DrawButton component instead.
  */
 class DigitizeButton extends React.Component<DigitizeButtonProps, DigitizeButtonState> {
   /**


### PR DESCRIPTION
<!-- Please choose one of the categories and choose the corresponding label, too. -->
## DOCUMENTATION

### Description:
<!-- Please describe what this PR is about. -->

Version [15.1.0](https://github.com/terrestris/react-geo/releases/tag/v15.1.0) introduced the `DrawButton`, but keeps the `DigitizeButton` for backwards-compatibility and some unique options in it. This PR adds a short note about a potential deprecation of the `DigitizeButton`.

Please note @terrestris/devs.

<!--- CHECKLIST
Fixes Issue?
Examples added?
Tests added?
Docs added?
Would a screenshot be helpful?
Do you want to mention someone?
-->
