### PR TITLE
Fix semantic release plugin order

### DIFF
--- a/package.json
+++ b/package.json
@@ -169,10 +169,10 @@
     "plugin": [
       "@semantic-release/commit-analyzer",
       "@semantic-release/release-notes-generator",
-      "@semantic-release/npm",
-      "@semantic-release/github",
       "@semantic-release/changelog",
-      "@semantic-release/git"
+      "@semantic-release/npm",
+      "@semantic-release/git",
+      "@semantic-release/github"
     ]
   }
 }


### PR DESCRIPTION
<!-- Please choose one of the categories and choose the corresponding label, too. -->
## BUGFIX | REFACTORING

### Description:
Fix ordering of `@semantic-release` plugins loading according to the [official example](https://github.com/semantic-release/git#examples)

Please review @terrestris/devs 
