### PR TITLE
Copy button

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26175,11 +26175,6 @@
         "safer-buffer": "^2.0.2",
         "tweetnacl": "~0.14.0"
       },
-      "bin": {
-        "sshpk-conv": "bin/sshpk-conv",
-        "sshpk-sign": "bin/sshpk-sign",
-        "sshpk-verify": "bin/sshpk-verify"
-      },
       "engines": {
         "node": ">=0.10.0"
       }

--- a/src/Button/CopyButton/CopyButton.example.md
+++ b/src/Button/CopyButton/CopyButton.example.md
@@ -1,0 +1,69 @@
+This demonstrates the use of the CopyButton.
+
+```jsx
+import { useEffect, useState } from 'react';
+
+import OlMap from 'ol/Map';
+import OlView from 'ol/View';
+import OlLayerTile from 'ol/layer/Tile';
+import OlSourceOsm from 'ol/source/OSM';
+import OlFormatGeoJSON from 'ol/format/GeoJSON';
+import { fromLonLat } from 'ol/proj';
+
+import MapContext from '@terrestris/react-geo/Context/MapContext/MapContext'
+import MapComponent from '@terrestris/react-geo/Map/MapComponent/MapComponent';
+import CopyButton from '@terrestris/react-geo/Button/CopyButton/CopyButton';
+import { DigitizeUtil } from '@terrestris/react-geo/Util/DigitizeUtil';
+
+import federalStates from '../../../assets/federal-states-ger.json';
+
+const format = new OlFormatGeoJSON();
+const features = format.readFeatures(federalStates);
+
+const CopyButtonExample = () => {
+  const [map, setMap] = useState();
+
+  useEffect(() => {
+    const newMap = new OlMap({
+      layers: [
+        new OlLayerTile({
+          name: 'OSM',
+          source: new OlSourceOsm()
+        })
+      ],
+      view: new OlView({
+        center: fromLonLat([8, 50]),
+        zoom: 4
+      })
+    });
+
+    const digitizeLayer = DigitizeUtil.getDigitizeLayer(newMap);
+    digitizeLayer.getSource().addFeatures(features);
+
+    setMap(newMap);
+  }, []);
+
+  if (!map) {
+    return null;
+  }
+
+  return (
+    <div>
+      <MapContext.Provider value={map}>
+        <MapComponent
+          map={map}
+          style={{
+            height: '400px'
+          }}
+        />
+    
+        <CopyButton>
+          Copy feature
+        </CopyButton>
+      </MapContext.Provider>
+    </div>
+  );
+}
+
+<CopyButtonExample />
+```

--- a/src/Button/CopyButton/CopyButton.spec.tsx
+++ b/src/Button/CopyButton/CopyButton.spec.tsx
@@ -1,0 +1,79 @@
+import CopyButton from './CopyButton';
+import { screen,  within } from '@testing-library/react';
+import * as React from 'react';
+import userEvent from '@testing-library/user-event';
+
+import OlView from 'ol/View';
+import OlMap from 'ol/Map';
+import OlPoint from 'ol/geom/Point';
+import OlFeature from 'ol/Feature';
+
+import { clickMap, mockForEachFeatureAtPixel, renderInMapContext } from '../../Util/rtlTestUtils';
+import { DigitizeUtil } from '../../Util/DigitizeUtil';
+
+describe('<CopyButton />', () => {
+
+  const coord = [829729, 6708850];
+  let map: OlMap;
+  let feature: OlFeature<OlPoint>;
+
+  beforeEach(() => {
+    feature = new OlFeature<OlPoint>({
+      geometry: new OlPoint(coord),
+      someProp: 'test'
+    });
+
+    map = new OlMap({
+      view: new OlView({
+        center: coord,
+        zoom: 10
+      }),
+      controls: [],
+      layers: []
+    });
+
+    DigitizeUtil.getDigitizeLayer(map)
+      .getSource().addFeature(feature);
+  });
+
+  describe('#Basics', () => {
+
+    it('is defined', () => {
+      expect(CopyButton).not.toBeUndefined();
+    });
+
+    it('can be rendered', () => {
+      const { container } = renderInMapContext(map, <CopyButton />);
+
+      const button = within(container).getByRole('button');
+      expect(button).toBeVisible();
+    });
+  });
+
+  describe('#Copying', () => {
+    it('copys the feature', () => {
+      const mock = mockForEachFeatureAtPixel(map, [200, 200], feature);
+
+      const layer = DigitizeUtil.getDigitizeLayer(map);
+
+      renderInMapContext(map, <CopyButton />);
+
+      const button = screen.getByRole('button');
+      userEvent.click(button);
+
+      expect(layer.getSource().getFeatures()).toHaveLength(1);
+
+      clickMap(map, 200, 200);
+
+      expect(layer.getSource().getFeatures()).toHaveLength(2);
+
+      const [feat1, feat2] = layer.getSource().getFeatures();
+
+      expect(feat2.get('someProp')).toEqual('test');
+
+      expect(feat1.getGeometry().getType()).toEqual(feat2.getGeometry().getType());
+
+      mock.mockRestore();
+    });
+  });
+});

--- a/src/Button/CopyButton/CopyButton.tsx
+++ b/src/Button/CopyButton/CopyButton.tsx
@@ -25,9 +25,7 @@ interface OwnProps {
 
 export type CopyButtonProps = OwnProps & Omit<SelectFeaturesButtonProps, 'layers'>;
 
-/**
- * The className added to this component.
- */
+// The class name for the component.
 const defaultClassName = `${CSS_PREFIX}copybutton`;
 
 const CopyButton: React.FC<CopyButtonProps> = ({

--- a/src/Button/CopyButton/CopyButton.tsx
+++ b/src/Button/CopyButton/CopyButton.tsx
@@ -1,5 +1,7 @@
-import * as React from 'react';
-import { useEffect, useState } from 'react';
+import React, {
+  useEffect,
+  useState
+} from 'react';
 
 import OlVectorSource from 'ol/source/Vector';
 import OlGeometry from 'ol/geom/Geometry';

--- a/src/Button/CopyButton/CopyButton.tsx
+++ b/src/Button/CopyButton/CopyButton.tsx
@@ -6,6 +6,7 @@ import React, {
 import OlVectorSource from 'ol/source/Vector';
 import OlGeometry from 'ol/geom/Geometry';
 import OlVectorLayer from 'ol/layer/Vector';
+import { SelectEvent } from 'ol/interaction/Select';
 
 import AnimateUtil from '@terrestris/ol-util/dist/AnimateUtil/AnimateUtil';
 
@@ -13,7 +14,6 @@ import { CSS_PREFIX } from '../../constants';
 import { useMap } from '../../Hook/useMap';
 import { DigitizeUtil } from '../../Util/DigitizeUtil';
 import SelectFeaturesButton, { SelectFeaturesButtonProps } from '../SelectFeaturesButton/SelectFeaturesButton';
-import { SelectEvent } from 'ol/interaction/Select';
 
 interface OwnProps {
   /**

--- a/src/Button/CopyButton/CopyButton.tsx
+++ b/src/Button/CopyButton/CopyButton.tsx
@@ -1,0 +1,94 @@
+import * as React from 'react';
+import { useEffect, useState } from 'react';
+
+import OlVectorSource from 'ol/source/Vector';
+import OlGeometry from 'ol/geom/Geometry';
+import OlVectorLayer from 'ol/layer/Vector';
+
+import AnimateUtil from '@terrestris/ol-util/dist/AnimateUtil/AnimateUtil';
+
+import { CSS_PREFIX } from '../../constants';
+import { useMap } from '../../Hook/useMap';
+import { DigitizeUtil } from '../../Util/DigitizeUtil';
+import SelectFeaturesButton, { SelectFeaturesButtonProps } from '../SelectFeaturesButton/SelectFeaturesButton';
+import { SelectEvent } from 'ol/interaction/Select';
+
+interface OwnProps {
+  /**
+   * The vector layer which will be used for digitize features.
+   * The standard digitizeLayer can be retrieved via `DigitizeUtil.getDigitizeLayer(map)`.
+   */
+  digitizeLayer?: OlVectorLayer<OlVectorSource<OlGeometry>>;
+}
+
+export type CopyButtonProps = OwnProps & Omit<SelectFeaturesButtonProps, 'layers'>;
+
+/**
+ * The className added to this component.
+ */
+const defaultClassName = `${CSS_PREFIX}copybutton`;
+
+const CopyButton: React.FC<CopyButtonProps> = ({
+  className,
+  onFeatureSelect,
+  digitizeLayer,
+  ...passThroughProps
+}) => {
+
+  const [layers, setLayers] = useState<[OlVectorLayer<OlVectorSource<OlGeometry>>]>(null);
+
+  const map = useMap();
+
+  useEffect(() => {
+    if (!map) {
+      return;
+    }
+
+    if (digitizeLayer) {
+      setLayers([digitizeLayer]);
+    } else {
+      setLayers([DigitizeUtil.getDigitizeLayer(map)]);
+    }
+  }, [map, digitizeLayer]);
+
+  const onSelectInternal = (event: SelectEvent) => {
+    onFeatureSelect?.(event);
+
+    const feat = event.selected[0];
+
+    if (!feat) {
+      return;
+    }
+
+    const copy = feat.clone();
+
+    layers[0].getSource().addFeature(copy);
+
+    AnimateUtil.moveFeature(
+      map,
+      layers[0],
+      copy,
+      500,
+      50
+    );
+  };
+
+  const finalClassName = className
+    ? `${defaultClassName} ${className}`
+    : defaultClassName;
+
+  if (!layers) {
+    return null;
+  }
+
+  return <SelectFeaturesButton
+    layers={layers}
+    onFeatureSelect={onSelectInternal}
+    className={finalClassName}
+    clearAfterSelect={true}
+    {...passThroughProps}
+  />;
+
+};
+
+export default CopyButton;

--- a/src/Button/SelectFeaturesButton/SelectFeaturesButton.example.md
+++ b/src/Button/SelectFeaturesButton/SelectFeaturesButton.example.md
@@ -24,7 +24,8 @@ const features = format.readFeatures(federalStates);
 const SelectFeaturesButtonExample = () => {
     
   const [map, setMap] = useState();
-  const [layer, setLayer] = useState();
+  const [layers, setLayers] = useState();
+  const [feature, setFeature] = useState();
     
   useEffect(() => {
     const layer = new OlVectorLayer({
@@ -33,7 +34,7 @@ const SelectFeaturesButtonExample = () => {
       })    
     });
 
-    setLayer(layer);
+    setLayers([layer]);
 
     setMap(new OlMap({
       layers: [
@@ -48,8 +49,8 @@ const SelectFeaturesButtonExample = () => {
         zoom: 4
       })
     }));
-  }, [])
-    
+  }, []);
+
   if (!map) {
     return null;
   }
@@ -64,9 +65,12 @@ const SelectFeaturesButtonExample = () => {
           }}
         />
     
-        <SelectFeaturesButton layers={[layer]}>
+        <SelectFeaturesButton layers={layers} onFeatureSelect={e => setFeature(e.selected[0])}>
           Select feature
         </SelectFeaturesButton>
+        
+        { feature && feature.get('GEN') }
+
       </MapContext.Provider>
     </div>
   );

--- a/src/Button/SelectFeaturesButton/SelectFeaturesButton.spec.tsx
+++ b/src/Button/SelectFeaturesButton/SelectFeaturesButton.spec.tsx
@@ -11,7 +11,7 @@ import OlVectorSource from 'ol/source/Vector';
 import { SelectEvent as OlSelectEvent } from 'ol/interaction/Select';
 
 import DrawButton from '../DrawButton/DrawButton';
-import { clickMap, renderInMapContext } from '../../Util/rtlTestUtils';
+import { clickMap, mockForEachFeatureAtPixel, renderInMapContext } from '../../Util/rtlTestUtils';
 import SelectFeaturesButton from './SelectFeaturesButton';
 
 describe('<SelectFeaturesButton />', () => {
@@ -57,23 +57,17 @@ describe('<SelectFeaturesButton />', () => {
   });
 
   describe('#Selection', () => {
-    it('calls the listener', async () => {
+    it('calls the listener', () => {
+      const mock = mockForEachFeatureAtPixel(map, [200, 200], feature);
+
       const selectSpy = jest.fn();
 
       renderInMapContext(map, <SelectFeaturesButton layers={[layer]} onFeatureSelect={selectSpy} />);
 
-      map.renderSync();
-
       const button = screen.getByRole('button');
       userEvent.click(button);
 
-      const mock = jest.spyOn(map, 'forEachFeatureAtPixel').mockImplementation((pixel, callback) => {
-        if (pixel[0] === 200 && pixel[1] === 200) {
-          callback(feature, layer, null);
-        }
-      });
-
-      await clickMap(map, 200, 200);
+      clickMap(map, 200, 200);
 
       expect(selectSpy).toBeCalled();
       const event: OlSelectEvent = selectSpy.mock.calls[0][0];

--- a/src/Util/rtlTestUtils.tsx
+++ b/src/Util/rtlTestUtils.tsx
@@ -4,6 +4,10 @@ import MapContext from '../Context/MapContext/MapContext';
 import MapComponent from '../Map/MapComponent/MapComponent';
 import * as React from 'react';
 import { ReactElement } from 'react';
+import OlFeature from 'ol/Feature';
+import OlGeometry from 'ol/geom/Geometry';
+import OlVectorLayer from 'ol/layer/Vector';
+import OlVectorSource from 'ol/source/Vector';
 
 export async function actSetTimeout(time: number): Promise<void> {
   return act(async () => {
@@ -88,4 +92,17 @@ export function renderInMapContext(map: OlMap, element: ReactElement, size: [num
     rerenderInMapContext,
     ...results
   };
+}
+
+export function mockForEachFeatureAtPixel(
+  map: OlMap,
+  pixel: [number, number],
+  feature: OlFeature<OlGeometry>,
+  layer?: OlVectorLayer<OlVectorSource<OlGeometry>>
+): jest.SpyInstance {
+  return jest.spyOn(map, 'forEachFeatureAtPixel').mockImplementation((atPixel, callback) => {
+    if (pixel[0] === atPixel[0] && pixel[1] === atPixel[1]) {
+      callback(feature, layer, null);
+    }
+  });
 }


### PR DESCRIPTION
<!-- Please choose one of the categories and choose the corresponding label, too. -->
## FEATURE | BUGFIX

### Description:
This PR adds a dedicated CopyButton that copies features on click. Also this PR addresses an issue with the SelectFeaturesButton which was clearing the feature collection on rerender. This is originally caused by the ToggleButton which seems to call `onToggle` on rerender. This change makes the button more robust regardless.