### PR TITLE
fix: prevents double labels on measure polygon features

### DIFF
--- a/src/Button/MeasureButton/MeasureButton.tsx
+++ b/src/Button/MeasureButton/MeasureButton.tsx
@@ -537,7 +537,10 @@ class MeasureButton extends React.Component<MeasureButtonProps> {
     }
 
     // Fix doubled label for lastPoint of line
-    if ((multipleDrawing || showMeasureInfoOnClickedPoints) && measureType === 'line') {
+    if (
+      (multipleDrawing || showMeasureInfoOnClickedPoints) &&
+      (measureType === 'line' || measureType === 'polygon')
+    ) {
       this.removeMeasureTooltip();
     } else {
       this._measureTooltipElement.className =
@@ -551,7 +554,10 @@ class MeasureButton extends React.Component<MeasureButtonProps> {
     this._feature = null;
 
     // fix doubled label for last point of line
-    if ((multipleDrawing || showMeasureInfoOnClickedPoints) && measureType === 'line') {
+    if (
+      (multipleDrawing || showMeasureInfoOnClickedPoints) &&
+      (measureType === 'line' || measureType === 'polygon')
+    ) {
       this._measureTooltipElement = null;
       this.createMeasureTooltip();
     }


### PR DESCRIPTION
<!-- Please choose one of the categories and choose the corresponding label, too. -->
## BUGFIX

### Description:
With this adjustment, duplicate labs are no longer drawn on the polygons during measurements


@terrestris/devs please review