### PR TITLE
chore: enable engine-strict

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true


### PR DESCRIPTION
<!-- Please choose one of the categories and choose the corresponding label, too. -->
## DEVSETUP

### Description:
This enables `engine-strict` to force `npm i` to work with `npm >= 7`. This will prevent rewriting the lockfile from version 1 to 2 and back.