### PR TITLE
Fix automated action run and allow manual execution

### DIFF
--- a/.github/workflows/on-publish.yml
+++ b/.github/workflows/on-publish.yml
@@ -2,7 +2,8 @@ name: Update gh-pages
 
 on:
   release:
-    types: [published]
+    types: [created]
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
<!-- Please choose one of the categories and choose the corresponding label, too. -->
## BUILD

### Description:
<!-- Please describe what this PR is about. -->

This tries to fix the automated update of the gh-pages branch by running it on release creation. Not sure, by I assume the 
 `published` one isn't triggered by the semantic-release process. In addition [workflow_dispatch](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch) allows for a manual trigger of the pipeline.

Potentially resolves #2313.

Please review @terrestris/devs.

<!--- CHECKLIST
Fixes Issue?
Examples added?
Tests added?
Docs added?
Would a screenshot be helpful?
Do you want to mention someone?
-->
