### PR TITLE
Fix some GitHub check annotations

### DIFF
--- a/src/Field/CoordinateReferenceSystemCombo/CoordinateReferenceSystemCombo.tsx
+++ b/src/Field/CoordinateReferenceSystemCombo/CoordinateReferenceSystemCombo.tsx
@@ -105,7 +105,7 @@ class CoordinateReferenceSystemCombo extends React.Component<CRSComboProps, CRSC
    *
    */
   onFetchError(error: Error) {
-    Logger.error(`Error while requesting in CoordinateReferenceSystemCombo`, error);
+    Logger.error('Error while requesting in CoordinateReferenceSystemCombo', error);
   }
 
   /**

--- a/src/Provider/MapProvider/MapProvider.tsx
+++ b/src/Provider/MapProvider/MapProvider.tsx
@@ -60,7 +60,7 @@ class MapProvider extends React.Component<MapProviderProps, MapProviderState> {
       })
       .catch(error => {
         Logger.error(error);
-      })
+      });
   }
 
   /**


### PR DESCRIPTION

<!-- Please choose one of the categories and choose the corresponding label, too. -->
## BUGFIX 

### Description:
Fixes the following:

* in `CoordinateReferenceSystemCombo.tsx`: Strings must use singlequote
* in `MapProvider.tsx`: Missing semicolon

Compare e.g.:
![image](https://user-images.githubusercontent.com/227934/156000404-fa3c8705-7660-4f60-b51c-fc93cd54bf8e.png)

Please review.