### PR TITLE
fix: enable `noImplicitAny`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@fortawesome/free-solid-svg-icons": "^6.0.0",
         "@fortawesome/react-fontawesome": "^0.1.17",
         "@terrestris/base-util": "^1.0.1",
-        "@terrestris/ol-util": "^6.0.0",
+        "@terrestris/ol-util": "^6.0.1",
         "@types/geojson": "^7946.0.8",
         "@types/lodash": "^4.14.179",
         "@types/moment": "^2.13.0",
@@ -3642,9 +3642,9 @@
       }
     },
     "node_modules/@terrestris/ol-util": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@terrestris/ol-util/-/ol-util-6.0.0.tgz",
-      "integrity": "sha512-99km/hVLd0JS6y7zCNnD1Bf9IW2lpiUWfKcawvhkyVkEujsSP4zlgl6QwCiYgWQYUsoCAyNZHeiFVoXklEwW+A==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@terrestris/ol-util/-/ol-util-6.0.1.tgz",
+      "integrity": "sha512-8AH+1IX2Mmg5wckKjaxgRFayq3RhJ6L15pVRd4qlF9nKPwnDj2ysPJY3aJA9BwsJ5I6cue/TTyPqjU3u2nGyRA==",
       "dependencies": {
         "@terrestris/base-util": "^1.0.1",
         "@turf/turf": "^6.5.0",
@@ -3660,18 +3660,6 @@
       },
       "peerDependencies": {
         "ol": "^6.5"
-      }
-    },
-    "node_modules/@terrestris/ol-util/node_modules/typescript": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.2.tgz",
-      "integrity": "sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
       }
     },
     "node_modules/@testing-library/dom": {
@@ -27775,7 +27763,6 @@
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.2.tgz",
       "integrity": "sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==",
-      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -32361,9 +32348,9 @@
       }
     },
     "@terrestris/ol-util": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@terrestris/ol-util/-/ol-util-6.0.0.tgz",
-      "integrity": "sha512-99km/hVLd0JS6y7zCNnD1Bf9IW2lpiUWfKcawvhkyVkEujsSP4zlgl6QwCiYgWQYUsoCAyNZHeiFVoXklEwW+A==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@terrestris/ol-util/-/ol-util-6.0.1.tgz",
+      "integrity": "sha512-8AH+1IX2Mmg5wckKjaxgRFayq3RhJ6L15pVRd4qlF9nKPwnDj2ysPJY3aJA9BwsJ5I6cue/TTyPqjU3u2nGyRA==",
       "requires": {
         "@terrestris/base-util": "^1.0.1",
         "@turf/turf": "^6.5.0",
@@ -32372,13 +32359,6 @@
         "proj4": "^2.7.5",
         "shpjs": "^4.0.2",
         "typescript": "^4.5.5"
-      },
-      "dependencies": {
-        "typescript": {
-          "version": "4.6.2",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.2.tgz",
-          "integrity": "sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg=="
-        }
       }
     },
     "@testing-library/dom": {
@@ -50776,8 +50756,7 @@
     "typescript": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.2.tgz",
-      "integrity": "sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==",
-      "dev": true
+      "integrity": "sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg=="
     },
     "uglify-js": {
       "version": "3.15.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -27775,6 +27775,7 @@
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.2.tgz",
       "integrity": "sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==",
+      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -32360,9 +32361,9 @@
       }
     },
     "@terrestris/ol-util": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@terrestris/ol-util/-/ol-util-5.1.0.tgz",
-      "integrity": "sha512-IDmqh0H47uSmtZWAWYzILW1Vi4CUvUKgIhL5Vj3OgQ+mYA4k9vL3QvisRWxun3cH6Ra1fgTDy+39i7AT953QdA==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@terrestris/ol-util/-/ol-util-6.0.0.tgz",
+      "integrity": "sha512-99km/hVLd0JS6y7zCNnD1Bf9IW2lpiUWfKcawvhkyVkEujsSP4zlgl6QwCiYgWQYUsoCAyNZHeiFVoXklEwW+A==",
       "requires": {
         "@terrestris/base-util": "^1.0.1",
         "@turf/turf": "^6.5.0",
@@ -32371,6 +32372,13 @@
         "proj4": "^2.7.5",
         "shpjs": "^4.0.2",
         "typescript": "^4.5.5"
+      },
+      "dependencies": {
+        "typescript": {
+          "version": "4.6.2",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.2.tgz",
+          "integrity": "sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg=="
+        }
       }
     },
     "@testing-library/dom": {
@@ -50768,7 +50776,8 @@
     "typescript": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.2.tgz",
-      "integrity": "sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg=="
+      "integrity": "sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==",
+      "dev": true
     },
     "uglify-js": {
       "version": "3.15.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@fortawesome/free-solid-svg-icons": "^6.0.0",
         "@fortawesome/react-fontawesome": "^0.1.17",
         "@terrestris/base-util": "^1.0.1",
-        "@terrestris/ol-util": "^5.1.0",
+        "@terrestris/ol-util": "^6.0.0",
         "@types/geojson": "^7946.0.8",
         "@types/lodash": "^4.14.179",
         "@types/moment": "^2.13.0",
@@ -3642,9 +3642,9 @@
       }
     },
     "node_modules/@terrestris/ol-util": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@terrestris/ol-util/-/ol-util-5.1.0.tgz",
-      "integrity": "sha512-IDmqh0H47uSmtZWAWYzILW1Vi4CUvUKgIhL5Vj3OgQ+mYA4k9vL3QvisRWxun3cH6Ra1fgTDy+39i7AT953QdA==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@terrestris/ol-util/-/ol-util-6.0.0.tgz",
+      "integrity": "sha512-99km/hVLd0JS6y7zCNnD1Bf9IW2lpiUWfKcawvhkyVkEujsSP4zlgl6QwCiYgWQYUsoCAyNZHeiFVoXklEwW+A==",
       "dependencies": {
         "@terrestris/base-util": "^1.0.1",
         "@turf/turf": "^6.5.0",
@@ -3660,6 +3660,18 @@
       },
       "peerDependencies": {
         "ol": "^6.5"
+      }
+    },
+    "node_modules/@terrestris/ol-util/node_modules/typescript": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.2.tgz",
+      "integrity": "sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
       }
     },
     "node_modules/@testing-library/dom": {

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "@fortawesome/free-solid-svg-icons": "^6.0.0",
     "@fortawesome/react-fontawesome": "^0.1.17",
     "@terrestris/base-util": "^1.0.1",
-    "@terrestris/ol-util": "^6.0.0",
+    "@terrestris/ol-util": "^6.0.1",
     "@types/geojson": "^7946.0.8",
     "@types/lodash": "^4.14.179",
     "@types/moment": "^2.13.0",

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "@fortawesome/free-solid-svg-icons": "^6.0.0",
     "@fortawesome/react-fontawesome": "^0.1.17",
     "@terrestris/base-util": "^1.0.1",
-    "@terrestris/ol-util": "^5.1.0",
+    "@terrestris/ol-util": "^6.0.0",
     "@types/geojson": "^7946.0.8",
     "@types/lodash": "^4.14.179",
     "@types/moment": "^2.13.0",

--- a/src/Button/CopyButton/CopyButton.tsx
+++ b/src/Button/CopyButton/CopyButton.tsx
@@ -64,7 +64,7 @@ const CopyButton: React.FC<CopyButtonProps> = ({
 
     const feat = event.selected[0];
 
-    if (!feat || !layers) {
+    if (!feat || !layers || !map) {
       return;
     }
 

--- a/src/Button/DigitizeButton/DigitizeButton.tsx
+++ b/src/Button/DigitizeButton/DigitizeButton.tsx
@@ -526,9 +526,9 @@ class DigitizeButton extends React.Component<DigitizeButtonProps, DigitizeButton
       map
     } = this.props;
 
-    let digitizeLayer = digitizeLayerName ? MapUtil.getLayerByName(map, digitizeLayerName) : null;
+    let digitizeLayer = digitizeLayerName ? MapUtil.getLayerByName(map, digitizeLayerName) as OlLayerVector<OlSourceVector<OlGeometry>>: null;
 
-    if (!digitizeLayer) {
+    if (digitizeLayer == null) {
       digitizeLayer = new OlLayerVector({
         source: new OlSourceVector({
           features: new OlCollection()
@@ -544,7 +544,7 @@ class DigitizeButton extends React.Component<DigitizeButtonProps, DigitizeButton
 
     this._digitizeLayer = digitizeLayer;
 
-    this._digitizeFeatures = digitizeLayer.getSource().getFeaturesCollection();
+    this._digitizeFeatures = digitizeLayer.getSource()?.getFeaturesCollection() ?? null;
   };
 
   /**

--- a/src/Button/DigitizeButton/DigitizeButton.tsx
+++ b/src/Button/DigitizeButton/DigitizeButton.tsx
@@ -526,7 +526,9 @@ class DigitizeButton extends React.Component<DigitizeButtonProps, DigitizeButton
       map
     } = this.props;
 
-    let digitizeLayer = digitizeLayerName ? MapUtil.getLayerByName(map, digitizeLayerName) as OlLayerVector<OlSourceVector<OlGeometry>>: null;
+    let digitizeLayer = digitizeLayerName ?
+      MapUtil.getLayerByName(map, digitizeLayerName) as OlLayerVector<OlSourceVector<OlGeometry>> :
+      null;
 
     if (digitizeLayer == null) {
       digitizeLayer = new OlLayerVector({
@@ -851,7 +853,8 @@ class DigitizeButton extends React.Component<DigitizeButtonProps, DigitizeButton
     }
 
     const translateInteractionName = `react-geo-translate-interaction-${editType}`;
-    let translateInteraction = MapUtil.getInteractionsByName(map, translateInteractionName)[0] as OlInteractionTranslate;
+    let translateInteraction =
+      MapUtil.getInteractionsByName(map, translateInteractionName)[0] as OlInteractionTranslate;
 
     if (!translateInteraction) {
       translateInteraction = new OlInteractionTranslate({

--- a/src/Button/DrawButton/DrawButton.tsx
+++ b/src/Button/DrawButton/DrawButton.tsx
@@ -15,6 +15,7 @@ import { CSS_PREFIX } from '../../constants';
 import { useMap } from '../../Hook/useMap';
 import { DigitizeUtil } from '../../Util/DigitizeUtil';
 import { FeatureLabelModal } from '../../FeatureLabelModal/FeatureLabelModal';
+import { EventsKey } from 'ol/events';
 
 type DrawType = 'Point' | 'LineString' | 'Polygon' | 'Circle' | 'Rectangle' | 'Text';
 
@@ -165,7 +166,7 @@ const DrawButton: React.FC<DrawButtonProps> = ({
 
     setDrawInteraction(newInteraction);
 
-    let key;
+    let key: EventsKey;
 
     if (drawType === 'Text') {
       key = newInteraction.on('drawend', evt => {

--- a/src/Button/GeoLocationButton/GeoLocationButton.tsx
+++ b/src/Button/GeoLocationButton/GeoLocationButton.tsx
@@ -273,30 +273,28 @@ class GeoLocationButton extends React.Component<GeoLocationButtonProps> {
 
   // recenters the view by putting the given coordinates at 3/4 from the top or
   // the screen
-  getCenterWithHeading = (position, rotation, resolution) => {
+  getCenterWithHeading = (position: [number, number], rotation: number, resolution: number) => {
     const size = this.props.map.getSize() ?? [0, 0];
     const height = size[1];
 
     return [
-      position[0] - Math.sin(rotation) * height * resolution * 1 / 4,
-      position[1] + Math.cos(rotation) * height * resolution * 1 / 4
+      position[0] - Math.sin(rotation) * height * resolution / 4,
+      position[1] + Math.cos(rotation) * height * resolution / 4
     ];
   };
 
   updateView = () => {
     const view = this.props.map.getView();
     const deltaMean = 500; // the geolocation sampling period mean in ms
-    let previousM = 0;
     // use sampling period to get a smooth transition
     let m = Date.now() - deltaMean * 1.5;
-    m = Math.max(m, previousM);
+    m = Math.max(m, 0);
 
-    previousM = m;
     // interpolate position along positions LineString
     const c = this._positions.getCoordinateAtM(m, true);
     if (c) {
       if (this.props.follow) {
-        view.setCenter(this.getCenterWithHeading(c, -c[2], view.getResolution()));
+        view.setCenter(this.getCenterWithHeading([c[0], c[1]], -c[2], view.getResolution() ?? 0));
         view.setRotation(-c[2]);
       }
       if (this.props.showMarker) {

--- a/src/Button/MeasureButton/MeasureButton.tsx
+++ b/src/Button/MeasureButton/MeasureButton.tsx
@@ -462,10 +462,8 @@ class MeasureButton extends React.Component<MeasureButtonProps> {
 
   /**
    * Called if the current geometry of the draw interaction has changed.
-   *
-   * @param evt The generic change event.
    */
-  onDrawInteractionGeometryChange(/* evt*/) {
+  onDrawInteractionGeometryChange() {
     this.updateMeasureTooltip();
   }
 
@@ -608,8 +606,8 @@ class MeasureButton extends React.Component<MeasureButtonProps> {
       }
 
       const value = measureType === 'line' ?
-        MeasureUtil.formatLength(geom, map, decimalPlacesInTooltips, geodesic) :
-        MeasureUtil.formatArea(geom, map, decimalPlacesInTooltips, geodesic);
+        MeasureUtil.formatLength(geom as OlGeomLineString, map, decimalPlacesInTooltips, geodesic) :
+        MeasureUtil.formatArea(geom as OlGeomPolygon, map, decimalPlacesInTooltips, geodesic);
 
       if (parseInt(value, 10) > 0) {
         const div = document.createElement('div');
@@ -843,13 +841,15 @@ class MeasureButton extends React.Component<MeasureButtonProps> {
         if (measureType === 'line') {
           output = MeasureUtil.formatLength(geom, map, decimalPlacesInTooltips, geodesic);
         } else if (measureType === 'angle') {
-          output = MeasureUtil.formatAngle(geom, map, decimalPlacesInTooltips);
+          output = MeasureUtil.formatAngle(geom, 0);
         }
       } else {
         return;
       }
 
-      this._measureTooltipElement.innerHTML = output;
+      if (output) {
+        this._measureTooltipElement.innerHTML = output;
+      }
       this._measureTooltip?.setPosition(measureTooltipCoord);
     }
   }

--- a/src/Button/MeasureButton/MeasureButton.tsx
+++ b/src/Button/MeasureButton/MeasureButton.tsx
@@ -335,7 +335,7 @@ class MeasureButton extends React.Component<MeasureButtonProps> {
       map
     } = this.props;
 
-    let measureLayer = MapUtil.getLayerByName(map, measureLayerName);
+    let measureLayer = MapUtil.getLayerByName(map, measureLayerName) as OlLayerVector<OlSourceVector<OlGeometry>>;
 
     if (!measureLayer) {
       measureLayer = new OlLayerVector({

--- a/src/Button/ToggleGroup/ToggleGroup.tsx
+++ b/src/Button/ToggleGroup/ToggleGroup.tsx
@@ -6,6 +6,7 @@ import _isFunction from 'lodash/isFunction';
 import { CSS_PREFIX } from '../../constants';
 
 import './ToggleGroup.less';
+import { ToggleButtonProps } from '../ToggleButton/ToggleButton';
 
 export interface ToggleGroupProps {
   /**
@@ -124,7 +125,7 @@ class ToggleGroup extends React.Component<ToggleGroupProps, ToggleGroupState> {
    *
    * @param childProps The properties of the children.
    */
-  onChange = (childProps) => {
+  onChange = (childProps: ToggleButtonProps) => {
     if (_isFunction(this.props.onChange)) {
       this.props.onChange(childProps);
     }

--- a/src/Container/AddWmsPanel/AddWmsLayerEntry/AddWmsLayerEntry.tsx
+++ b/src/Container/AddWmsPanel/AddWmsLayerEntry/AddWmsLayerEntry.tsx
@@ -47,7 +47,7 @@ export class AddWmsLayerEntry extends React.Component<AddWmsLayerEntryProps, Add
    */
   static defaultProps = {
     layerQueryableText: 'Layer is queryable',
-    layerTextTemplateFn: (wmsLayer) => {
+    layerTextTemplateFn: (wmsLayer: WmsLayer) => {
       const title = wmsLayer.get('title');
       const abstract = wmsLayer.get('abstract');
       return abstract ?

--- a/src/Field/CoordinateReferenceSystemCombo/CoordinateReferenceSystemCombo.tsx
+++ b/src/Field/CoordinateReferenceSystemCombo/CoordinateReferenceSystemCombo.tsx
@@ -118,7 +118,7 @@ class CoordinateReferenceSystemCombo extends React.Component<CRSComboProps, CRSC
   transformResults = (json: any): CrsDefinition[] => {
     const results = json.results;
     if (results && results.length > 0) {
-      return results.map(obj => ({code: obj.code, value: obj.name, proj4def: obj.proj4, bbox: obj.bbox}));
+      return results.map((obj: any) => ({code: obj.code, value: obj.name, proj4def: obj.proj4, bbox: obj.bbox}));
     } else {
       return [];
     }

--- a/src/Field/NominatimSearch/NominatimSearch.tsx
+++ b/src/Field/NominatimSearch/NominatimSearch.tsx
@@ -173,6 +173,7 @@ export class NominatimSearch extends React.Component<NominatimSearchProps, Nomin
      * selected item.
      *
      * @param selected The selected item as it is returned by nominatim.
+     * @param olMap The map
      */
     onSelect: (selected: NominatimPlace, olMap: OlMap) => {
       if (selected && selected.boundingbox) {
@@ -222,7 +223,7 @@ export class NominatimSearch extends React.Component<NominatimSearchProps, Nomin
    *
    * @param prevProps Previous props
    */
-  componentDidUpdate(prevProps) {
+  componentDidUpdate(prevProps: Readonly<NominatimSearchProps>) {
     if (this.props.searchTerm !== prevProps.searchTerm) {
       this.onUpdateInput(this.props.searchTerm);
     }

--- a/src/Field/ScaleCombo/ScaleCombo.tsx
+++ b/src/Field/ScaleCombo/ScaleCombo.tsx
@@ -4,6 +4,7 @@ const Option = Select.Option;
 
 import OlMap from 'ol/Map';
 import OlView from 'ol/View';
+import OlMapEvent from 'ol/MapEvent';
 
 import _isInteger from 'lodash/isInteger';
 import _isEmpty from 'lodash/isEmpty';
@@ -19,6 +20,7 @@ import MapUtil from '@terrestris/ol-util/dist/MapUtil/MapUtil';
 import { CSS_PREFIX } from '../../constants';
 
 import './ScaleCombo.less';
+import _isNumber from 'lodash/isNumber';
 
 interface ScaleComboProps {
   /**
@@ -111,7 +113,7 @@ class ScaleCombo extends React.Component<ScaleComboProps, ScaleComboState> {
     const defaultOnZoomLevelSelect = (selectedScale: string) => {
       const mapView = props.map.getView();
       const calculatedResolution = MapUtil.getResolutionForScale(
-        selectedScale, mapView.getProjection().getUnits()
+        parseInt(selectedScale, 10), mapView.getProjection().getUnits()
       );
       mapView.setResolution(calculatedResolution);
     };
@@ -180,11 +182,11 @@ class ScaleCombo extends React.Component<ScaleComboProps, ScaleComboState> {
    * @param evt The 'moveend' event
    * @private
    */
-  zoomListener = (evt) => {
-    const zoom = evt.target.getView().getZoom();
-    let roundZoom = Math.round(zoom);
-    if (!roundZoom) {
-      roundZoom = 0;
+  zoomListener = (evt: OlMapEvent) => {
+    const zoom = (evt.target as OlMap).getView().getZoom();
+    let roundZoom = 0;
+    if (_isNumber(zoom)) {
+      roundZoom = Math.round(zoom);
     }
 
     this.setState({
@@ -194,14 +196,14 @@ class ScaleCombo extends React.Component<ScaleComboProps, ScaleComboState> {
 
   /**
    * @function pushScaleOption: Helper function to create a {@link Option} scale component
-   * based on a resolution and the {@link Ol.View}
+   * based on a resolution and the {@link OlView}
    *
    * @param scales The scales array to push the scale to.
    * @param resolution map cresolution to generate the option for
    * @param view The map view
    *
    */
-  pushScale = (scales: string[], resolution: number, view: OlView) => {
+  pushScale = (scales: number[], resolution: number, view: OlView) => {
     const scale = MapUtil.getScaleForResolution(resolution, view.getProjection().getUnits());
     const roundScale = MapUtil.roundScale(scale);
     if (scales.includes(roundScale) ) {
@@ -212,7 +214,7 @@ class ScaleCombo extends React.Component<ScaleComboProps, ScaleComboState> {
 
   /**
    * Generates the scales to add as {@link Option} to the SelectField based on
-   * the given instance of {@link Ol.Map}.
+   * the given instance of {@link OlMap}.
    *
    * @return The array of scales.
    */
@@ -227,7 +229,7 @@ class ScaleCombo extends React.Component<ScaleComboProps, ScaleComboState> {
       return [];
     }
 
-    const scales = [];
+    const scales: number[] = [];
     const view = map.getView();
     // use existing resolutions array if exists
     const resolutions = view.getResolutions();

--- a/src/Field/WfsSearchInput/WfsSearchInput.tsx
+++ b/src/Field/WfsSearchInput/WfsSearchInput.tsx
@@ -328,7 +328,7 @@ export class WfsSearchInput extends React.Component<WfsSearchInputProps, WfsSear
           });
           this.onFetchSuccess(await response.json());
         } catch (e) {
-          this.onFetchError(e.getMessage())
+          this.onFetchError(e.getMessage());
         }
       });
     } else {

--- a/src/Field/WfsSearchInput/WfsSearchInput.tsx
+++ b/src/Field/WfsSearchInput/WfsSearchInput.tsx
@@ -15,6 +15,8 @@ import _debounce from 'lodash/debounce';
 import Logger from '@terrestris/base-util/dist/Logger';
 import WfsFilterUtil from '@terrestris/ol-util/dist/WfsFilterUtil/WfsFilterUtil';
 
+import { Feature } from 'geojson';
+
 import { CSS_PREFIX } from '../../constants';
 
 import './WfsSearchInput.less';
@@ -139,12 +141,12 @@ interface OwnProps {
    * Please note: if omitted only data fetch will be performed and no data
    * will be shown afterwards!
    */
-  onFetchSuccess?: (data: any) => void;
+  onFetchSuccess?: (features: Feature[]) => void;
   /**
    * An onFetchError callback function which gets called if data fetch is
    * failed.
    */
-  onFetchError?: (data: any) => void;
+  onFetchError?: (error: string) => void;
   /**
    * Optional callback function, that will be called if 'clear' button of
    * input field was clicked.
@@ -159,7 +161,7 @@ interface OwnProps {
 
 interface WfsSearchState {
   searchTerm: string;
-  data: any[];
+  data: Feature[];
   fetching: boolean;
 }
 
@@ -223,7 +225,7 @@ export class WfsSearchInput extends React.Component<WfsSearchInputProps, WfsSear
    *
    * @param prevProps Previous props
    */
-  componentDidUpdate(prevProps) {
+  componentDidUpdate(prevProps: Readonly<WfsSearchInputProps>) {
     if (this.props.searchTerm !== prevProps.searchTerm) {
       const evt = {
         target: {
@@ -314,18 +316,20 @@ export class WfsSearchInput extends React.Component<WfsSearchInputProps, WfsSear
     if (request) {
       this.setState({
         fetching: true
-      }, () => {
-        fetch(`${baseUrl}`, {
-          method: 'POST',
-          credentials: additionalFetchOptions.credentials
-            ? additionalFetchOptions.credentials
-            : 'same-origin',
-          body: new XMLSerializer().serializeToString(request),
-          ...additionalFetchOptions
-        })
-          .then(response => response.json())
-          .then(this.onFetchSuccess.bind(this))
-          .catch(this.onFetchError.bind(this));
+      }, async () => {
+        try {
+          const response = await fetch(`${baseUrl}`, {
+            method: 'POST',
+            credentials: additionalFetchOptions.credentials
+              ? additionalFetchOptions.credentials
+              : 'same-origin',
+            body: new XMLSerializer().serializeToString(request),
+            ...additionalFetchOptions
+          });
+          this.onFetchSuccess(await response.json());
+        } catch (e) {
+          this.onFetchError(e.getMessage())
+        }
       });
     } else {
       this.onFetchError('Missing GetFeature request parameters');
@@ -343,15 +347,18 @@ export class WfsSearchInput extends React.Component<WfsSearchInputProps, WfsSear
     const {
       onFetchSuccess
     } = this.props;
-    const data = response.features ? response.features : [];
-    data.forEach(feature => feature.searchTerm = this.state.searchTerm);
+    const data: Feature[] = response.features ? response.features : [];
+    for (const feature of data) {
+      if (!feature.properties) {
+        feature.properties = {};
+      }
+      feature.properties.searchTerm = this.state.searchTerm;
+    }
     this.setState({
       data,
       fetching: false
     }, () => {
-      if (onFetchSuccess) {
-        onFetchSuccess(data);
-      }
+      onFetchSuccess?.(data);
     });
   }
 
@@ -371,9 +378,7 @@ export class WfsSearchInput extends React.Component<WfsSearchInputProps, WfsSear
     this.setState({
       fetching: false
     }, () => {
-      if (onFetchError) {
-        onFetchError(error);
-      }
+      onFetchError?.(error);
     });
   }
 

--- a/src/HigherOrderComponent/TimeLayerAware/TimeLayerAware.tsx
+++ b/src/HigherOrderComponent/TimeLayerAware/TimeLayerAware.tsx
@@ -45,7 +45,7 @@ export function timeLayerAware<P>(WrappedComponent: React.ComponentType<P>, laye
 
   return class TimeLayerAware extends React.Component<Omit<P, 'onChange'>> {
 
-    timeChanged = newValues => {
+    timeChanged = (newValues: any) => {
       layers.forEach(config => {
         if (config.isWmsTime) {
           const parms = config.layer.getSource()?.getParams();

--- a/src/LayerSwitcher/LayerSwitcher.tsx
+++ b/src/LayerSwitcher/LayerSwitcher.tsx
@@ -118,10 +118,9 @@ export class LayerSwitcher extends React.Component<LayerSwitcherProps, LayerSwit
    * @param layer The layer to clone.
    * @returns The cloned layer.
    */
-  cloneLayer = (layer: OlLayerTile<OlTileSource> | OlLayerGroup) => {
-    let layerClone: OlLayerTile<OlTileSource> | OlLayerGroup;
+  cloneLayer (layer: OlLayerTile<OlTileSource> | OlLayerGroup): OlLayerTile<OlTileSource> | OlLayerGroup {
     if (layer instanceof OlLayerGroup) {
-      layerClone = new OlLayerGroup({
+      return new OlLayerGroup({
         layers: layer.getLayers().getArray().map(this.cloneLayer),
         properties: {
           originalLayer: layer
@@ -129,15 +128,14 @@ export class LayerSwitcher extends React.Component<LayerSwitcherProps, LayerSwit
         ...layer.getProperties()
       });
     } else {
-      layerClone = new OlLayerTile({
-        source: layer.getSource() || undefined,
+      return new OlLayerTile({
+        source: (layer as OlLayerTile<OlTileSource>).getSource() || undefined,
         properties: {
           originalLayer: layer
         },
         ...layer.getProperties()
       });
     }
-    return layerClone;
   };
 
   /**

--- a/src/LayerTree/LayerTree.tsx
+++ b/src/LayerTree/LayerTree.tsx
@@ -432,7 +432,8 @@ class LayerTree extends React.Component<LayerTreeProps, LayerTreeState> {
       return [];
     }
 
-    return MapUtil.getAllLayers(this.state.layerGroup, (layer: OlLayerBase) => {
+    return MapUtil.getAllLayers(this.state.layerGroup,
+      (layer: OlLayerBase) => {
         return !(layer instanceof OlLayerGroup) && layer.getVisible();
       })
       .filter(this.props.filterFunction)

--- a/src/LayerTree/LayerTree.tsx
+++ b/src/LayerTree/LayerTree.tsx
@@ -18,6 +18,7 @@ import OlCollection from 'ol/Collection';
 import OlMapEvent from 'ol/MapEvent';
 import { unByKey } from 'ol/Observable';
 import { getUid } from 'ol';
+import { EventsKey as OlEventsKey } from 'ol/events';
 
 import _isFunction from 'lodash/isFunction';
 import _isEqual from 'lodash/isEqual';
@@ -27,7 +28,6 @@ import MapUtil from '@terrestris/ol-util/dist/MapUtil/MapUtil';
 import LayerTreeNode, { LayerTreeNodeProps } from './LayerTreeNode/LayerTreeNode';
 
 import { CSS_PREFIX } from '../constants';
-import { EventsKey } from 'ol/events';
 
 
 interface OwnProps {
@@ -101,7 +101,7 @@ class LayerTree extends React.Component<LayerTreeProps, LayerTreeState> {
    *  An array of ol.EventsKey as returned by on() or once().
    * @private
    */
-  olListenerKeys: EventsKey[] = [];
+  olListenerKeys: OlEventsKey[] = [];
 
   /**
    * Create the LayerTree.
@@ -267,7 +267,7 @@ class LayerTree extends React.Component<LayerTreeProps, LayerTreeState> {
   onCollectionRemove = (evt: any) => {
     this.unregisterEventsByLayer(evt.element);
     if (evt.element instanceof OlLayerGroup) {
-      evt.element.getLayers().forEach((layer) => {
+      evt.element.getLayers().forEach((layer: OlLayerBase) => {
         this.unregisterEventsByLayer(layer);
       });
     }
@@ -283,7 +283,7 @@ class LayerTree extends React.Component<LayerTreeProps, LayerTreeState> {
   onChangeLayers = (evt: any) => {
     this.unregisterEventsByLayer(evt.oldValue);
     if (evt.oldValue instanceof OlCollection) {
-      evt.oldValue.forEach((layer) => this.unregisterEventsByLayer(layer));
+      evt.oldValue.forEach((layer: OlLayerBase) => this.unregisterEventsByLayer(layer));
     }
     if (evt.target instanceof OlLayerGroup) {
       this.registerAddRemoveListeners(evt.target);
@@ -381,7 +381,7 @@ class LayerTree extends React.Component<LayerTreeProps, LayerTreeState> {
         return this.treeNodeFromLayer(childLayer);
       }).reverse();
     } else {
-      if (!this.hasListener(layer, 'change:visible', this.onLayerChangeVisible)) {
+      if (!this.hasListener({ target: layer, type: 'change:visible', listener: this.onLayerChangeVisible })) {
         const eventKey = layer.on('change:visible', this.onLayerChangeVisible);
         this.olListenerKeys.push(eventKey);
       }
@@ -401,24 +401,17 @@ class LayerTree extends React.Component<LayerTreeProps, LayerTreeState> {
   /**
    * Determines if the target has already registered the given listener for the
    * given eventtype.
-   *
-   * @param target The event target.
-   * @param type The events type (name).
-   * @param listener The function.
-   * @return True if the listener is already contained in this.olListenerKeys.
    */
-  hasListener = (target, type, listener) => {
+  hasListener = (key: OlEventsKey) => {
     return this.olListenerKeys.some((listenerKey) => {
-      return listenerKey.target === target
-        && listenerKey.type === type
-        && listenerKey.listener === listener;
+      return listenerKey.target === key.target
+        && listenerKey.type === key.type
+        && listenerKey.listener === key.listener;
     });
   };
 
   /**
    * Reacts to the layer change:visible event and calls setCheckedState.
-   *
-   * @param evt The change:visible event
    */
   onLayerChangeVisible = () => {
     const checkedKeys = this.getVisibleOlUids();
@@ -434,11 +427,16 @@ class LayerTree extends React.Component<LayerTreeProps, LayerTreeState> {
    *
    * @return The visible ol_uids.
    */
-  getVisibleOlUids = () => {
-    const layers = MapUtil.getAllLayers(this.state.layerGroup, (layer) => {
-      return !(layer instanceof OlLayerGroup) && layer.getVisible();
-    }).filter(this.props.filterFunction);
-    return layers.map(getUid);
+  getVisibleOlUids = (): string[] => {
+    if (!this.state.layerGroup) {
+      return [];
+    }
+
+    return MapUtil.getAllLayers(this.state.layerGroup, (layer: OlLayerBase) => {
+        return !(layer instanceof OlLayerGroup) && layer.getVisible();
+      })
+      .filter(this.props.filterFunction)
+      .map(getUid);
   };
 
   /**
@@ -450,9 +448,10 @@ class LayerTree extends React.Component<LayerTreeProps, LayerTreeState> {
   onCheck(checkedKeys: string[], e: AntTreeNodeCheckedEvent) {
     const { checked = false } = e;
     const eventKey = e.node.props.eventKey;
-    const layer = MapUtil.getLayerByOlUid(this.props.map, eventKey);
-
-    this.setLayerVisibility(layer, checked);
+    if (eventKey) {
+      const layer = MapUtil.getLayerByOlUid(this.props.map, eventKey);
+      this.setLayerVisibility(layer, checked);
+    }
   }
 
   /**
@@ -508,6 +507,9 @@ class LayerTree extends React.Component<LayerTreeProps, LayerTreeState> {
    * @param e The ant-tree event object for this event. See ant docs.
    */
   onDrop(e: AntTreeNodeDropEvent) {
+    if (!e.dragNode.props.eventKey || !e.node.props.eventKey) {
+      return;
+    }
     const dragLayer = MapUtil.getLayerByOlUid(this.props.map, e.dragNode.props.eventKey);
     const dragInfo = MapUtil.getLayerPositionInfo(dragLayer, this.props.map);
     const dragCollection = dragInfo.groupLayer.getLayers();

--- a/src/Legend/Legend.tsx
+++ b/src/Legend/Legend.tsx
@@ -4,9 +4,9 @@ import _isEqual from 'lodash/isEqual';
 
 import Logger from '@terrestris/base-util/dist/Logger';
 import MapUtil from '@terrestris/ol-util/dist/MapUtil/MapUtil';
-import OlBaseLayer from 'ol/layer/Base';
 
 import { CSS_PREFIX } from '../constants';
+import { WmsLayer } from '../Util/typeUtils';
 
 export interface BaseProps {
   /**
@@ -16,7 +16,7 @@ export interface BaseProps {
   /**
    * The layer you want to display the legend of.
    */
-  layer: OlBaseLayer;
+  layer: WmsLayer;
   /**
    * An object containing additional request params like "{HEIGHT: 400}" will
    * be transformed to "&HEIGHT=400" an added to the GetLegendGraphic request.
@@ -105,7 +105,7 @@ export class Legend extends React.Component<LegendProps, LegendState> {
    * @param layer The layer to get the legend graphic request for.
    * @param extraParams The extra params.
    */
-  getLegendUrl(layer: OlBaseLayer, extraParams: any) {
+  getLegendUrl(layer: WmsLayer, extraParams: any) {
     let legendUrl;
 
     if (layer.get('legendUrl')) {

--- a/src/Legend/Legend.tsx
+++ b/src/Legend/Legend.tsx
@@ -25,7 +25,7 @@ export interface BaseProps {
   /**
    * Optional method that should be called when the image retrieval errors
    */
-  onError?: () => void;
+  onError?: (e: Error) => void;
   /**
    * Optional error message that should be displayed when image retrieval
    * errors. Will remove the browsers default broken image
@@ -120,7 +120,7 @@ export class Legend extends React.Component<LegendProps, LegendState> {
   /**
    * onError handler for the rendered img.
    */
-  onError(e) {
+  onError(e: Error) {
     Logger.warn(`Image error for legend of "${this.props.layer.get('name')}".`);
     this.setState({
       legendError: true

--- a/src/Panel/TimeLayerSliderPanel/TimeLayerSliderPanel.tsx
+++ b/src/Panel/TimeLayerSliderPanel/TimeLayerSliderPanel.tsx
@@ -172,10 +172,8 @@ export class TimeLayerSliderPanel extends React.Component<TimeLayerSliderPanelPr
     if (!(_isEqual(nextProps.timeAwareLayers, timeAwareLayers))) {
       return true;
     }
-    if (!(_isEqual(nextProps.tooltips, tooltips))) {
-      return true;
-    }
-    return false;
+
+    return !(_isEqual(nextProps.tooltips, tooltips));
   }
 
   /**
@@ -331,15 +329,9 @@ export class TimeLayerSliderPanel extends React.Component<TimeLayerSliderPanelPr
   /**
    * handle playback speed change
    */
-  onPlaybackSpeedChange = (val: string) => {
-    let valueToSet;
-    if (_isFinite(parseFloat(val))) {
-      valueToSet = parseFloat(val);
-    } else {
-      valueToSet = val;
-    }
+  onPlaybackSpeedChange = (val: number | PlaybackSpeedType) => {
     this.setState({
-      playbackSpeed: valueToSet
+      playbackSpeed: val
     }, () => {
       if (this.state.autoPlayActive) {
         this.autoPlay(true);
@@ -487,7 +479,7 @@ export class TimeLayerSliderPanel extends React.Component<TimeLayerSliderPanelPr
           pressedIconName="pause-circle"
         />
         <Select
-          defaultValue={'1'}
+          defaultValue={1}
           className={extraCls + ' speed-picker'}
           onChange={this.onPlaybackSpeedChange}
         >

--- a/src/Slider/LayerTransparencySlider/LayerTransparencySlider.tsx
+++ b/src/Slider/LayerTransparencySlider/LayerTransparencySlider.tsx
@@ -66,8 +66,8 @@ class LayerTransparencySlider extends React.Component<LayerTransparencySliderPro
       <Slider
         tipFormatter={value => `${value}%`}
         defaultValue={this.getLayerTransparency()}
-        onChange={(value) => {
-          this.setLayerTransparency(value as number);
+        onChange={(value: number) => {
+          this.setLayerTransparency(value);
         }}
         {...passThroughProps}
       />

--- a/src/Slider/TimeSlider/TimeSlider.spec.tsx
+++ b/src/Slider/TimeSlider/TimeSlider.spec.tsx
@@ -12,12 +12,6 @@ describe('<TimeSlider />', () => {
     expect(wrapper).not.toBeUndefined();
   });
 
-  it('does not fail to convert on undefined', () => {
-    const slider = TestUtil.mountComponent(TimeSlider, {}).instance();
-    const undef = slider.convert();
-    expect(undef).toBeUndefined();
-  });
-
   it('converts time millis properly', () => {
     const slider = TestUtil.mountComponent(TimeSlider, {}).instance();
     const time = moment(1500000000000);

--- a/src/Slider/TimeSlider/TimeSlider.tsx
+++ b/src/Slider/TimeSlider/TimeSlider.tsx
@@ -105,10 +105,7 @@ class TimeSlider extends React.Component<TimeSliderProps> {
    * @param val the input value(s)
    * @return The converted value(s)
    */
-  convert(val: string[] | string): number | [number, number] | undefined {
-    if (val === undefined) {
-      return val as undefined;
-    }
+  convert(val: string[] | string): number | [number, number] {
     return _isArray(val) ?
       (val as Array<string>).map(iso => moment(iso).unix()) as [number, number]:
       moment(val).unix() as number;
@@ -136,8 +133,8 @@ class TimeSlider extends React.Component<TimeSliderProps> {
    * @param unix unix timestamps
    * @return The formatted timestamps
    */
-  formatTimestamp(unix: number): string {
-    return moment(unix * 1000).format(this.props.formatString);
+  formatTimestamp(unix: number|undefined): string {
+    return unix ? moment(unix * 1000).format(this.props.formatString) : '';
   }
 
   /**
@@ -175,30 +172,37 @@ class TimeSlider extends React.Component<TimeSliderProps> {
 
     const convertedMarks = this.convertMarks(marks);
 
-    let defaultVal;
-    let val;
     if (useRange) {
-      defaultVal = this.convert(defaultValue) as [number, number];
-      val = this.convert(value) as [number, number];
+      return (
+        <Slider
+          className={finalClassName}
+          defaultValue={this.convert(defaultValue) as [number, number]}
+          range={true}
+          min={moment(min).unix()}
+          max={moment(max).unix()}
+          tipFormatter={val => this.formatTimestamp(val)}
+          onChange={val => this.valueUpdated(val)}
+          value={this.convert(value) as [number, number]}
+          marks={convertedMarks}
+          {...passThroughProps}
+        />
+      );
     } else {
-      defaultVal = this.convert(defaultValue) as number;
-      val = this.convert(value) as number;
+      return (
+        <Slider
+          className={finalClassName}
+          defaultValue={this.convert(defaultValue) as number}
+          range={false}
+          min={moment(min).unix()}
+          max={moment(max).unix()}
+          tipFormatter={val => this.formatTimestamp(val)}
+          onChange={val => this.valueUpdated(val)}
+          value={this.convert(value) as number}
+          marks={convertedMarks}
+          {...passThroughProps}
+        />
+      );
     }
-
-    return (
-      <Slider
-        className={finalClassName}
-        defaultValue={defaultVal}
-        range={useRange}
-        min={moment(min).unix()}
-        max={moment(max).unix()}
-        tipFormatter={this.formatTimestamp.bind(this)}
-        onChange={this.valueUpdated.bind(this)}
-        value={val}
-        marks={convertedMarks}
-        {...passThroughProps}
-      />
-    );
   }
 }
 

--- a/src/Util/DigitizeUtil.ts
+++ b/src/Util/DigitizeUtil.ts
@@ -95,7 +95,7 @@ export class DigitizeUtil {
    * @param map
    */
   static getDigitizeLayer(map: OlMap): OlVectorLayer<OlSourceVector<Geometry>> {
-    let digitizeLayer = MapUtil.getLayerByName(map, DigitizeUtil.DIGITIZE_LAYER_NAME);
+    let digitizeLayer = MapUtil.getLayerByName(map, DigitizeUtil.DIGITIZE_LAYER_NAME) as OlVectorLayer<OlSourceVector>;
 
     if (!digitizeLayer) {
       digitizeLayer = new OlLayerVector({

--- a/src/Util/typeUtils.ts
+++ b/src/Util/typeUtils.ts
@@ -5,7 +5,7 @@ import OlTileWMS from 'ol/source/TileWMS';
 import OlImageLayer from 'ol/layer/Image';
 import OlTileLayer from 'ol/layer/Tile';
 
-export type WmsLayer = OlImageLayer<OlImageWMS> | OlTileLayer<OlTileWMS>;
+export type WmsLayer = OlImageLayer<OlImageWMS> | OlTileLayer<OlTileWMS> | OlLayer<OlImageWMS | OlTileWMS>;
 
 export function isWmsLayer(layer: OlBaseLayer): layer is OlLayer<OlImageWMS | OlTileWMS, any> {
   if (layer instanceof OlLayer) {

--- a/src/Util/typeUtils.ts
+++ b/src/Util/typeUtils.ts
@@ -7,14 +7,10 @@ import OlTileLayer from 'ol/layer/Tile';
 
 export type WmsLayer = OlImageLayer<OlImageWMS> | OlTileLayer<OlTileWMS> | OlLayer<OlImageWMS | OlTileWMS>;
 
-export function isWmsLayer(layer: OlBaseLayer): layer is OlLayer<OlImageWMS | OlTileWMS, any> {
+export function isWmsLayer(layer: OlBaseLayer): layer is WmsLayer {
   if (layer instanceof OlLayer) {
     const source = layer.getSource();
     return source instanceof OlImageWMS || source instanceof OlTileWMS;
   }
   return false;
-}
-
-export function isImageOrTileLayer(layer: OlBaseLayer): layer is WmsLayer {
-  return layer instanceof OlImageLayer || layer instanceof OlTileLayer;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,7 @@
     "lib": ["es7", "dom"],
     "module": "commonjs",
     "moduleResolution": "node",
-    "noImplicitAny": false, //temporal
+    "noImplicitAny": true,
     "noImplicitReturns": true,
     "noImplicitThis": true,
     "noUnusedLocals": true,


### PR DESCRIPTION
## Description

This enables the `noImplicitAny` option of typescript. Updates `ol-util` to version 6.0.0.

- [ ] Bugfix
- [ ] Feature
- [x] Dependency updates
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the
  [BSD-2-Clause](https://github.com/terrestris/react-geo/blob/main/LICENSE).
- [x] I have followed the [guidelines for contributing](https://github.com/terrestris/react-geo/blob/main/CONTRIBUTING.md).
- [x] The proposed change fits to the content of the [Code of Conduct](https://github.com/terrestris/react-geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally).
- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
