### PR TITLE
fix(LayerSwitcher): use -1 for check if layer was not set visible

### DIFF
--- a/src/LayerSwitcher/LayerSwitcher.tsx
+++ b/src/LayerSwitcher/LayerSwitcher.tsx
@@ -56,7 +56,7 @@ export class LayerSwitcher extends React.Component<LayerSwitcherProps, LayerSwit
    */
   _map: OlMap | null = null;
 
-  _visibleLayerIndex: number = 0;
+  _visibleLayerIndex: number = -1;
 
   _layerClones: Array<OlLayerTile<OlTileSource> | OlLayerGroup> = [];
 
@@ -164,7 +164,7 @@ export class LayerSwitcher extends React.Component<LayerSwitcherProps, LayerSwit
       this._map?.addLayer(layerClone);
       return layerClone;
     });
-    if (!_isNumber(this._visibleLayerIndex)) {
+    if (this._visibleLayerIndex < 0) {
       Logger.warn('The initial visibility of at least one layer used with LayerSwitcher should be set to true.');
     }
   };


### PR DESCRIPTION
## Description

fixes failing test that was related to the type checking pr.

## Related issues or pull requests

## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the
  [BSD-2-Clause](https://github.com/terrestris/react-geo/blob/main/LICENSE).
- [x] I have followed the [guidelines for contributing](https://github.com/terrestris/react-geo/blob/main/CONTRIBUTING.md).
- [x] The proposed change fits to the content of the [Code of Conduct](https://github.com/terrestris/react-geo/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally).
- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
