### PR TITLE
fix(MeasureButton): make property `geodesic` a boolean with default value `true`

### DIFF
--- a/src/Button/MeasureButton/MeasureButton.tsx
+++ b/src/Button/MeasureButton/MeasureButton.tsx
@@ -106,7 +106,6 @@ interface OwnProps {
    * A custom onToogle function that will be called if button is toggled
    */
   onToggle: (pressed: boolean) => void;
-
   /**
    * The className which should be added.
    */
@@ -122,7 +121,7 @@ interface OwnProps {
   /**
    * Whether the measure is using geodesic or cartesian mode. Geodesic is used by default.
    */
-  geodesic: true;
+  geodesic: boolean;
 }
 
 export type MeasureButtonProps = OwnProps & Partial<ToggleButtonProps>;
@@ -156,7 +155,8 @@ class MeasureButton extends React.Component<MeasureButtonProps> {
       tooltipStatic: `${CSS_PREFIX}measure-tooltip-static`
     },
     pressed: false,
-    onToggle: () => undefined
+    onToggle: () => undefined,
+    geodesic: true
   };
 
   /**


### PR DESCRIPTION
## Description

See title

## Related issues or pull requests


## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the
  [BSD-2-Clause](https://github.com/terrestris/react-geo/blob/main/LICENSE).
- [x] I have followed the [guidelines for contributing](https://github.com/terrestris/react-geo/blob/main/CONTRIBUTING.md).
- [x] The proposed change fits to the content of the [Code of Conduct](https://github.com/terrestris/react-geo/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally).
- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
