### PR TITLE
fix(DigitizeButton): do not propagate event to translate if modifying

### DIFF
--- a/src/Button/DigitizeButton/DigitizeButton.tsx
+++ b/src/Button/DigitizeButton/DigitizeButton.tsx
@@ -29,6 +29,7 @@ import AnimateUtil from '@terrestris/ol-util/dist/AnimateUtil/AnimateUtil';
 import Logger from '@terrestris/base-util/dist/Logger';
 
 import { CSS_PREFIX } from '../../constants';
+import OlMapBrowserEvent from 'ol/MapBrowserEvent';
 
 interface DefaultProps {
   /**
@@ -806,7 +807,16 @@ class DigitizeButton extends React.Component<DigitizeButtonProps, DigitizeButton
     let modifyInteraction = MapUtil.getInteractionsByName(map, modifyInteractionName)[0];
 
     if (!modifyInteraction) {
+      const condition = modifyInteractionConfig?.condition ?? OlEventConditions.primaryAction;
+
       modifyInteraction = new OlInteractionModify({
+        condition: (evt: OlMapBrowserEvent<MouseEvent>) => {
+          if (condition(evt)) {
+            evt.stopPropagation();
+            return true;
+          }
+          return false;
+        },
         features: this._selectInteraction.getFeatures(),
         deleteCondition: OlEventConditions.singleClick,
         style: this.selectedStyleFunction,


### PR DESCRIPTION
## Description
Do not propagate event in DigitizeButton to the translate interaction if already modifying.

## Related issues or pull requests

## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the
  [BSD-2-Clause](https://github.com/terrestris/react-geo/blob/main/LICENSE).
- [x] I have followed the [guidelines for contributing](https://github.com/terrestris/react-geo/blob/main/CONTRIBUTING.md).
- [x] The proposed change fits to the content of the [Code of Conduct](https://github.com/terrestris/react-geo/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally).
- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
