### PR TITLE
Do not propagate event to translate if modifying

### DIFF
--- a/src/Button/DigitizeButton/DigitizeButton.tsx
+++ b/src/Button/DigitizeButton/DigitizeButton.tsx
@@ -823,7 +823,16 @@ class DigitizeButton extends React.Component<DigitizeButtonProps, DigitizeButton
     let modifyInteraction = MapUtil.getInteractionsByName(map, modifyInteractionName)[0] as OlInteractionModify;
 
     if (!modifyInteraction) {
+      const condition = modifyInteractionConfig?.condition ?? OlEventConditions.primaryAction;
+
       modifyInteraction = new OlInteractionModify({
+        condition: (evt: OlMapBrowserEvent<MouseEvent>) => {
+          if (condition(evt)) {
+            evt.stopPropagation();
+            return true;
+          }
+          return false;
+        },
         features: this._selectInteraction.getFeatures(),
         deleteCondition: OlEventConditions.singleClick,
         style: this.selectedStyleFunction,

--- a/src/Button/ModifyButton/ModifyButton.tsx
+++ b/src/Button/ModifyButton/ModifyButton.tsx
@@ -10,11 +10,12 @@ import * as React from 'react';
 import Modify, { ModifyEvent, Options as ModifyOptions } from 'ol/interaction/Modify';
 import Translate, { Options as TranslateOptions, TranslateEvent } from 'ol/interaction/Translate';
 import OlFeature from 'ol/Feature';
-import { singleClick } from 'ol/events/condition';
+import { singleClick, primaryAction } from 'ol/events/condition';
 import { unByKey } from 'ol/Observable';
 import OlCollection from 'ol/Collection';
 import { FeatureLabelModal } from '../../FeatureLabelModal/FeatureLabelModal';
 import { SelectEvent as OlSelectEvent } from 'ol/interaction/Select';
+import OlMapBrowserEvent from 'ol/MapBrowserEvent';
 
 interface OwnProps {
   /**
@@ -164,8 +165,17 @@ export const ModifyButton: React.FC<ModifyButtonProps> = ({
     map.addInteraction(newTranslateInteraction);
     setTranslateInteraction(newTranslateInteraction);
 
+    const condition = modifyInteractionConfig?.condition ?? primaryAction;
+
     const newModifyInteraction = new Modify({
       features,
+      condition: (evt: OlMapBrowserEvent<MouseEvent>) => {
+        if (condition(evt)) {
+          evt.stopPropagation();
+          return true;
+        }
+        return false;
+      },
       deleteCondition: singleClick,
       style: selectStyle ?? DigitizeUtil.DEFAULT_SELECT_STYLE,
       ...modifyInteractionConfig


### PR DESCRIPTION
## Description

Do not propagate event in DigitizeButton and ModifyButton to the translate interaction if already modifying.

## Related issues or pull requests

## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the
  [BSD-2-Clause](https://github.com/terrestris/react-geo/blob/main/LICENSE).
- [x] I have followed the [guidelines for contributing](https://github.com/terrestris/react-geo/blob/main/CONTRIBUTING.md).
- [x] The proposed change fits to the content of the [Code of Conduct](https://github.com/terrestris/react-geo/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally).
- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
