### PR TITLE
Custom tipFormatter for transparency slider

### DIFF
--- a/src/Slider/LayerTransparencySlider/LayerTransparencySlider.example.md
+++ b/src/Slider/LayerTransparencySlider/LayerTransparencySlider.example.md
@@ -54,6 +54,7 @@ class LayerTransparencySliderExample extends React.Component {
 
           <LayerTransparencySlider
             layer={this.layer}
+            tipFormatter={val => `Transparency: ${val}%`}
           />
         </div>
       </div>

--- a/src/Slider/LayerTransparencySlider/LayerTransparencySlider.spec.tsx
+++ b/src/Slider/LayerTransparencySlider/LayerTransparencySlider.spec.tsx
@@ -41,4 +41,24 @@ describe('<LayerTransparencySlider />', () => {
     expect(layer.getOpacity()).toBe(0.09);
   });
 
+  it('uses default format in tooltip if no tipFormatter is provided', () => {
+    const props = {
+      layer: layer
+    };
+    const wrapper = TestUtil.mountComponent(LayerTransparencySlider, props);
+
+    const formattedValue = wrapper.instance().tipFormatter(50);
+    expect(formattedValue).toBe('50%');
+  });
+  it('uses provided tipFormatter in tooltip', () => {
+    const props = {
+      layer: layer,
+      valueFormatter: val => `Format: ${val}`
+    };
+    const wrapper = TestUtil.mountComponent(LayerTransparencySlider, props);
+
+    const formattedValue = wrapper.instance().tipFormatter(50);
+    expect(formattedValue).toBe('Format: 50');
+  });
+
 });

--- a/src/Slider/LayerTransparencySlider/LayerTransparencySlider.tsx
+++ b/src/Slider/LayerTransparencySlider/LayerTransparencySlider.tsx
@@ -8,6 +8,11 @@ export interface BaseProps {
    * The layer to handle.
    */
   layer: OlLayerBase;
+
+  /**
+   * Custom valueFormatter, will be used as slider tooltip.
+   */
+  valueFormatter?: (val: string | number | undefined) => string;
 }
 
 export type LayerTransparencySliderProps = BaseProps & SliderSingleProps;
@@ -53,6 +58,16 @@ class LayerTransparencySlider extends React.Component<LayerTransparencySliderPro
     return transparency;
   }
 
+  tipFormatter(value: number | undefined) {
+    const {
+      valueFormatter
+    } = this.props;
+    if (valueFormatter) {
+      return valueFormatter(value);
+    }
+    return `${value}%`;
+  }
+
   /**
    * The render function.
    */
@@ -64,7 +79,7 @@ class LayerTransparencySlider extends React.Component<LayerTransparencySliderPro
 
     return (
       <Slider
-        tipFormatter={value => `${value}%`}
+        tipFormatter={(value: number | undefined) => this.tipFormatter(value)}
         defaultValue={this.getLayerTransparency()}
         onChange={(value: number) => {
           this.setLayerTransparency(value);


### PR DESCRIPTION
## Description

This one proposes to pass an optional prop `valueFormatter` to `LayerTransparencySlider` which will be used as tooltip on slider value change.

If not provided, the default tooltip `${value}%` will be used further as usual (no breaking change).

Please review @terrestris/devs 

## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [ ] Bugfix
- [x] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the
  [BSD-2-Clause](https://github.com/terrestris/react-geo/blob/main/LICENSE).
- [x] I have followed the [guidelines for contributing](https://github.com/terrestris/react-geo/blob/main/CONTRIBUTING.md).
- [x] The proposed change fits to the content of the [Code of Conduct](https://github.com/terrestris/react-geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally).
- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
