### PR TITLE
Fix layer cloning for LayerSwitcher component

### DIFF
--- a/src/LayerSwitcher/LayerSwitcher.tsx
+++ b/src/LayerSwitcher/LayerSwitcher.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import _isEqual from 'lodash/isEqual';
-import _isNumber from 'lodash/isNumber';
 import Logger from '@terrestris/base-util/dist/Logger';
 import { ArrayTwoOrMore } from '@terrestris/base-util/dist/types';
 
@@ -145,13 +144,16 @@ export class LayerSwitcher extends React.Component<LayerSwitcherProps, LayerSwit
         ...layer.getProperties()
       });
     } else {
-      return new OlLayerTile({
+      const clone = new OlLayerTile({
         source: (layer as OlLayerTile<OlTileSource>).getSource() || undefined,
         properties: {
           originalLayer: layer
         },
         ...layer.getProperties()
       });
+      // reset reference to the map instance of original layer
+      clone.setMap(null);
+      return clone;
     }
   };
 


### PR DESCRIPTION
## Description

Reset reference to the map instance of original layer to ensure that the cloned layer will be properly assigned to the internal layer swticher map instance.

Please review @terrestris/devs 

## Related issues or pull requests

<!-- Please list issues or pull requests that the changes you propose are related to. It does not matter if they are still open and/or unmerged, any link is appreciated. -->

## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the
  [BSD-2-Clause](https://github.com/terrestris/react-geo/blob/main/LICENSE).
- [x] I have followed the [guidelines for contributing](https://github.com/terrestris/react-geo/blob/main/CONTRIBUTING.md).
- [x] The proposed change fits to the content of the [Code of Conduct](https://github.com/terrestris/react-geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally).
- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
