### PR TITLE
Fix rerendering of the `PropertyGrid` on changed props

### DIFF
--- a/src/Grid/PropertyGrid/PropertyGrid.spec.tsx
+++ b/src/Grid/PropertyGrid/PropertyGrid.spec.tsx
@@ -49,10 +49,10 @@ describe('<PropertyGrid />', () => {
       feature: testFeature
     };
     const wrapper = TestUtil.mountComponent(PropertyGrid, props);
-    const state = wrapper.state();
+    const instance = wrapper.instance() as PropertyGrid;
 
-    const dataSource = state.dataSource;
-    const columns = state.columns;
+    const dataSource = instance.getDataSource();
+    const columns = instance.getColumns();
 
     // check dataSource
     expect(dataSource).toBeInstanceOf(Array);
@@ -79,10 +79,10 @@ describe('<PropertyGrid />', () => {
       attributeFilter
     };
     const wrapper = TestUtil.mountComponent(PropertyGrid, props);
-    const state = wrapper.state();
+    const instance = wrapper.instance() as PropertyGrid;
 
     // check dataSource
-    const dataSource = state.dataSource;
+    const dataSource = instance.getDataSource();
     expect(dataSource).toBeInstanceOf(Array);
     expect(dataSource).toHaveLength(attributeFilter.length);
     dataSource.forEach((dataSourceElement) => {
@@ -98,9 +98,9 @@ describe('<PropertyGrid />', () => {
       attributeNameColumnWidthInPercent
     };
     const wrapper = TestUtil.mountComponent(PropertyGrid, props);
-    const state = wrapper.state();
+    const instance = wrapper.instance() as PropertyGrid;
 
-    const columns = state.columns;
+    const columns = instance.getColumns();
 
     expect(columns).toBeInstanceOf(Array);
     expect(columns).toHaveLength(2);
@@ -118,10 +118,10 @@ describe('<PropertyGrid />', () => {
       attributeNames
     };
     const wrapper = TestUtil.mountComponent(PropertyGrid, props);
-    const state = wrapper.state();
+    const instance = wrapper.instance() as PropertyGrid;
 
     // check dataSource
-    const dataSource = state.dataSource;
+    const dataSource = instance.getDataSource();
     expect(dataSource).toBeInstanceOf(Array);
     dataSource.forEach((dataSourceElement) => {
       const key = dataSourceElement.key;


### PR DESCRIPTION
## Description

<!-- Please give a short description of the changes you propose. Please use prose and try not to be too technical, if possible. Make sure to mention people that you think should know about the PR. -->

The `PropertyGrid` component doesn't rerender on updated props (espacially while receiving a new feature) properly. 

This suggests to recalculate the `dataSource` and `columnDefs` accordingly and not on initial render only.

Please review @terrestris/devs.

## Related issues or pull requests

<!-- Please list issues or pull requests that the changes you propose are related to. It does not matter if they are still open and/or unmerged, any link is appreciated. -->

--

## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the
  [BSD-2-Clause](https://github.com/terrestris/react-geo/blob/main/LICENSE).
- [x] I have followed the [guidelines for contributing](https://github.com/terrestris/react-geo/blob/main/CONTRIBUTING.md).
- [x] The proposed change fits to the content of the [Code of Conduct](https://github.com/terrestris/react-geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally).
- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
