### PR TITLE
introduce client-side print component

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -20,7 +20,7 @@ module.exports = {
     '<rootDir>/dist/'
   ],
   transformIgnorePatterns: [
-    'node_modules/(?!(ol|antd|(rc-[a-z-]*)|@ant-design\/css-animation|(@ant-design\/icons)(-[a-z]+)*|@babel\/runtime)/)'
+    'node_modules/(?!(ol|antd|@camptocamp/inkmap|(rc-[a-z-]*)|@ant-design\/css-animation|(@ant-design\/icons)(-[a-z]+)*|@babel\/runtime)/)'
   ],
   setupFiles: [
     '<rootDir>/jest/__mocks__/matchMediaMock.js'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1992,1446 +1992,581 @@
         "rxjs": "^6.6.3"
       }
     },
-    "node_modules/@camptocamp/inkmap/node_modules/@terrestris/ol-util": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/@terrestris/ol-util/-/ol-util-4.1.3.tgz",
-      "integrity": "sha512-vTS7rXxOcvTpXQzRGR6DVldEYcbFjADQ9/ArSKeq9yCmmY9wb3dkeGKw+rN/dltu6oZbaswjsUsBQe060kiMOQ==",
+    "node_modules/@commitlint/cli": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-17.0.2.tgz",
+      "integrity": "sha512-Axe89Js0YzGGd4gxo3JLlF7yIdjOVpG1LbOorGc6PfYF+drBh14PvarSDLzyd2TNqdylUCq9wb9/A88ZjIdyhA==",
+      "dev": true,
       "dependencies": {
-        "@terrestris/base-util": "^1.0.0",
-        "@turf/turf": "^5.1.6",
-        "lodash": "^4.17.20",
-        "proj4": "^2.7.0",
-        "shpjs": "^3.6.3"
+        "@commitlint/format": "^17.0.0",
+        "@commitlint/lint": "^17.0.0",
+        "@commitlint/load": "^17.0.0",
+        "@commitlint/read": "^17.0.0",
+        "@commitlint/types": "^17.0.0",
+        "execa": "^5.0.0",
+        "lodash": "^4.17.19",
+        "resolve-from": "5.0.0",
+        "resolve-global": "1.0.0",
+        "yargs": "^17.0.0"
+      },
+      "bin": {
+        "commitlint": "cli.js"
       },
       "engines": {
-        "node": ">=10.0.0"
+        "node": ">=v14"
+      }
+    },
+    "node_modules/@commitlint/cli/node_modules/yargs": {
+      "version": "17.5.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.5.1.tgz",
+      "integrity": "sha512-t6YAJcxDkNX7NFYiVtKvWUz8l+PaKTLiL63mJYWR2GnHq2gjEWISzsLp9wg3aY36dY1j+gfIEL3pIF+XlJJfbA==",
+      "dev": true,
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.0.0"
       },
-      "peerDependencies": {
-        "ol": "~6.5"
-      }
-    },
-    "node_modules/@camptocamp/inkmap/node_modules/@turf/along": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/along/-/along-5.1.5.tgz",
-      "integrity": "sha512-N7BN1xvj6VWMe3UpjQDdVI0j0oY/EZ0bWgOgBXc4DlJ411uEsKCh6iBv0b2MSxQ3YUXEez3oc5FcgO9eVSs7iQ==",
-      "dependencies": {
-        "@turf/bearing": "^5.1.5",
-        "@turf/destination": "^5.1.5",
-        "@turf/distance": "^5.1.5",
-        "@turf/helpers": "^5.1.5"
-      }
-    },
-    "node_modules/@camptocamp/inkmap/node_modules/@turf/area": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/area/-/area-5.1.5.tgz",
-      "integrity": "sha512-lz16gqtvoz+j1jD9y3zj0Z5JnGNd3YfS0h+DQY1EcZymvi75Frm9i5YbEyth0RfxYZeOVufY7YIS3LXbJlI57g==",
-      "dependencies": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/meta": "^5.1.5"
-      }
-    },
-    "node_modules/@camptocamp/inkmap/node_modules/@turf/bbox": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/bbox/-/bbox-5.1.5.tgz",
-      "integrity": "sha512-sYQU4fqsOYYJoD8UndC1n2hy8hV/lGIAmMLKWuzwmPUWqWOuSKWUcoRWDi9mGB0GvQQe/ow2IxZr8UaVaGz3sQ==",
-      "dependencies": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/meta": "^5.1.5"
-      }
-    },
-    "node_modules/@camptocamp/inkmap/node_modules/@turf/bbox-clip": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/bbox-clip/-/bbox-clip-5.1.5.tgz",
-      "integrity": "sha512-KP64aoTvjcXxWHeM/Hs25vOQUBJgyJi7DlRVEoZofFJiR1kPnmDQrK7Xj+60lAk5cxuqzFnaPPxUk9Q+3v4p1Q==",
-      "dependencies": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "lineclip": "^1.1.5"
-      }
-    },
-    "node_modules/@camptocamp/inkmap/node_modules/@turf/bbox-polygon": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/bbox-polygon/-/bbox-polygon-5.1.5.tgz",
-      "integrity": "sha512-PKVPF5LABFWZJud8KzzfesLGm5ihiwLbVa54HJjYySe6yqU/cr5q/qcN9TWptynOFhNktG1dr0KXVG0I2FZmfw==",
-      "dependencies": {
-        "@turf/helpers": "^5.1.5"
-      }
-    },
-    "node_modules/@camptocamp/inkmap/node_modules/@turf/bearing": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/bearing/-/bearing-5.1.5.tgz",
-      "integrity": "sha512-PrvZuJjnXGseB8hUatIjsrK3tgD3wttyRnVYXTbSfXYJZzaOfHDMplgO4lxXQp7diraZhGhCdSlbMvRRXItbUQ==",
-      "dependencies": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
-      }
-    },
-    "node_modules/@camptocamp/inkmap/node_modules/@turf/bezier-spline": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/bezier-spline/-/bezier-spline-5.1.5.tgz",
-      "integrity": "sha512-Y9NoComaGgFFFe9TWWE/cEMg2+EnBfU1R3112ec2wlx21ygDmFGXs4boOS71WM4ySwm/dbS3wxnbVxs4j68sKw==",
-      "dependencies": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
-      }
-    },
-    "node_modules/@camptocamp/inkmap/node_modules/@turf/boolean-clockwise": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/boolean-clockwise/-/boolean-clockwise-5.1.5.tgz",
-      "integrity": "sha512-FqbmEEOJ4rU4/2t7FKx0HUWmjFEVqR+NJrFP7ymGSjja2SQ7Q91nnBihGuT+yuHHl6ElMjQ3ttsB/eTmyCycxA==",
-      "dependencies": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
-      }
-    },
-    "node_modules/@camptocamp/inkmap/node_modules/@turf/boolean-contains": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/boolean-contains/-/boolean-contains-5.1.5.tgz",
-      "integrity": "sha512-x2HeEieeE9vBQrTdCuj4swnAXlpKbj9ChxMdDTV479c0m2gVmfea83ocmkj3w+9cvAaS63L8WqFyNVSmkwqljQ==",
-      "dependencies": {
-        "@turf/bbox": "^5.1.5",
-        "@turf/boolean-point-in-polygon": "^5.1.5",
-        "@turf/boolean-point-on-line": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
-      }
-    },
-    "node_modules/@camptocamp/inkmap/node_modules/@turf/boolean-crosses": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/boolean-crosses/-/boolean-crosses-5.1.5.tgz",
-      "integrity": "sha512-odljvS7INr9k/8yXeyXQVry7GqEaChOmXawP0+SoTfGO3hgptiik59TLU/Yjn/SLFjE2Ul54Ga1jKFSL7vvH0Q==",
-      "dependencies": {
-        "@turf/boolean-point-in-polygon": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/line-intersect": "^5.1.5",
-        "@turf/polygon-to-line": "^5.1.5"
-      }
-    },
-    "node_modules/@camptocamp/inkmap/node_modules/@turf/boolean-disjoint": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/@turf/boolean-disjoint/-/boolean-disjoint-5.1.6.tgz",
-      "integrity": "sha512-KHvUS6SBNYHBCLIJEJrg04pF5Oy+Fqn8V5G9U+9pti5vI9tyX7Ln2g7RSB7iJ1Cxsz8QAi6OukhXjEF2/8ZpGg==",
-      "dependencies": {
-        "@turf/boolean-point-in-polygon": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/line-intersect": "^5.1.5",
-        "@turf/meta": "^5.1.5",
-        "@turf/polygon-to-line": "^5.1.5"
-      }
-    },
-    "node_modules/@camptocamp/inkmap/node_modules/@turf/boolean-equal": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/boolean-equal/-/boolean-equal-5.1.5.tgz",
-      "integrity": "sha512-QEMbhDPV+J8PlRkMlVg6m5oSLaYUpOx2VUhDDekQ73FlpnhFBKRIlidhvHtS6CYnEw8d+/zA3h8Z18B4W4mq9Q==",
-      "dependencies": {
-        "@turf/clean-coords": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "geojson-equality": "0.1.6"
-      }
-    },
-    "node_modules/@camptocamp/inkmap/node_modules/@turf/boolean-overlap": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/boolean-overlap/-/boolean-overlap-5.1.5.tgz",
-      "integrity": "sha512-lizojgU559KME0G705YAgWVa0B3/tsWNobMzOEWDx/1rABWTojCY4uxw2rFxpOsP++s8JJHrGWXRLh1PbdAvRQ==",
-      "dependencies": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/line-intersect": "^5.1.5",
-        "@turf/line-overlap": "^5.1.5",
-        "@turf/meta": "^5.1.5",
-        "geojson-equality": "0.1.6"
-      }
-    },
-    "node_modules/@camptocamp/inkmap/node_modules/@turf/boolean-parallel": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/boolean-parallel/-/boolean-parallel-5.1.5.tgz",
-      "integrity": "sha512-eeuGgDhnas3nJ22A/DD8aiH0kg9dSzbQChIMAqYRPGg3pWNK41aGAbeh5z0GO5N/EVFX1+ga5a0vsPmiRgQB5g==",
-      "dependencies": {
-        "@turf/clean-coords": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/line-segment": "^5.1.5",
-        "@turf/rhumb-bearing": "^5.1.5"
-      }
-    },
-    "node_modules/@camptocamp/inkmap/node_modules/@turf/boolean-parallel/node_modules/@turf/rhumb-bearing": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/rhumb-bearing/-/rhumb-bearing-5.1.5.tgz",
-      "integrity": "sha512-zXTl2khjwf7mx2D1uPo5vgpGgP4sM2VrKDbJNKyulPu4TO4ELt8x7FsKyCBlRTzzQf284t/xnNcZOfUbkkd70g==",
-      "dependencies": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
-      }
-    },
-    "node_modules/@camptocamp/inkmap/node_modules/@turf/boolean-point-in-polygon": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/boolean-point-in-polygon/-/boolean-point-in-polygon-5.1.5.tgz",
-      "integrity": "sha512-y+gbAhLmsAZH9uYhv+C68pu06mxsGIm3o7l0hzVkc/PXYdbkr+vKe7n7PfSN3xpVA3qoDLKLpCGOqeW8/ThaJA==",
-      "dependencies": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
-      }
-    },
-    "node_modules/@camptocamp/inkmap/node_modules/@turf/boolean-point-on-line": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/boolean-point-on-line/-/boolean-point-on-line-5.1.5.tgz",
-      "integrity": "sha512-Zf4d28mckV2tYfLWf2iqxQ8eeLZqi2HGimM26mptf1OCEIwc1wfkKgLRRJXMu94Crvd/pJxjRAjoYGcGliP6Vg==",
-      "dependencies": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
-      }
-    },
-    "node_modules/@camptocamp/inkmap/node_modules/@turf/boolean-within": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/boolean-within/-/boolean-within-5.1.5.tgz",
-      "integrity": "sha512-CNAtrvm4HiUwV/vhpGhvJzfhV9CN7VhPC5y4tTfQicK82fYY6ifPz0iaNpUOmshU6+TAot/fsVQVgDJ4t7HXcA==",
-      "dependencies": {
-        "@turf/bbox": "^5.1.5",
-        "@turf/boolean-point-in-polygon": "^5.1.5",
-        "@turf/boolean-point-on-line": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
-      }
-    },
-    "node_modules/@camptocamp/inkmap/node_modules/@turf/buffer": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/buffer/-/buffer-5.1.5.tgz",
-      "integrity": "sha512-U3LU0HF/JNFUNabpB5ArpNG6yPla7yR5XPrZvzZRH48vvbr/N0rkSRI0tJFRWTz7ntugVm9X0OD9Y382NTJRhA==",
-      "dependencies": {
-        "@turf/bbox": "^5.1.5",
-        "@turf/center": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/meta": "^5.1.5",
-        "@turf/projection": "^5.1.5",
-        "d3-geo": "1.7.1",
-        "turf-jsts": "*"
-      }
-    },
-    "node_modules/@camptocamp/inkmap/node_modules/@turf/buffer/node_modules/@turf/projection": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/projection/-/projection-5.1.5.tgz",
-      "integrity": "sha512-TWKJDFeEKQhI4Ce1+2PuOSDggn4cnMibqyUoCpIW+4KxUC1R88SE3/SYomqzwxMn00O09glHSycPkGD5JzHd8A==",
-      "dependencies": {
-        "@turf/clone": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/meta": "^5.1.5"
-      }
-    },
-    "node_modules/@camptocamp/inkmap/node_modules/@turf/center": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/center/-/center-5.1.5.tgz",
-      "integrity": "sha512-Dy1TvAv2oHKFddZcWqlVsanxurfcZV1Mmb1E+7H7GRKI+fXZTfRjwCdbiZCbO/tPwxt8jWQHWdLHn8E9lecc3A==",
-      "dependencies": {
-        "@turf/bbox": "^5.1.5",
-        "@turf/helpers": "^5.1.5"
-      }
-    },
-    "node_modules/@camptocamp/inkmap/node_modules/@turf/center-mean": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/center-mean/-/center-mean-5.1.5.tgz",
-      "integrity": "sha512-XdkBXzFUuyCqu5EPlBwgkv8FLA8pIGBnt7xy5cxxhxKOYLMrKqwMPPHPA84TjeQpNti0gH0CVuOk2r1f/Pp8iQ==",
-      "dependencies": {
-        "@turf/bbox": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/meta": "^5.1.5"
-      }
-    },
-    "node_modules/@camptocamp/inkmap/node_modules/@turf/center-median": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/center-median/-/center-median-5.1.5.tgz",
-      "integrity": "sha512-M+O6bSNsIDKZ4utk/YzSOIg6W0isjLVWud+TCLWyrDCWTSERlSJlhOaVE1y7cObhG8nYBHvmszqZyoAY6nufQw==",
-      "dependencies": {
-        "@turf/center-mean": "^5.1.5",
-        "@turf/centroid": "^5.1.5",
-        "@turf/distance": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/meta": "^5.1.5"
-      }
-    },
-    "node_modules/@camptocamp/inkmap/node_modules/@turf/center-of-mass": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/center-of-mass/-/center-of-mass-5.1.5.tgz",
-      "integrity": "sha512-UvI7q6GgW3afCVIDOyTRuLT54v9Xwv65Xudxh4FIT6w7HNU4KUBtTGnx0NuhODZcgvZgWVWVakhmIcHQTMjYYA==",
-      "dependencies": {
-        "@turf/centroid": "^5.1.5",
-        "@turf/convex": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/meta": "^5.1.5"
-      }
-    },
-    "node_modules/@camptocamp/inkmap/node_modules/@turf/centroid": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/centroid/-/centroid-5.1.5.tgz",
-      "integrity": "sha512-0m9ZAZJB4YXLDxF2fWGqlE/g9Y68cebeWaRNOMN+e6Bti1fz0JKQuaEqJV+J8xOmODPHSMbZZ1SqSDVRgVHP2Q==",
-      "dependencies": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/meta": "^5.1.5"
-      }
-    },
-    "node_modules/@camptocamp/inkmap/node_modules/@turf/circle": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/circle/-/circle-5.1.5.tgz",
-      "integrity": "sha512-CNaEtvp38Q+TSFJHdzdl5iYNjBFZRluRTFikIuEcennSeMJD60nP0dMubP58TR/QQn541eNDUyED90V4KuOjyQ==",
-      "dependencies": {
-        "@turf/destination": "^5.1.5",
-        "@turf/helpers": "^5.1.5"
-      }
-    },
-    "node_modules/@camptocamp/inkmap/node_modules/@turf/clean-coords": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/clean-coords/-/clean-coords-5.1.5.tgz",
-      "integrity": "sha512-xd/iSM0McVUxbu81KCKDqirCsYkKk3EAwpDjYI8vIQ+eKf/MLSdteRcm3PB7wo2y6JcYp4dMGv2cr9IP7V+dXQ==",
-      "dependencies": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
-      }
-    },
-    "node_modules/@camptocamp/inkmap/node_modules/@turf/clone": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/clone/-/clone-5.1.5.tgz",
-      "integrity": "sha512-//pITsQ8xUdcQ9pVb4JqXiSqG4dos5Q9N4sYFoWghX21tfOV2dhc5TGqYOhnHrQS7RiKQL1vQ48kIK34gQ5oRg==",
-      "dependencies": {
-        "@turf/helpers": "^5.1.5"
-      }
-    },
-    "node_modules/@camptocamp/inkmap/node_modules/@turf/clusters": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/clusters/-/clusters-5.1.5.tgz",
-      "integrity": "sha512-+rQe+g66xfbIXz58tveXQCDdE9hzqRJtDVSw5xth92TvCcL4J60ZKN8mHNUSn1ZZvpUHtVPe4dYcbtk5bW8fXQ==",
-      "dependencies": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/meta": "^5.1.5"
-      }
-    },
-    "node_modules/@camptocamp/inkmap/node_modules/@turf/clusters-dbscan": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/clusters-dbscan/-/clusters-dbscan-5.1.5.tgz",
-      "integrity": "sha512-X3qLLHJkwMuv+xdWQ08NtOc6BgeqCKKSAltyyAZ7iImE65f0C+sW024DfHSbTMsZVXBFst2Q6RQY8RVUf3QBeQ==",
-      "dependencies": {
-        "@turf/clone": "^5.1.5",
-        "@turf/distance": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/meta": "^5.1.5",
-        "density-clustering": "1.3.0"
-      }
-    },
-    "node_modules/@camptocamp/inkmap/node_modules/@turf/clusters-kmeans": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/clusters-kmeans/-/clusters-kmeans-5.1.5.tgz",
-      "integrity": "sha512-W6raiv9+fRgmJxCvKrpSacbLXzh7beZUk0A1pjF82Fv3CFTrXAJbgAyIbdlmgXezYSXhOT5NMUugnbkUy2oBZw==",
-      "dependencies": {
-        "@turf/clone": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/meta": "^5.1.5",
-        "skmeans": "0.9.7"
-      }
-    },
-    "node_modules/@camptocamp/inkmap/node_modules/@turf/collect": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/collect/-/collect-5.1.5.tgz",
-      "integrity": "sha512-voFWu6EGPcNuIbAp43yvGf2Ip4/q8TTeWhOSJ2yDEHgOfbAwrNUwUJCclEjcUVsnc7ypKNrFn3/8bmR9tI0NQg==",
-      "dependencies": {
-        "@turf/bbox": "^5.1.5",
-        "@turf/boolean-point-in-polygon": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "rbush": "^2.0.1"
-      }
-    },
-    "node_modules/@camptocamp/inkmap/node_modules/@turf/combine": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/combine/-/combine-5.1.5.tgz",
-      "integrity": "sha512-/RqmfCvduHquINVyNmzKOcZtZjfaEHMhghgmj8MYnzepN3ro+E2QXoaQGGrQ7nChAvGgWPAvN8EveVSc1MvzPg==",
-      "dependencies": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/meta": "^5.1.5"
-      }
-    },
-    "node_modules/@camptocamp/inkmap/node_modules/@turf/concave": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/concave/-/concave-5.1.5.tgz",
-      "integrity": "sha512-NvR5vmAunmgjEPjNzmvjLRvPcj7C6WuqCf+vu/aqyc4h2c1B/x399bDsSM64iFT+PYesFuoS1ZhJHWivXG8Y5g==",
-      "dependencies": {
-        "@turf/clone": "^5.1.5",
-        "@turf/distance": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/meta": "^5.1.5",
-        "@turf/tin": "^5.1.5",
-        "topojson-client": "3.x",
-        "topojson-server": "3.x"
-      }
-    },
-    "node_modules/@camptocamp/inkmap/node_modules/@turf/convex": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/convex/-/convex-5.1.5.tgz",
-      "integrity": "sha512-ZEk4kIAoYR/mjO3C8rMe2StgmwhdwmbxVvNxg3udeahe2m0ZzbfkRC4HiJAaBgfR4TLJUAEewynESReTPwASBQ==",
-      "dependencies": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/meta": "^5.1.5",
-        "concaveman": "*"
-      }
-    },
-    "node_modules/@camptocamp/inkmap/node_modules/@turf/destination": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/destination/-/destination-5.1.5.tgz",
-      "integrity": "sha512-EWwZnd4wxUO9d8UWzJt88jQlFf6W/6SE1930MMzzIR9o+RfqhrS/BL1eUDrg5I5drsymf6PZsK0j/V0q6jqkFQ==",
-      "dependencies": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
-      }
-    },
-    "node_modules/@camptocamp/inkmap/node_modules/@turf/difference": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/difference/-/difference-5.1.5.tgz",
-      "integrity": "sha512-hIjiUHS8WiDfnmADQrhh6QcXWc3zNtjIpPQ5g/2NZ3k1mjnOdmGBVObkSJG4WEUNqyj3PKlsZ8W9xnSu+lLF1Q==",
-      "dependencies": {
-        "@turf/area": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/meta": "^5.1.5",
-        "turf-jsts": "*"
-      }
-    },
-    "node_modules/@camptocamp/inkmap/node_modules/@turf/dissolve": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/dissolve/-/dissolve-5.1.5.tgz",
-      "integrity": "sha512-YcQgyp7pvhyZHCmbqqItVH6vHs43R9N0jzP/LnAG03oMiY4wves/BO1du6VDDbnJSXeRKf1afmY9tRGKYrm9ag==",
-      "dependencies": {
-        "@turf/boolean-overlap": "^5.1.5",
-        "@turf/clone": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/line-intersect": "^5.1.5",
-        "@turf/meta": "^5.1.5",
-        "@turf/union": "^5.1.5",
-        "geojson-rbush": "2.1.0",
-        "get-closest": "*"
-      }
-    },
-    "node_modules/@camptocamp/inkmap/node_modules/@turf/distance": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/distance/-/distance-5.1.5.tgz",
-      "integrity": "sha512-sYCAgYZ2MjNKMtx17EijHlK9qHwpA0MuuQWbR4P30LTCl52UlG/reBfV899wKyF3HuDL9ux78IbILwOfeQ4zgA==",
-      "dependencies": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
-      }
-    },
-    "node_modules/@camptocamp/inkmap/node_modules/@turf/ellipse": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/ellipse/-/ellipse-5.1.5.tgz",
-      "integrity": "sha512-oVTzEyDOi3d9isgB7Ah+YiOoUKB1eHMtMDXVl1oT+vC/T+6KR2aq+HjjbF11A0cjuh3VhjSWUZaS+2TYY0pu0w==",
-      "dependencies": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/rhumb-destination": "^5.1.5",
-        "@turf/transform-rotate": "^5.1.5"
-      }
-    },
-    "node_modules/@camptocamp/inkmap/node_modules/@turf/envelope": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/envelope/-/envelope-5.1.5.tgz",
-      "integrity": "sha512-Mxl5A2euAxq3RZVN65/MVyaO91kzGU8MJXfegPdep6SN4bONDadEp0olwW5qSRf2U3cJ8Jppl089X6AeifD3IA==",
-      "dependencies": {
-        "@turf/bbox": "^5.1.5",
-        "@turf/bbox-polygon": "^5.1.5",
-        "@turf/helpers": "^5.1.5"
-      }
-    },
-    "node_modules/@camptocamp/inkmap/node_modules/@turf/explode": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/explode/-/explode-5.1.5.tgz",
-      "integrity": "sha512-v/hC9DB9RKRW9/ZjnKoQelIp08JNa5wew0889465s//tfgY8+JEGkSGMag2L2NnVARWmzI/vlLgMK36qwkyDIA==",
-      "dependencies": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/meta": "^5.1.5"
-      }
-    },
-    "node_modules/@camptocamp/inkmap/node_modules/@turf/flatten": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/flatten/-/flatten-5.1.5.tgz",
-      "integrity": "sha512-aagHz5tjHmOtb8eMb5fd10+HJwdlhkhsPql1vRXQNnpv0Q9xL/4SsbvXZ6lPqkRAjiZuy087mvaz+ERml76/jg==",
-      "dependencies": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/meta": "^5.1.5"
-      }
-    },
-    "node_modules/@camptocamp/inkmap/node_modules/@turf/flip": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/flip/-/flip-5.1.5.tgz",
-      "integrity": "sha512-7+IYM3QQAkV4co3wjEmM726/OkXqUCCHWWyIqrI9hiK+LR628qkoqP1hk6rQ4vZJrAYuvSlK+FZnr24OtgY0cw==",
-      "dependencies": {
-        "@turf/clone": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/meta": "^5.1.5"
-      }
-    },
-    "node_modules/@camptocamp/inkmap/node_modules/@turf/great-circle": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/great-circle/-/great-circle-5.1.5.tgz",
-      "integrity": "sha512-k6FWwlt+YCQoD5VS1NybQjriNL7apYHO+tm2HbIFQ85blPUX4IyLppHIFevfD/k+K2bJqhFCze8JNVMBwdrzVw==",
-      "dependencies": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
-      }
-    },
-    "node_modules/@camptocamp/inkmap/node_modules/@turf/helpers": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-5.1.5.tgz",
-      "integrity": "sha512-/lF+JR+qNDHZ8bF9d+Cp58nxtZWJ3sqFe6n3u3Vpj+/0cqkjk4nXKYBSY0azm+GIYB5mWKxUXvuP/m0ZnKj1bw=="
-    },
-    "node_modules/@camptocamp/inkmap/node_modules/@turf/hex-grid": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/hex-grid/-/hex-grid-5.1.5.tgz",
-      "integrity": "sha512-rwDL+DlUyxDNL1aVHIKKCmrt1131ZULF3irExYIO/um6/SwRzsBw+522/RcxD/mg/Shtrpozb6bz8aJJ/3RXHA==",
-      "dependencies": {
-        "@turf/distance": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/intersect": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
-      }
-    },
-    "node_modules/@camptocamp/inkmap/node_modules/@turf/interpolate": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/interpolate/-/interpolate-5.1.5.tgz",
-      "integrity": "sha512-LfmvtIUWc3NVkqPkX6j3CAIjF7y1LAZqfDd+2Ii+0fN7XOOGMWcb1uiTTAb8zDQjhTsygcUYgaz6mMYDCWYKPg==",
-      "dependencies": {
-        "@turf/bbox": "^5.1.5",
-        "@turf/centroid": "^5.1.5",
-        "@turf/clone": "^5.1.5",
-        "@turf/distance": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/hex-grid": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/meta": "^5.1.5",
-        "@turf/point-grid": "^5.1.5",
-        "@turf/square-grid": "^5.1.5",
-        "@turf/triangle-grid": "^5.1.5"
-      }
-    },
-    "node_modules/@camptocamp/inkmap/node_modules/@turf/intersect": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/@turf/intersect/-/intersect-5.1.6.tgz",
-      "integrity": "sha512-KXyNv/GXdoGAOy03qZF53rgtXC2tNhF/4jLwTKiVRrBQH6kcEpipGStdJ+QkYIlarQPa8f7I9UlVAB19et4MfQ==",
-      "dependencies": {
-        "@turf/clean-coords": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/truncate": "^5.1.5",
-        "turf-jsts": "*"
-      }
-    },
-    "node_modules/@camptocamp/inkmap/node_modules/@turf/invariant": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-5.1.5.tgz",
-      "integrity": "sha512-4elbC8GVQ8XxrnWLWpFFXTK3qnzIYzIVtSkJrY9eefA8WNZzwcwT3WGFY3xte4BB48o5oEjihjoJharWRis78w==",
-      "dependencies": {
-        "@turf/helpers": "^5.1.5"
-      }
-    },
-    "node_modules/@camptocamp/inkmap/node_modules/@turf/isobands": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/isobands/-/isobands-5.1.5.tgz",
-      "integrity": "sha512-0n3NPfDYQyqjOch00I4hVCCqjKn9Sm+a8qlWOKbkuhmGa9dCDzsu2bZL0ahT+LjwlS4c8/owQXqe6KE2GWqT1Q==",
-      "dependencies": {
-        "@turf/area": "^5.1.5",
-        "@turf/bbox": "^5.1.5",
-        "@turf/boolean-point-in-polygon": "^5.1.5",
-        "@turf/explode": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/meta": "^5.1.5"
-      }
-    },
-    "node_modules/@camptocamp/inkmap/node_modules/@turf/isolines": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/isolines/-/isolines-5.1.5.tgz",
-      "integrity": "sha512-Ehn5pJmiq4hAn2+2jPB2rLt3iF8DDp8zciw9z2pAt5IGVRU/K+x3z4aYG5ra5vbFB/E4G3aHr/X4QPIb9LCJtA==",
-      "dependencies": {
-        "@turf/bbox": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/meta": "^5.1.5"
-      }
-    },
-    "node_modules/@camptocamp/inkmap/node_modules/@turf/kinks": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/kinks/-/kinks-5.1.5.tgz",
-      "integrity": "sha512-G38sC8/+MYqQpVocT3XahhV42cqEAVJAZwUND9YOfKJZfjUn7FKmWhPURs5py95me48UuI0C0jLLAMzBkUc2nQ==",
-      "dependencies": {
-        "@turf/helpers": "^5.1.5"
-      }
-    },
-    "node_modules/@camptocamp/inkmap/node_modules/@turf/length": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/length/-/length-5.1.5.tgz",
-      "integrity": "sha512-0ryx68h512wCoNfwyksLdabxEfwkGNTPg61/QiY+QfGFUOUNhHbP+QimViFpwF5hyX7qmroaSHVclLUqyLGRbg==",
-      "dependencies": {
-        "@turf/distance": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/meta": "^5.1.5"
-      }
-    },
-    "node_modules/@camptocamp/inkmap/node_modules/@turf/line-arc": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/line-arc/-/line-arc-5.1.5.tgz",
-      "integrity": "sha512-Kz5RX/qRIHVrGNqF3BRlD3ACuuCr0G5lpaVyPjNvN+vA7Q4bEDyWIYeqm3DdTn7X2MXitpTNgr2uvX4WoUy4yA==",
-      "dependencies": {
-        "@turf/circle": "^5.1.5",
-        "@turf/destination": "^5.1.5",
-        "@turf/helpers": "^5.1.5"
-      }
-    },
-    "node_modules/@camptocamp/inkmap/node_modules/@turf/line-chunk": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/line-chunk/-/line-chunk-5.1.5.tgz",
-      "integrity": "sha512-mKvTUMahnb3EsYUMI8tQmygsliQkgQ1FZAY915zoTrm+WV246loa+84+h7i5d8W2O8gGJWuY7jQTpM7toTeL5w==",
-      "dependencies": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/length": "^5.1.5",
-        "@turf/line-slice-along": "^5.1.5",
-        "@turf/meta": "^5.1.5"
-      }
-    },
-    "node_modules/@camptocamp/inkmap/node_modules/@turf/line-intersect": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/line-intersect/-/line-intersect-5.1.5.tgz",
-      "integrity": "sha512-9DajJbHhJauLI2qVMnqZ7SeFsinFroVICOSUheODk7j5teuwNABuZ2Z6WmKATzEsPkEJ1iVykqB+F9vGMVKB6g==",
-      "dependencies": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/line-segment": "^5.1.5",
-        "@turf/meta": "^5.1.5",
-        "geojson-rbush": "2.1.0"
-      }
-    },
-    "node_modules/@camptocamp/inkmap/node_modules/@turf/line-offset": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/line-offset/-/line-offset-5.1.5.tgz",
-      "integrity": "sha512-VccGDgFfBSiCTqrHdQgxD7Rs9lnJmDOJ5gqQRculKPsCNUyRFMYIZud7l2dTs83g66evfOwkZCrTxtSoBY3Jxg==",
-      "dependencies": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/meta": "^5.1.5"
-      }
-    },
-    "node_modules/@camptocamp/inkmap/node_modules/@turf/line-overlap": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/line-overlap/-/line-overlap-5.1.5.tgz",
-      "integrity": "sha512-hMz3XARXEbfGwLF9WXyErqQjzhZYMKvGQwlPGOoth+2o9Uga9mfWfevduJvozJAE1MKxtFttMjIXMzcShW3O8A==",
-      "dependencies": {
-        "@turf/boolean-point-on-line": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/line-segment": "^5.1.5",
-        "@turf/meta": "^5.1.5",
-        "@turf/nearest-point-on-line": "^5.1.5",
-        "geojson-rbush": "2.1.0"
-      }
-    },
-    "node_modules/@camptocamp/inkmap/node_modules/@turf/line-segment": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/line-segment/-/line-segment-5.1.5.tgz",
-      "integrity": "sha512-wIrRtWuLuLXhnSkqdVG1SDayTU0/CmZf+a+BBhEf0vFIsAedJnrY3a2cbCEvtfuk6ZsAbhOi7/kYiaR/F+rEzg==",
-      "dependencies": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/meta": "^5.1.5"
-      }
-    },
-    "node_modules/@camptocamp/inkmap/node_modules/@turf/line-slice": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/line-slice/-/line-slice-5.1.5.tgz",
-      "integrity": "sha512-Fo+CuD+fj6T702BofHO+rgiXUgzCk0iO2JqMPtttMtgzfKkVTUOQoauMNS1LNNaG/7n/TfKGh5gRCEDRNaNwYA==",
-      "dependencies": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/nearest-point-on-line": "^5.1.5"
-      }
-    },
-    "node_modules/@camptocamp/inkmap/node_modules/@turf/line-slice-along": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/line-slice-along/-/line-slice-along-5.1.5.tgz",
-      "integrity": "sha512-yKvSDtULztLtlPIMowm9l8pS6XLAEpCPmrARZA0sIWFX8XrcSzISBaXZbiMMzg3nxQJMXfGIgWDk10B7+J8Tqw==",
-      "dependencies": {
-        "@turf/bearing": "^5.1.5",
-        "@turf/destination": "^5.1.5",
-        "@turf/distance": "^5.1.5",
-        "@turf/helpers": "^5.1.5"
-      }
-    },
-    "node_modules/@camptocamp/inkmap/node_modules/@turf/line-split": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/line-split/-/line-split-5.1.5.tgz",
-      "integrity": "sha512-gtUUBwZL3hcSu5MpqHTl68hgAJBNHcr1APDj8E5o6iX5xFX+wvl4ohQXyMs5HOATCI8Iy83wLuggcY6maNw7LQ==",
-      "dependencies": {
-        "@turf/bbox": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/line-intersect": "^5.1.5",
-        "@turf/line-segment": "^5.1.5",
-        "@turf/meta": "^5.1.5",
-        "@turf/nearest-point-on-line": "^5.1.5",
-        "@turf/square": "^5.1.5",
-        "@turf/truncate": "^5.1.5",
-        "geojson-rbush": "2.1.0"
-      }
-    },
-    "node_modules/@camptocamp/inkmap/node_modules/@turf/line-to-polygon": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/line-to-polygon/-/line-to-polygon-5.1.5.tgz",
-      "integrity": "sha512-hGiDAPd6j986kZZLDgEAkVD7O6DmIqHQliBedspoKperPJOUJJzdzSnF6OAWSsxY+j8fWtQnIo5TTqdO/KfamA==",
-      "dependencies": {
-        "@turf/bbox": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
-      }
-    },
-    "node_modules/@camptocamp/inkmap/node_modules/@turf/mask": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/mask/-/mask-5.1.5.tgz",
-      "integrity": "sha512-2eOuxA3ammZAGsjlsy/H7IpeJxjl3hrgkcKM6kTKRJGft4QyKwCxqQP7RN5j0zIYvAurgs9JOLe/dpd5sE5HXQ==",
-      "dependencies": {
-        "@turf/bbox": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/meta": "^5.1.5",
-        "@turf/union": "^5.1.5",
-        "rbush": "^2.0.1"
-      }
-    },
-    "node_modules/@camptocamp/inkmap/node_modules/@turf/meta": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-5.1.6.tgz",
-      "integrity": "sha512-lv+6LCgoc3LVitQZ4TScN/8a/fcctq8bIoxBTMJVq4aU8xoHeY1851Dq8MCU37EzbH33utkx8/jENaQP+aeElg==",
-      "dependencies": {
-        "@turf/helpers": "^5.1.5"
-      }
-    },
-    "node_modules/@camptocamp/inkmap/node_modules/@turf/midpoint": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/midpoint/-/midpoint-5.1.5.tgz",
-      "integrity": "sha512-0pDQAKHyK/zxlvUx3XNxwvqftf4sV32QxnHfqSs4AXaODUGUbPhzAD7aXgDScBeUOVLwpAzFRQfitUvUMTGC6A==",
-      "dependencies": {
-        "@turf/bearing": "^5.1.5",
-        "@turf/destination": "^5.1.5",
-        "@turf/distance": "^5.1.5",
-        "@turf/helpers": "^5.1.5"
-      }
-    },
-    "node_modules/@camptocamp/inkmap/node_modules/@turf/nearest-point": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/nearest-point/-/nearest-point-5.1.5.tgz",
-      "integrity": "sha512-tZQXI7OE7keNKK4OvYOJ5gervCEuu2pJ6psu59QW9yhe2Di3Gl+HAdLvVa6RZ8s5Fndr3u0JWKsmxve3fCxc9g==",
-      "dependencies": {
-        "@turf/clone": "^5.1.5",
-        "@turf/distance": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/meta": "^5.1.5"
-      }
-    },
-    "node_modules/@camptocamp/inkmap/node_modules/@turf/nearest-point-on-line": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/nearest-point-on-line/-/nearest-point-on-line-5.1.5.tgz",
-      "integrity": "sha512-qT7BLTwToo8cq0oNoz921oLlRPJamyRg/rZgll+kNBadyDPmJI4W66riHcpM9RQcAJ6TPvDveIIBeGJH7iG88w==",
-      "dependencies": {
-        "@turf/bearing": "^5.1.5",
-        "@turf/destination": "^5.1.5",
-        "@turf/distance": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/line-intersect": "^5.1.5",
-        "@turf/meta": "^5.1.5"
-      }
-    },
-    "node_modules/@camptocamp/inkmap/node_modules/@turf/nearest-point-to-line": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/@turf/nearest-point-to-line/-/nearest-point-to-line-5.1.6.tgz",
-      "integrity": "sha512-ZSvDIEiHhifn/vNwLXZI/E8xmEz5yBPqfUR7BVHRZrB1cP7jLhKZvkbidjG//uW8Fr1Ulc+PFOXczLspIcx/lw==",
-      "dependencies": {
-        "@turf/helpers": "6.x",
-        "@turf/invariant": "6.x",
-        "@turf/meta": "6.x",
-        "@turf/point-to-line-distance": "^5.1.5",
-        "object-assign": "*"
-      }
-    },
-    "node_modules/@camptocamp/inkmap/node_modules/@turf/nearest-point-to-line/node_modules/@turf/helpers": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.5.0.tgz",
-      "integrity": "sha512-VbI1dV5bLFzohYYdgqwikdMVpe7pJ9X3E+dlr425wa2/sMJqYDhTO++ec38/pcPvPE6oD9WEEeU3Xu3gza+VPw==",
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/@camptocamp/inkmap/node_modules/@turf/nearest-point-to-line/node_modules/@turf/invariant": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-6.5.0.tgz",
-      "integrity": "sha512-Wv8PRNCtPD31UVbdJE/KVAWKe7l6US+lJItRR/HOEW3eh+U/JwRCSUl/KZ7bmjM/C+zLNoreM2TU6OoLACs4eg==",
-      "dependencies": {
-        "@turf/helpers": "^6.5.0"
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@commitlint/cli/node_modules/yargs-parser": {
+      "version": "21.0.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.1.tgz",
+      "integrity": "sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@commitlint/config-conventional": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-17.0.2.tgz",
+      "integrity": "sha512-MfP0I/JbxKkzo+HXWB7B3WstGS4BiniotU3d3xQ9gK8cR0DbeZ4MuyGCWF65YDyrcDTS3WlrJ3ndSPA1pqhoPw==",
+      "dev": true,
+      "dependencies": {
+        "conventional-changelog-conventionalcommits": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=v14"
+      }
+    },
+    "node_modules/@commitlint/config-validator": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/config-validator/-/config-validator-17.0.0.tgz",
+      "integrity": "sha512-78IQjoZWR4kDHp/U5y17euEWzswJpPkA9TDL5F6oZZZaLIEreWzrDZD5PWtM8MsSRl/K2LDU/UrzYju2bKLMpA==",
+      "dev": true,
+      "dependencies": {
+        "@commitlint/types": "^17.0.0",
+        "ajv": "^6.12.6"
+      },
+      "engines": {
+        "node": ">=v14"
+      }
+    },
+    "node_modules/@commitlint/ensure": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-17.0.0.tgz",
+      "integrity": "sha512-M2hkJnNXvEni59S0QPOnqCKIK52G1XyXBGw51mvh7OXDudCmZ9tZiIPpU882p475Mhx48Ien1MbWjCP1zlyC0A==",
+      "dev": true,
+      "dependencies": {
+        "@commitlint/types": "^17.0.0",
+        "lodash": "^4.17.19"
+      },
+      "engines": {
+        "node": ">=v14"
+      }
+    },
+    "node_modules/@commitlint/execute-rule": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/execute-rule/-/execute-rule-17.0.0.tgz",
+      "integrity": "sha512-nVjL/w/zuqjCqSJm8UfpNaw66V9WzuJtQvEnCrK4jDw6qKTmZB+1JQ8m6BQVZbNBcwfYdDNKnhIhqI0Rk7lgpQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=v14"
+      }
+    },
+    "node_modules/@commitlint/format": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/format/-/format-17.0.0.tgz",
+      "integrity": "sha512-MZzJv7rBp/r6ZQJDEodoZvdRM0vXu1PfQvMTNWFb8jFraxnISMTnPBWMMjr2G/puoMashwaNM//fl7j8gGV5lA==",
+      "dev": true,
+      "dependencies": {
+        "@commitlint/types": "^17.0.0",
+        "chalk": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=v14"
+      }
+    },
+    "node_modules/@commitlint/format/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       },
       "funding": {
-        "url": "https://opencollective.com/turf"
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/@camptocamp/inkmap/node_modules/@turf/nearest-point-to-line/node_modules/@turf/meta": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-6.5.0.tgz",
-      "integrity": "sha512-RrArvtsV0vdsCBegoBtOalgdSOfkBrTJ07VkpiCnq/491W67hnMWmDu7e6Ztw0C3WldRYTXkg3SumfdzZxLBHA==",
+    "node_modules/@commitlint/format/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
       "dependencies": {
-        "@turf/helpers": "^6.5.0"
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
       },
       "funding": {
-        "url": "https://opencollective.com/turf"
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/@camptocamp/inkmap/node_modules/@turf/planepoint": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/planepoint/-/planepoint-5.1.5.tgz",
-      "integrity": "sha512-+Tp+SQ0Db2tqwLbxfXJPysT9IxcOHSMIin2dJb/j3Qn5+g0LRus6rczZl6dWNAIjqBPMawj/V/dZhMu6Q9O9wA==",
+    "node_modules/@commitlint/format/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
       "dependencies": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
       }
     },
-    "node_modules/@camptocamp/inkmap/node_modules/@turf/point-grid": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/point-grid/-/point-grid-5.1.5.tgz",
-      "integrity": "sha512-4ibozguP9YJ297Q7i9e8/ypGSycvt1re2jrPXTxeuZ4/L/NE5B1nOBLG+tw121nMjD+S+v2RWOtqD+FZ3Ga+ew==",
-      "dependencies": {
-        "@turf/boolean-within": "^5.1.5",
-        "@turf/distance": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
+    "node_modules/@commitlint/format/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/@commitlint/format/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
-    "node_modules/@camptocamp/inkmap/node_modules/@turf/point-on-feature": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/point-on-feature/-/point-on-feature-5.1.5.tgz",
-      "integrity": "sha512-NTcpe5xZjybRh0aTL+7td1cm0s49GGbAt5u8Cdec4W9ix2PsehRcLUbmQIQsODN2kiVyUSpnhECIpsyN5MjX7A==",
+    "node_modules/@commitlint/format/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
       "dependencies": {
-        "@turf/boolean-point-in-polygon": "^5.1.5",
-        "@turf/center": "^5.1.5",
-        "@turf/explode": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/nearest-point": "^5.1.5"
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
-    "node_modules/@camptocamp/inkmap/node_modules/@turf/point-to-line-distance": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/@turf/point-to-line-distance/-/point-to-line-distance-5.1.6.tgz",
-      "integrity": "sha512-PE3hiTeeDEi4ZLPtI8XAzFYW9nHo1EVsZGm/4ZVV8jo39d3X1oLVHxY3e1PkCmWwRapXy4QLqvnTQ7nU4wspNw==",
+    "node_modules/@commitlint/is-ignored": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-17.0.0.tgz",
+      "integrity": "sha512-UmacD0XM/wWykgdXn5CEWVS4XGuqzU+ZGvM2hwv85+SXGnIOaG88XHrt81u37ZeVt1riWW+YdOxcJW6+nd5v5w==",
+      "dev": true,
       "dependencies": {
-        "@turf/bearing": "6.x",
-        "@turf/distance": "6.x",
-        "@turf/helpers": "6.x",
-        "@turf/invariant": "6.x",
-        "@turf/meta": "6.x",
-        "@turf/projection": "6.x",
-        "@turf/rhumb-bearing": "6.x",
-        "@turf/rhumb-distance": "6.x"
+        "@commitlint/types": "^17.0.0",
+        "semver": "7.3.7"
+      },
+      "engines": {
+        "node": ">=v14"
       }
     },
-    "node_modules/@camptocamp/inkmap/node_modules/@turf/point-to-line-distance/node_modules/@turf/bearing": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@turf/bearing/-/bearing-6.5.0.tgz",
-      "integrity": "sha512-dxINYhIEMzgDOztyMZc20I7ssYVNEpSv04VbMo5YPQsqa80KO3TFvbuCahMsCAW5z8Tncc8dwBlEFrmRjJG33A==",
+    "node_modules/@commitlint/is-ignored/node_modules/semver": {
+      "version": "7.3.7",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "dev": true,
       "dependencies": {
-        "@turf/helpers": "^6.5.0",
-        "@turf/invariant": "^6.5.0"
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@commitlint/lint": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-17.0.0.tgz",
+      "integrity": "sha512-5FL7VLvGJQby24q0pd4UdM8FNFcL+ER1T/UBf8A9KRL5+QXV1Rkl6Zhcl7+SGpGlVo6Yo0pm6aLW716LVKWLGg==",
+      "dev": true,
+      "dependencies": {
+        "@commitlint/is-ignored": "^17.0.0",
+        "@commitlint/parse": "^17.0.0",
+        "@commitlint/rules": "^17.0.0",
+        "@commitlint/types": "^17.0.0"
+      },
+      "engines": {
+        "node": ">=v14"
+      }
+    },
+    "node_modules/@commitlint/load": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-17.0.0.tgz",
+      "integrity": "sha512-XaiHF4yWQOPAI0O6wXvk+NYLtJn/Xb7jgZEeKd4C1ZWd7vR7u8z5h0PkWxSr0uLZGQsElGxv3fiZ32C5+q6M8w==",
+      "dev": true,
+      "dependencies": {
+        "@commitlint/config-validator": "^17.0.0",
+        "@commitlint/execute-rule": "^17.0.0",
+        "@commitlint/resolve-extends": "^17.0.0",
+        "@commitlint/types": "^17.0.0",
+        "@types/node": ">=12",
+        "chalk": "^4.1.0",
+        "cosmiconfig": "^7.0.0",
+        "cosmiconfig-typescript-loader": "^2.0.0",
+        "lodash": "^4.17.19",
+        "resolve-from": "^5.0.0",
+        "typescript": "^4.6.4"
+      },
+      "engines": {
+        "node": ">=v14"
+      }
+    },
+    "node_modules/@commitlint/load/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       },
       "funding": {
-        "url": "https://opencollective.com/turf"
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/@camptocamp/inkmap/node_modules/@turf/point-to-line-distance/node_modules/@turf/distance": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@turf/distance/-/distance-6.5.0.tgz",
-      "integrity": "sha512-xzykSLfoURec5qvQJcfifw/1mJa+5UwByZZ5TZ8iaqjGYN0vomhV9aiSLeYdUGtYRESZ+DYC/OzY+4RclZYgMg==",
+    "node_modules/@commitlint/load/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
       "dependencies": {
-        "@turf/helpers": "^6.5.0",
-        "@turf/invariant": "^6.5.0"
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
       },
       "funding": {
-        "url": "https://opencollective.com/turf"
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/@camptocamp/inkmap/node_modules/@turf/point-to-line-distance/node_modules/@turf/helpers": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.5.0.tgz",
-      "integrity": "sha512-VbI1dV5bLFzohYYdgqwikdMVpe7pJ9X3E+dlr425wa2/sMJqYDhTO++ec38/pcPvPE6oD9WEEeU3Xu3gza+VPw==",
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/@camptocamp/inkmap/node_modules/@turf/point-to-line-distance/node_modules/@turf/invariant": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-6.5.0.tgz",
-      "integrity": "sha512-Wv8PRNCtPD31UVbdJE/KVAWKe7l6US+lJItRR/HOEW3eh+U/JwRCSUl/KZ7bmjM/C+zLNoreM2TU6OoLACs4eg==",
+    "node_modules/@commitlint/load/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
       "dependencies": {
-        "@turf/helpers": "^6.5.0"
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@commitlint/load/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/@commitlint/load/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@commitlint/load/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@commitlint/message": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/message/-/message-17.0.0.tgz",
+      "integrity": "sha512-LpcwYtN+lBlfZijHUdVr8aNFTVpHjuHI52BnfoV01TF7iSLnia0jttzpLkrLmI8HNQz6Vhr9UrxDWtKZiMGsBw==",
+      "dev": true,
+      "engines": {
+        "node": ">=v14"
+      }
+    },
+    "node_modules/@commitlint/parse": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-17.0.0.tgz",
+      "integrity": "sha512-cKcpfTIQYDG1ywTIr5AG0RAiLBr1gudqEsmAGCTtj8ffDChbBRxm6xXs2nv7GvmJN7msOt7vOKleLvcMmRa1+A==",
+      "dev": true,
+      "dependencies": {
+        "@commitlint/types": "^17.0.0",
+        "conventional-changelog-angular": "^5.0.11",
+        "conventional-commits-parser": "^3.2.2"
+      },
+      "engines": {
+        "node": ">=v14"
+      }
+    },
+    "node_modules/@commitlint/read": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/read/-/read-17.0.0.tgz",
+      "integrity": "sha512-zkuOdZayKX3J6F6mPnVMzohK3OBrsEdOByIqp4zQjA9VLw1hMsDEFQ18rKgUc2adkZar+4S01QrFreDCfZgbxA==",
+      "dev": true,
+      "dependencies": {
+        "@commitlint/top-level": "^17.0.0",
+        "@commitlint/types": "^17.0.0",
+        "fs-extra": "^10.0.0",
+        "git-raw-commits": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=v14"
+      }
+    },
+    "node_modules/@commitlint/read/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@commitlint/resolve-extends": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-17.0.0.tgz",
+      "integrity": "sha512-wi60WiJmwaQ7lzMXK8Vbc18Hq9tE2j/6iv2AFfPUGV7fvfY6Sf1iNKuUHirSqR0fquUyufIXe4y/K9A6LVIIvw==",
+      "dev": true,
+      "dependencies": {
+        "@commitlint/config-validator": "^17.0.0",
+        "@commitlint/types": "^17.0.0",
+        "import-fresh": "^3.0.0",
+        "lodash": "^4.17.19",
+        "resolve-from": "^5.0.0",
+        "resolve-global": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=v14"
+      }
+    },
+    "node_modules/@commitlint/rules": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-17.0.0.tgz",
+      "integrity": "sha512-45nIy3dERKXWpnwX9HeBzK5SepHwlDxdGBfmedXhL30fmFCkJOdxHyOJsh0+B0RaVsLGT01NELpfzJUmtpDwdQ==",
+      "dev": true,
+      "dependencies": {
+        "@commitlint/ensure": "^17.0.0",
+        "@commitlint/message": "^17.0.0",
+        "@commitlint/to-lines": "^17.0.0",
+        "@commitlint/types": "^17.0.0",
+        "execa": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=v14"
+      }
+    },
+    "node_modules/@commitlint/to-lines": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/to-lines/-/to-lines-17.0.0.tgz",
+      "integrity": "sha512-nEi4YEz04Rf2upFbpnEorG8iymyH7o9jYIVFBG1QdzebbIFET3ir+8kQvCZuBE5pKCtViE4XBUsRZz139uFrRQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=v14"
+      }
+    },
+    "node_modules/@commitlint/top-level": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/top-level/-/top-level-17.0.0.tgz",
+      "integrity": "sha512-dZrEP1PBJvodNWYPOYiLWf6XZergdksKQaT6i1KSROLdjf5Ai0brLOv5/P+CPxBeoj3vBxK4Ax8H1Pg9t7sHIQ==",
+      "dev": true,
+      "dependencies": {
+        "find-up": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=v14"
+      }
+    },
+    "node_modules/@commitlint/top-level/node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
       },
       "funding": {
-        "url": "https://opencollective.com/turf"
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@camptocamp/inkmap/node_modules/@turf/point-to-line-distance/node_modules/@turf/meta": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-6.5.0.tgz",
-      "integrity": "sha512-RrArvtsV0vdsCBegoBtOalgdSOfkBrTJ07VkpiCnq/491W67hnMWmDu7e6Ztw0C3WldRYTXkg3SumfdzZxLBHA==",
+    "node_modules/@commitlint/top-level/node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
       "dependencies": {
-        "@turf/helpers": "^6.5.0"
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
       },
       "funding": {
-        "url": "https://opencollective.com/turf"
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@camptocamp/inkmap/node_modules/@turf/points-within-polygon": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/points-within-polygon/-/points-within-polygon-5.1.5.tgz",
-      "integrity": "sha512-nexe2AHVOY8wEBvs+CYSOp10NyOCkyZ1gkhIfsx0mzU8LPYBxD9ctjlKveheKh4AAldLcFupd/gSCBTKF1JS7A==",
+    "node_modules/@commitlint/top-level/node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
       "dependencies": {
-        "@turf/boolean-point-in-polygon": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/meta": "^5.1.5"
-      }
-    },
-    "node_modules/@camptocamp/inkmap/node_modules/@turf/polygon-tangents": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/polygon-tangents/-/polygon-tangents-5.1.5.tgz",
-      "integrity": "sha512-uoZfKvFhl6rf0+CDWucru9fZ4mJB5Nsg37TS/7emrzjoVxXyOdxc/s1HFCjcKflMue7MjU/gT6AitJyrvdztDg==",
-      "dependencies": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
-      }
-    },
-    "node_modules/@camptocamp/inkmap/node_modules/@turf/polygon-to-line": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/polygon-to-line/-/polygon-to-line-5.1.5.tgz",
-      "integrity": "sha512-kVo0owPqyccy5+qZGvaxGvMsYkgueKE2OOgX2UV/HyrXF3uI3TomK1txjApqeFsLvwuSANxesvVbYLrYiIwvGw==",
-      "dependencies": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
-      }
-    },
-    "node_modules/@camptocamp/inkmap/node_modules/@turf/polygonize": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/polygonize/-/polygonize-5.1.5.tgz",
-      "integrity": "sha512-qzhtuzoOhldqZHm+ZPsWAs9nDpnkcDfsr+I0twmBF+wjAmo0HKiy9++sRQ4kEePpdwbMpF07D/NdZqYdmOJkGQ==",
-      "dependencies": {
-        "@turf/boolean-point-in-polygon": "^5.1.5",
-        "@turf/envelope": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/meta": "^5.1.5"
-      }
-    },
-    "node_modules/@camptocamp/inkmap/node_modules/@turf/random": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/random/-/random-5.1.5.tgz",
-      "integrity": "sha512-oitpBwEb6YXqoUkIAOVMK+vrTPxUi2rqITmtTa/FBHr6J8TDwMWq6bufE3Gmgjxsss50O2ITJunOksxrouWGDQ==",
-      "dependencies": {
-        "@turf/helpers": "^5.1.5"
-      }
-    },
-    "node_modules/@camptocamp/inkmap/node_modules/@turf/rewind": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/rewind/-/rewind-5.1.5.tgz",
-      "integrity": "sha512-Gdem7JXNu+G4hMllQHXRFRihJl3+pNl7qY+l4qhQFxq+hiU1cQoVFnyoleIqWKIrdK/i2YubaSwc3SCM7N5mMw==",
-      "dependencies": {
-        "@turf/boolean-clockwise": "^5.1.5",
-        "@turf/clone": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/meta": "^5.1.5"
-      }
-    },
-    "node_modules/@camptocamp/inkmap/node_modules/@turf/rhumb-destination": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/rhumb-destination/-/rhumb-destination-5.1.5.tgz",
-      "integrity": "sha512-FdDUCSRfRAfsRmUaWjc76Wk32QYFJ6ckmSt6Ls6nEczO6eg/RgH1atF8CIYwR5ifl0Sk1rQzKiOSbpCyvVwQtw==",
-      "dependencies": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
-      }
-    },
-    "node_modules/@camptocamp/inkmap/node_modules/@turf/sample": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/sample/-/sample-5.1.5.tgz",
-      "integrity": "sha512-EJE8yx+5x7rXejTzwBdOKpvT4tOCS0jwYJfycyTVDuLUSh2rETeYdjy7EeJbofnxm9CRPXqWQMPWIBKWxNTjow==",
-      "dependencies": {
-        "@turf/helpers": "^5.1.5"
-      }
-    },
-    "node_modules/@camptocamp/inkmap/node_modules/@turf/sector": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/sector/-/sector-5.1.5.tgz",
-      "integrity": "sha512-dnWVifL3xWTqPPs8mfbbV9muDimNJtxRk4ogrkOLEDQ9ZZ1ALQMtQdYrg7kI3iC+L+LscV37tl+E8bayWyX8YA==",
-      "dependencies": {
-        "@turf/circle": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/line-arc": "^5.1.5",
-        "@turf/meta": "^5.1.5"
-      }
-    },
-    "node_modules/@camptocamp/inkmap/node_modules/@turf/shortest-path": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/shortest-path/-/shortest-path-5.1.5.tgz",
-      "integrity": "sha512-ZGC8kSBj02GKWiI56Z5FNdrZ+fS0xyeOUNrPJWzudAlrv9wKGaRuWoIVRLGBu0j0OuO1HCwggic2c6WV/AhP0A==",
-      "dependencies": {
-        "@turf/bbox": "^5.1.5",
-        "@turf/bbox-polygon": "^5.1.5",
-        "@turf/boolean-point-in-polygon": "^5.1.5",
-        "@turf/clean-coords": "^5.1.5",
-        "@turf/distance": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/meta": "^5.1.5",
-        "@turf/transform-scale": "^5.1.5"
-      }
-    },
-    "node_modules/@camptocamp/inkmap/node_modules/@turf/simplify": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/simplify/-/simplify-5.1.5.tgz",
-      "integrity": "sha512-IuBXEYdGSxbDOK3v949ajaPvs6NhjhTCTbKA6mSGuVbwGS7gzAuRiPSG4K/MvCVuQy3PKpkPcUGD+Uvt2Ov2PQ==",
-      "dependencies": {
-        "@turf/clean-coords": "^5.1.5",
-        "@turf/clone": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/meta": "^5.1.5"
-      }
-    },
-    "node_modules/@camptocamp/inkmap/node_modules/@turf/square": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/square/-/square-5.1.5.tgz",
-      "integrity": "sha512-GgP2le9ksoW6vsVef5wFkjmWQiLPTJvcjGXqmoGWT4oMwDpvTJVQ91RBLs8qQbI4KACCQevz94N69klk3ah30Q==",
-      "dependencies": {
-        "@turf/distance": "^5.1.5",
-        "@turf/helpers": "^5.1.5"
-      }
-    },
-    "node_modules/@camptocamp/inkmap/node_modules/@turf/square-grid": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/square-grid/-/square-grid-5.1.5.tgz",
-      "integrity": "sha512-/pusEL4FmOwNWLcZfIXUyqUe0fOdkfaLO4wLhDlg/ZL1jWr/wZjhVlMU0tQ27kVN6dJTvlzNc9e0JWNw6yt2eQ==",
-      "dependencies": {
-        "@turf/boolean-contains": "^5.1.5",
-        "@turf/boolean-overlap": "^5.1.5",
-        "@turf/distance": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/intersect": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
-      }
-    },
-    "node_modules/@camptocamp/inkmap/node_modules/@turf/standard-deviational-ellipse": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/standard-deviational-ellipse/-/standard-deviational-ellipse-5.1.5.tgz",
-      "integrity": "sha512-GOaxGKeeJAXV1H3Zz2fjQ5XeSbMKz1OkFRlTDBUipiAawe/9qTCF55L87I2ZPnO80B5BaaIT+AN2n0lMcAklzA==",
-      "dependencies": {
-        "@turf/center-mean": "^5.1.5",
-        "@turf/ellipse": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/meta": "^5.1.5",
-        "@turf/points-within-polygon": "^5.1.5"
-      }
-    },
-    "node_modules/@camptocamp/inkmap/node_modules/@turf/tag": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/tag/-/tag-5.1.5.tgz",
-      "integrity": "sha512-XI3QFpva6tEsRnzFe1tJGdAAWlzjnXZPfJ9EKShTxEW8ZgPzm92b2odjiSAt2KuQusK82ltNfdw5Frlna5xGYQ==",
-      "dependencies": {
-        "@turf/boolean-point-in-polygon": "^5.1.5",
-        "@turf/clone": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/meta": "^5.1.5"
-      }
-    },
-    "node_modules/@camptocamp/inkmap/node_modules/@turf/tesselate": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/tesselate/-/tesselate-5.1.5.tgz",
-      "integrity": "sha512-Rs/jAij26bcU4OzvFXkWDase1G3kSwyuuKZPFU0t7OmJu7eQJOR12WOZLGcVxd5oBlklo4xPE4EBQUqpQUsQgg==",
-      "dependencies": {
-        "@turf/helpers": "^5.1.5",
-        "earcut": "^2.0.0"
-      }
-    },
-    "node_modules/@camptocamp/inkmap/node_modules/@turf/tin": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/tin/-/tin-5.1.5.tgz",
-      "integrity": "sha512-lDyCTYKoThBIKmkBxBMupqEpFbvTDAYuZIs8qrWnmux2vntSb8OFGi7ZbGPC6apS2hdVwZZae3YB88Tp+Fg+xw==",
-      "dependencies": {
-        "@turf/helpers": "^5.1.5"
-      }
-    },
-    "node_modules/@camptocamp/inkmap/node_modules/@turf/transform-rotate": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/transform-rotate/-/transform-rotate-5.1.5.tgz",
-      "integrity": "sha512-3QKckeHKPXu5O5vEuT+nkszGDI6aknDD06ePb00+6H2oA7MZj7nj+fVQIJLs41MRb76IyKr4n5NvuKZU6idESA==",
-      "dependencies": {
-        "@turf/centroid": "^5.1.5",
-        "@turf/clone": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/meta": "^5.1.5",
-        "@turf/rhumb-bearing": "^5.1.5",
-        "@turf/rhumb-destination": "^5.1.5",
-        "@turf/rhumb-distance": "^5.1.5"
-      }
-    },
-    "node_modules/@camptocamp/inkmap/node_modules/@turf/transform-rotate/node_modules/@turf/rhumb-bearing": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/rhumb-bearing/-/rhumb-bearing-5.1.5.tgz",
-      "integrity": "sha512-zXTl2khjwf7mx2D1uPo5vgpGgP4sM2VrKDbJNKyulPu4TO4ELt8x7FsKyCBlRTzzQf284t/xnNcZOfUbkkd70g==",
-      "dependencies": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
-      }
-    },
-    "node_modules/@camptocamp/inkmap/node_modules/@turf/transform-rotate/node_modules/@turf/rhumb-distance": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/rhumb-distance/-/rhumb-distance-5.1.5.tgz",
-      "integrity": "sha512-AGA/ky5/BJJZtzQqafy2GvJfcUXSzCCrPFp8sDRPSKBoUN4gMBHN15ijDWYYLFoWFFj0urcauVx7chQlHZ/Qfw==",
-      "dependencies": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
-      }
-    },
-    "node_modules/@camptocamp/inkmap/node_modules/@turf/transform-scale": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/transform-scale/-/transform-scale-5.1.5.tgz",
-      "integrity": "sha512-t1fCZX29ONA7DJiqCKA4YZy0+hCzhppWNOZhglBUv9vKHsWCFYZDUKfFInciaypUInsZyvm8eKxxixBVPdPGsw==",
-      "dependencies": {
-        "@turf/bbox": "^5.1.5",
-        "@turf/center": "^5.1.5",
-        "@turf/centroid": "^5.1.5",
-        "@turf/clone": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/meta": "^5.1.5",
-        "@turf/rhumb-bearing": "^5.1.5",
-        "@turf/rhumb-destination": "^5.1.5",
-        "@turf/rhumb-distance": "^5.1.5"
-      }
-    },
-    "node_modules/@camptocamp/inkmap/node_modules/@turf/transform-scale/node_modules/@turf/rhumb-bearing": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/rhumb-bearing/-/rhumb-bearing-5.1.5.tgz",
-      "integrity": "sha512-zXTl2khjwf7mx2D1uPo5vgpGgP4sM2VrKDbJNKyulPu4TO4ELt8x7FsKyCBlRTzzQf284t/xnNcZOfUbkkd70g==",
-      "dependencies": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
-      }
-    },
-    "node_modules/@camptocamp/inkmap/node_modules/@turf/transform-scale/node_modules/@turf/rhumb-distance": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/rhumb-distance/-/rhumb-distance-5.1.5.tgz",
-      "integrity": "sha512-AGA/ky5/BJJZtzQqafy2GvJfcUXSzCCrPFp8sDRPSKBoUN4gMBHN15ijDWYYLFoWFFj0urcauVx7chQlHZ/Qfw==",
-      "dependencies": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
-      }
-    },
-    "node_modules/@camptocamp/inkmap/node_modules/@turf/transform-translate": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/transform-translate/-/transform-translate-5.1.5.tgz",
-      "integrity": "sha512-GdLFp7I7198oRQt311B8EjiqHupndeMSQ3Zclzki5L/niUrb1ptOIpo+mxSidSy03m+1Q5ylWlENroI1WBcQ3Q==",
-      "dependencies": {
-        "@turf/clone": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/meta": "^5.1.5",
-        "@turf/rhumb-destination": "^5.1.5"
-      }
-    },
-    "node_modules/@camptocamp/inkmap/node_modules/@turf/triangle-grid": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/triangle-grid/-/triangle-grid-5.1.5.tgz",
-      "integrity": "sha512-jmCRcynI80xsVqd+0rv0YxP6mvZn4BAaJv8dwthg2T3WfHB9OD+rNUMohMuUY8HmI0zRT3s/Ypdy2Cdri9u/tw==",
-      "dependencies": {
-        "@turf/distance": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/intersect": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
-      }
-    },
-    "node_modules/@camptocamp/inkmap/node_modules/@turf/truncate": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/truncate/-/truncate-5.1.5.tgz",
-      "integrity": "sha512-WjWGsRE6o1vUqULGb/O7O1eK6B4Eu6R/RBZWnF0rH0Os6WVel6tHktkeJdlKwz9WElIEO12wDIu6uKd54t7DDQ==",
-      "dependencies": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/meta": "^5.1.5"
-      }
-    },
-    "node_modules/@camptocamp/inkmap/node_modules/@turf/turf": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/@turf/turf/-/turf-5.1.6.tgz",
-      "integrity": "sha512-NIjkt5jAbOrom+56ELw9ERZF6qsdf1xAIHyC9/PkDMIOQAxe7FVe2HaqbQ+x88F0q5FaSX4dtpIEf08md6h5/A==",
-      "dependencies": {
-        "@turf/along": "5.1.x",
-        "@turf/area": "5.1.x",
-        "@turf/bbox": "5.1.x",
-        "@turf/bbox-clip": "5.1.x",
-        "@turf/bbox-polygon": "5.1.x",
-        "@turf/bearing": "5.1.x",
-        "@turf/bezier-spline": "5.1.x",
-        "@turf/boolean-clockwise": "5.1.x",
-        "@turf/boolean-contains": "5.1.x",
-        "@turf/boolean-crosses": "5.1.x",
-        "@turf/boolean-disjoint": "5.1.x",
-        "@turf/boolean-equal": "5.1.x",
-        "@turf/boolean-overlap": "5.1.x",
-        "@turf/boolean-parallel": "5.1.x",
-        "@turf/boolean-point-in-polygon": "5.1.x",
-        "@turf/boolean-point-on-line": "5.1.x",
-        "@turf/boolean-within": "5.1.x",
-        "@turf/buffer": "5.1.x",
-        "@turf/center": "5.1.x",
-        "@turf/center-mean": "5.1.x",
-        "@turf/center-median": "5.1.x",
-        "@turf/center-of-mass": "5.1.x",
-        "@turf/centroid": "5.1.x",
-        "@turf/circle": "5.1.x",
-        "@turf/clean-coords": "5.1.x",
-        "@turf/clone": "5.1.x",
-        "@turf/clusters": "5.1.x",
-        "@turf/clusters-dbscan": "5.1.x",
-        "@turf/clusters-kmeans": "5.1.x",
-        "@turf/collect": "5.1.x",
-        "@turf/combine": "5.1.x",
-        "@turf/concave": "5.1.x",
-        "@turf/convex": "5.1.x",
-        "@turf/destination": "5.1.x",
-        "@turf/difference": "5.1.x",
-        "@turf/dissolve": "5.1.x",
-        "@turf/distance": "5.1.x",
-        "@turf/ellipse": "5.1.x",
-        "@turf/envelope": "5.1.x",
-        "@turf/explode": "5.1.x",
-        "@turf/flatten": "5.1.x",
-        "@turf/flip": "5.1.x",
-        "@turf/great-circle": "5.1.x",
-        "@turf/helpers": "5.1.x",
-        "@turf/hex-grid": "5.1.x",
-        "@turf/interpolate": "5.1.x",
-        "@turf/intersect": "5.1.x",
-        "@turf/invariant": "5.1.x",
-        "@turf/isobands": "5.1.x",
-        "@turf/isolines": "5.1.x",
-        "@turf/kinks": "5.1.x",
-        "@turf/length": "5.1.x",
-        "@turf/line-arc": "5.1.x",
-        "@turf/line-chunk": "5.1.x",
-        "@turf/line-intersect": "5.1.x",
-        "@turf/line-offset": "5.1.x",
-        "@turf/line-overlap": "5.1.x",
-        "@turf/line-segment": "5.1.x",
-        "@turf/line-slice": "5.1.x",
-        "@turf/line-slice-along": "5.1.x",
-        "@turf/line-split": "5.1.x",
-        "@turf/line-to-polygon": "5.1.x",
-        "@turf/mask": "5.1.x",
-        "@turf/meta": "5.1.x",
-        "@turf/midpoint": "5.1.x",
-        "@turf/nearest-point": "5.1.x",
-        "@turf/nearest-point-on-line": "5.1.x",
-        "@turf/nearest-point-to-line": "5.1.x",
-        "@turf/planepoint": "5.1.x",
-        "@turf/point-grid": "5.1.x",
-        "@turf/point-on-feature": "5.1.x",
-        "@turf/point-to-line-distance": "5.1.x",
-        "@turf/points-within-polygon": "5.1.x",
-        "@turf/polygon-tangents": "5.1.x",
-        "@turf/polygon-to-line": "5.1.x",
-        "@turf/polygonize": "5.1.x",
-        "@turf/projection": "5.1.x",
-        "@turf/random": "5.1.x",
-        "@turf/rewind": "5.1.x",
-        "@turf/rhumb-bearing": "5.1.x",
-        "@turf/rhumb-destination": "5.1.x",
-        "@turf/rhumb-distance": "5.1.x",
-        "@turf/sample": "5.1.x",
-        "@turf/sector": "5.1.x",
-        "@turf/shortest-path": "5.1.x",
-        "@turf/simplify": "5.1.x",
-        "@turf/square": "5.1.x",
-        "@turf/square-grid": "5.1.x",
-        "@turf/standard-deviational-ellipse": "5.1.x",
-        "@turf/tag": "5.1.x",
-        "@turf/tesselate": "5.1.x",
-        "@turf/tin": "5.1.x",
-        "@turf/transform-rotate": "5.1.x",
-        "@turf/transform-scale": "5.1.x",
-        "@turf/transform-translate": "5.1.x",
-        "@turf/triangle-grid": "5.1.x",
-        "@turf/truncate": "5.1.x",
-        "@turf/union": "5.1.x",
-        "@turf/unkink-polygon": "5.1.x",
-        "@turf/voronoi": "5.1.x"
-      }
-    },
-    "node_modules/@camptocamp/inkmap/node_modules/@turf/turf/node_modules/@turf/projection": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/projection/-/projection-5.1.5.tgz",
-      "integrity": "sha512-TWKJDFeEKQhI4Ce1+2PuOSDggn4cnMibqyUoCpIW+4KxUC1R88SE3/SYomqzwxMn00O09glHSycPkGD5JzHd8A==",
-      "dependencies": {
-        "@turf/clone": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/meta": "^5.1.5"
-      }
-    },
-    "node_modules/@camptocamp/inkmap/node_modules/@turf/turf/node_modules/@turf/rhumb-bearing": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/rhumb-bearing/-/rhumb-bearing-5.1.5.tgz",
-      "integrity": "sha512-zXTl2khjwf7mx2D1uPo5vgpGgP4sM2VrKDbJNKyulPu4TO4ELt8x7FsKyCBlRTzzQf284t/xnNcZOfUbkkd70g==",
-      "dependencies": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
-      }
-    },
-    "node_modules/@camptocamp/inkmap/node_modules/@turf/turf/node_modules/@turf/rhumb-distance": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/rhumb-distance/-/rhumb-distance-5.1.5.tgz",
-      "integrity": "sha512-AGA/ky5/BJJZtzQqafy2GvJfcUXSzCCrPFp8sDRPSKBoUN4gMBHN15ijDWYYLFoWFFj0urcauVx7chQlHZ/Qfw==",
-      "dependencies": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
-      }
-    },
-    "node_modules/@camptocamp/inkmap/node_modules/@turf/union": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/union/-/union-5.1.5.tgz",
-      "integrity": "sha512-wBy1ixxC68PpsTeEDebk/EfnbI1Za5dCyY7xFY9NMzrtVEOy0l0lQ5syOsaqY4Ire+dbsDM66p2GGxmefoyIEA==",
-      "dependencies": {
-        "@turf/helpers": "^5.1.5",
-        "turf-jsts": "*"
-      }
-    },
-    "node_modules/@camptocamp/inkmap/node_modules/@turf/unkink-polygon": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/unkink-polygon/-/unkink-polygon-5.1.5.tgz",
-      "integrity": "sha512-lzSrgsfSuyxIc4pkE2qyM2dsHxR992e6oItoZAT8G58A2Ef4qc5gRocmXPWZakGx41fQobegSo7wlo4I49wyHg==",
-      "dependencies": {
-        "@turf/area": "^5.1.5",
-        "@turf/boolean-point-in-polygon": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/meta": "^5.1.5",
-        "rbush": "^2.0.1"
-      }
-    },
-    "node_modules/@camptocamp/inkmap/node_modules/@turf/voronoi": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/voronoi/-/voronoi-5.1.5.tgz",
-      "integrity": "sha512-Ad0HZAyYjOpMIZfDGV+Q+30M9PQHIirTyn32kWyTjEI1O6uhL5NOYjzSha4Sr77xOls3hGzKOj+JET7eDtOvsg==",
-      "dependencies": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "d3-voronoi": "1.1.2"
-      }
-    },
-    "node_modules/@camptocamp/inkmap/node_modules/geojson-rbush": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/geojson-rbush/-/geojson-rbush-2.1.0.tgz",
-      "integrity": "sha512-9HvLGhmAJBYkYYDdPlCrlfkKGwNW3PapiS0xPekdJLobkZE4rjtduKJXsO7+kUr97SsUlz4VtMcPuSIbjjJaQg==",
-      "dependencies": {
-        "@turf/helpers": "*",
-        "@turf/meta": "*",
-        "rbush": "*"
-      }
-    },
-    "node_modules/@camptocamp/inkmap/node_modules/geostyler-openlayers-parser": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/geostyler-openlayers-parser/-/geostyler-openlayers-parser-2.5.0.tgz",
-      "integrity": "sha512-Uum/lDci8oqhBA/c0RZbD91aXP4ycjlsAp4ZoVAPDHT6Og0XyF5Tze8wg0Ux44CerE6W+m2DfWkOTAP+iaakzQ==",
-      "dependencies": {
-        "@terrestris/ol-util": "^4.0.1",
-        "geostyler-style": "^4.0.0",
-        "lodash": "^4.17.15"
+        "yocto-queue": "^0.1.0"
       },
-      "peerDependencies": {
-        "ol": "^6.0.0"
-      }
-    },
-    "node_modules/@camptocamp/inkmap/node_modules/geostyler-style": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/geostyler-style/-/geostyler-style-4.0.3.tgz",
-      "integrity": "sha512-51esHVZz86HFoSvKRA/Kfqd2Mytek88zgHSSt8ZZg30o4dqyZuQluxwIjqkSLp5hdvmA0nwCAyqxHy6aMyJ5lQ==",
-      "dependencies": {
-        "@types/lodash": "^4.14.168",
-        "lodash": "^4.17.21"
-      }
-    },
-    "node_modules/@camptocamp/inkmap/node_modules/jszip": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/jszip/-/jszip-2.6.1.tgz",
-      "integrity": "sha512-C4Z++nYQv+CudUkCWUdz+yKVhQiFJjuWSmRJ5Sg3d3/OzcJ6U4ooUYlmE3+rJXrVk89KWQaiJ9mPp/VLQ4D66g==",
-      "dependencies": {
-        "pako": "~1.0.2"
-      }
-    },
-    "node_modules/@camptocamp/inkmap/node_modules/lru-cache": {
-      "version": "2.7.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
-      "integrity": "sha512-WpibWJ60c3AgAz8a2iYErDrcT2C7OmKnsWhIcHOjkUHFjkXncJhtLxNSqUmxRxRunpb5I8Vprd7aNSd2NtksJQ=="
-    },
-    "node_modules/@camptocamp/inkmap/node_modules/ol": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/ol/-/ol-6.5.0.tgz",
-      "integrity": "sha512-a5ebahrjF5yCPFle1rc0aHzKp/9A4LlUnjh+S3I+x4EgcvcddDhpOX3WDOs0Pg9/wEElrikHSGEvbeej2Hh4Ug==",
-      "dependencies": {
-        "ol-mapbox-style": "^6.1.1",
-        "pbf": "3.2.1",
-        "rbush": "^3.0.1"
+      "engines": {
+        "node": ">=10"
       },
       "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/openlayers"
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@camptocamp/inkmap/node_modules/ol-mapbox-style": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/ol-mapbox-style/-/ol-mapbox-style-6.9.0.tgz",
-      "integrity": "sha512-Isxk+IPB6pCBD2Pubz9cpQcZjEeuPhxyk/QsLZjb2+KwvyGaIFltdlxnxx/QXJ7rOxUiLvS/XhsOyiK0c7prEw==",
+    "node_modules/@commitlint/top-level/node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
       "dependencies": {
-        "@mapbox/mapbox-gl-style-spec": "^13.20.1",
-        "mapbox-to-css-font": "^2.4.1",
-        "webfont-matcher": "^1.1.0"
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@camptocamp/inkmap/node_modules/ol/node_modules/rbush": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/rbush/-/rbush-3.0.1.tgz",
-      "integrity": "sha512-XRaVO0YecOpEuIvbhbpTrZgoiI6xBlz6hnlr6EHhd+0x9ase6EmeN+hdwwUaJvLcsFFQ8iWVF1GAK1yB0BWi0w==",
+    "node_modules/@commitlint/types": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-17.0.0.tgz",
+      "integrity": "sha512-hBAw6U+SkAT5h47zDMeOu3HSiD0SODw4Aq7rRNh1ceUmL7GyLKYhPbUvlRWqZ65XjBLPHZhFyQlRaPNz8qvUyQ==",
+      "dev": true,
       "dependencies": {
-        "quickselect": "^2.0.0"
+        "chalk": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=v14"
       }
     },
-    "node_modules/@camptocamp/inkmap/node_modules/pako": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
-      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
-    },
-    "node_modules/@camptocamp/inkmap/node_modules/quickselect": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
-      "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw=="
-    },
-    "node_modules/@camptocamp/inkmap/node_modules/shpjs": {
-      "version": "3.6.3",
-      "resolved": "https://registry.npmjs.org/shpjs/-/shpjs-3.6.3.tgz",
-      "integrity": "sha512-wcR2S3WL/7RnEIm+YO+H/mZR9z9FCV46op+SZt+W5PtPs26Omb9U93f+EPI1DOpNKBuAIrWjHWh0SxlnBahJkg==",
+    "node_modules/@commitlint/types/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
       "dependencies": {
-        "jszip": "^2.4.0",
-        "lie": "^3.0.1",
-        "lru-cache": "^2.7.0",
-        "parsedbf": "^1.1.0",
-        "proj4": "^2.1.4"
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@commitlint/types/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@commitlint/types/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@commitlint/types/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/@commitlint/types/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@commitlint/types/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@ctrl/tinycolor": {
@@ -3919,15 +3054,6 @@
       "dependencies": {
         "jest-get-type": "^28.0.2"
       },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
-      }
-    },
-    "node_modules/@jest/expect-utils/node_modules/jest-get-type": {
-      "version": "28.0.2",
-      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-28.0.2.tgz",
-      "integrity": "sha512-ioj2w9/DxSYHfOm5lJKCdcAmPJzQXmbM/Url3rhlghrPvT3tt+7a/+oXc9azkKmLvoiXjtV83bEWqi+vs5nlPA==",
-      "dev": true,
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
       }
@@ -5098,18 +4224,18 @@
       }
     },
     "node_modules/@terrestris/eslint-config-typescript": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@terrestris/eslint-config-typescript/-/eslint-config-typescript-2.1.0.tgz",
-      "integrity": "sha512-fRAAfa2bIht5Nf/GZBbhhgVwnxNc3VG8YdyYwsauCwAn5XPHl/JDeJkyMpIu/NVML9LGSFbQBZChUEpZRhntwg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@terrestris/eslint-config-typescript/-/eslint-config-typescript-3.0.0.tgz",
+      "integrity": "sha512-dpAztRrJ/M036lTI5eqJoNbX4/80zTh2fRWxrXRG16RHorQoIbBsd8WqWtF7K42yTrSHz2kmEwWX4Yo0YBc2rQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/parser": "^5.15.0",
-        "typescript": ">= 3"
+        "@typescript-eslint/parser": "^5.28.0",
+        "typescript": ">= ~4"
       },
       "peerDependencies": {
-        "@typescript-eslint/eslint-plugin": ">= 4",
-        "eslint": ">= 7",
-        "typescript": ">= 3"
+        "@typescript-eslint/eslint-plugin": ">= ~5",
+        "eslint": ">= ~8",
+        "typescript": ">= ~4"
       }
     },
     "node_modules/@terrestris/ol-util": {
@@ -5135,10 +4261,37 @@
         "ol": "^6.5"
       }
     },
+    "node_modules/@terrestris/ol-util/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/@terrestris/ol-util/node_modules/geostyler-openlayers-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/geostyler-openlayers-parser/-/geostyler-openlayers-parser-3.1.0.tgz",
+      "integrity": "sha512-TidTBmvlM/yVUWuarjO5mb9uiBmRDeWxCkdnvktuUrezWUWsVZWUXk9faA9s9D8o3IQMKJtI5UzIcSGuCB6H0Q==",
+      "dependencies": {
+        "color-name": "^1.1.4",
+        "geostyler-style": "^5.0.2",
+        "lodash": "^4.17.21"
+      },
+      "peerDependencies": {
+        "ol": "^6.0.0"
+      }
+    },
+    "node_modules/@terrestris/ol-util/node_modules/geostyler-style": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/geostyler-style/-/geostyler-style-5.1.0.tgz",
+      "integrity": "sha512-AJzQBomzuTGr01uRYvu7bocJTBB6vrgBdxsIoSHDATbnNF07XnAtsrbkjXlMsKaRnbqE2MGLhQqBmBx6C2Gubg==",
+      "dependencies": {
+        "@types/lodash": "^4.14.168",
+        "lodash": "^4.17.21"
+      }
+    },
     "node_modules/@testing-library/dom": {
-      "version": "8.13.0",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.13.0.tgz",
-      "integrity": "sha512-9VHgfIatKNXQNaZTtLnalIy0jNZzY35a4S3oi08YAt9Hv1VsfZ/DfA45lM8D/UhtHBGJ4/lGwp0PZkVndRkoOQ==",
+      "version": "8.14.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.14.0.tgz",
+      "integrity": "sha512-m8FOdUo77iMTwVRCyzWcqxlEIk+GnopbrRI15a0EaLbpZSCinIVI4kSQzWhkShK83GogvEFJSsHF3Ws0z1vrqA==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
@@ -5341,9 +4494,9 @@
       }
     },
     "node_modules/@testing-library/user-event": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.2.0.tgz",
-      "integrity": "sha512-+hIlG4nJS6ivZrKnOP7OGsDu9Fxmryj9vCl8x0ZINtTJcCHs2zLsYif5GzuRiBF2ck5GZG2aQr7Msg+EHlnYVQ==",
+      "version": "14.2.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.2.1.tgz",
+      "integrity": "sha512-HOr1QiODrq+0j9lKU5i10y9TbhxMBMRMGimNx10asdmau9cb8Xb1Vyg0GvTwyIL2ziQyh2kAloOtAQFBQVuecA==",
       "dev": true,
       "engines": {
         "node": ">=12",
@@ -5374,6 +4527,30 @@
       "engines": {
         "node": ">= 10"
       }
+    },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
+      "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
+      "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
+      "dev": true
     },
     "node_modules/@turf/along": {
       "version": "6.5.0",
@@ -7098,14 +6275,47 @@
       }
     },
     "node_modules/@types/jest": {
-      "version": "28.1.1",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-28.1.1.tgz",
-      "integrity": "sha512-C2p7yqleUKtCkVjlOur9BWVA4HgUQmEj/HWCt5WzZ5mLXrWnyIfl0wGuArc+kBXsy0ZZfLp+7dywB4HtSVYGVA==",
+      "version": "28.1.3",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-28.1.3.tgz",
+      "integrity": "sha512-Tsbjk8Y2hkBaY/gJsataeb4q9Mubw9EOz7+4RjPkzD5KjTvHHs7cpws22InaoXxAVAhF5HfFbzJjo6oKWqSZLw==",
       "dev": true,
       "dependencies": {
-        "jest-matcher-utils": "^27.0.0",
-        "pretty-format": "^27.0.0"
+        "jest-matcher-utils": "^28.0.0",
+        "pretty-format": "^28.0.0"
       }
+    },
+    "node_modules/@types/jest/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@types/jest/node_modules/pretty-format": {
+      "version": "28.1.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-28.1.1.tgz",
+      "integrity": "sha512-wwJbVTGFHeucr5Jw2bQ9P+VYHyLdAqedFLEkdQUVaBF/eiidDwH5OpilINq4mEfhbCjLnirt6HTTDhv1HaTIQw==",
+      "dev": true,
+      "dependencies": {
+        "@jest/schemas": "^28.0.2",
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/react-is": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
+      "dev": true
     },
     "node_modules/@types/jsdom": {
       "version": "16.2.14",
@@ -7190,9 +6400,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "17.0.42",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.42.tgz",
-      "integrity": "sha512-Q5BPGyGKcvQgAMbsr7qEGN/kIPN6zZecYYABeTDBizOsau+2NMdSVTar9UQw21A2+JyA2KRNDYaYrPB0Rpk2oQ=="
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.0.0.tgz",
+      "integrity": "sha512-cHlGmko4gWLVI27cGJntjs/Sj8th9aYwplmZFwmmgYQQvL5NUsgVJG7OddLvNfLqYS31KFN0s3qlaD9qCaxACA=="
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.1",
@@ -7401,14 +6611,14 @@
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "5.27.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.27.1.tgz",
-      "integrity": "sha512-6dM5NKT57ZduNnJfpY81Phe9nc9wolnMCnknb1im6brWi1RYv84nbMS3olJa27B6+irUVV1X/Wb+Am0FjJdGFw==",
+      "version": "5.29.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.29.0.tgz",
+      "integrity": "sha512-kgTsISt9pM53yRFQmLZ4npj99yGl3x3Pl7z4eA66OuTzAGC4bQB5H5fuLwPnqTKU3yyrrg4MIhjF17UYnL4c0w==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.27.1",
-        "@typescript-eslint/type-utils": "5.27.1",
-        "@typescript-eslint/utils": "5.27.1",
+        "@typescript-eslint/scope-manager": "5.29.0",
+        "@typescript-eslint/type-utils": "5.29.0",
+        "@typescript-eslint/utils": "5.29.0",
         "debug": "^4.3.4",
         "functional-red-black-tree": "^1.0.1",
         "ignore": "^5.2.0",
@@ -7449,14 +6659,14 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "5.27.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.27.1.tgz",
-      "integrity": "sha512-7Va2ZOkHi5NP+AZwb5ReLgNF6nWLGTeUJfxdkVUAPPSaAdbWNnFZzLZ4EGGmmiCTg+AwlbE1KyUYTBglosSLHQ==",
+      "version": "5.29.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.29.0.tgz",
+      "integrity": "sha512-ruKWTv+x0OOxbzIw9nW5oWlUopvP/IQDjB5ZqmTglLIoDTctLlAJpAQFpNPJP/ZI7hTT9sARBosEfaKbcFuECw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.27.1",
-        "@typescript-eslint/types": "5.27.1",
-        "@typescript-eslint/typescript-estree": "5.27.1",
+        "@typescript-eslint/scope-manager": "5.29.0",
+        "@typescript-eslint/types": "5.29.0",
+        "@typescript-eslint/typescript-estree": "5.29.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -7476,13 +6686,13 @@
       }
     },
     "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.27.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.27.1.tgz",
-      "integrity": "sha512-fQEOSa/QroWE6fAEg+bJxtRZJTH8NTskggybogHt4H9Da8zd4cJji76gA5SBlR0MgtwF7rebxTbDKB49YUCpAg==",
+      "version": "5.29.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.29.0.tgz",
+      "integrity": "sha512-etbXUT0FygFi2ihcxDZjz21LtC+Eps9V2xVx09zFoN44RRHPrkMflidGMI+2dUs821zR1tDS6Oc9IXxIjOUZwA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.27.1",
-        "@typescript-eslint/visitor-keys": "5.27.1"
+        "@typescript-eslint/types": "5.29.0",
+        "@typescript-eslint/visitor-keys": "5.29.0"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -7493,9 +6703,9 @@
       }
     },
     "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/types": {
-      "version": "5.27.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.27.1.tgz",
-      "integrity": "sha512-LgogNVkBhCTZU/m8XgEYIWICD6m4dmEDbKXESCbqOXfKZxRKeqpiJXQIErv66sdopRKZPo5l32ymNqibYEH/xg==",
+      "version": "5.29.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.29.0.tgz",
+      "integrity": "sha512-X99VbqvAXOMdVyfFmksMy3u8p8yoRGITgU1joBJPzeYa0rhdf5ok9S56/itRoUSh99fiDoMtarSIJXo7H/SnOg==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -7506,13 +6716,13 @@
       }
     },
     "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.27.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.27.1.tgz",
-      "integrity": "sha512-DnZvvq3TAJ5ke+hk0LklvxwYsnXpRdqUY5gaVS0D4raKtbznPz71UJGnPTHEFo0GDxqLOLdMkkmVZjSpET1hFw==",
+      "version": "5.29.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.29.0.tgz",
+      "integrity": "sha512-mQvSUJ/JjGBdvo+1LwC+GY2XmSYjK1nAaVw2emp/E61wEVYEyibRHCqm1I1vEKbXCpUKuW4G7u9ZCaZhJbLoNQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.27.1",
-        "@typescript-eslint/visitor-keys": "5.27.1",
+        "@typescript-eslint/types": "5.29.0",
+        "@typescript-eslint/visitor-keys": "5.29.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -7533,12 +6743,12 @@
       }
     },
     "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.27.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.27.1.tgz",
-      "integrity": "sha512-xYs6ffo01nhdJgPieyk7HAOpjhTsx7r/oB9LWEhwAXgwn33tkr+W8DI2ChboqhZlC4q3TC6geDYPoiX8ROqyOQ==",
+      "version": "5.29.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.29.0.tgz",
+      "integrity": "sha512-Hpb/mCWsjILvikMQoZIE3voc9wtQcS0A9FUw3h8bhr9UxBdtI/tw1ZDZUOXHXLOVMedKCH5NxyzATwnU78bWCQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.27.1",
+        "@typescript-eslint/types": "5.29.0",
         "eslint-visitor-keys": "^3.3.0"
       },
       "engines": {
@@ -7574,13 +6784,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.27.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.27.1.tgz",
-      "integrity": "sha512-fQEOSa/QroWE6fAEg+bJxtRZJTH8NTskggybogHt4H9Da8zd4cJji76gA5SBlR0MgtwF7rebxTbDKB49YUCpAg==",
+      "version": "5.29.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.29.0.tgz",
+      "integrity": "sha512-etbXUT0FygFi2ihcxDZjz21LtC+Eps9V2xVx09zFoN44RRHPrkMflidGMI+2dUs821zR1tDS6Oc9IXxIjOUZwA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.27.1",
-        "@typescript-eslint/visitor-keys": "5.27.1"
+        "@typescript-eslint/types": "5.29.0",
+        "@typescript-eslint/visitor-keys": "5.29.0"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -7591,12 +6801,12 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "5.27.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.27.1.tgz",
-      "integrity": "sha512-+UC1vVUWaDHRnC2cQrCJ4QtVjpjjCgjNFpg8b03nERmkHv9JV9X5M19D7UFMd+/G7T/sgFwX2pGmWK38rqyvXw==",
+      "version": "5.29.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.29.0.tgz",
+      "integrity": "sha512-JK6bAaaiJozbox3K220VRfCzLa9n0ib/J+FHIwnaV3Enw/TO267qe0pM1b1QrrEuy6xun374XEAsRlA86JJnyg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/utils": "5.27.1",
+        "@typescript-eslint/utils": "5.29.0",
         "debug": "^4.3.4",
         "tsutils": "^3.21.0"
       },
@@ -7617,9 +6827,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "5.27.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.27.1.tgz",
-      "integrity": "sha512-LgogNVkBhCTZU/m8XgEYIWICD6m4dmEDbKXESCbqOXfKZxRKeqpiJXQIErv66sdopRKZPo5l32ymNqibYEH/xg==",
+      "version": "5.29.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.29.0.tgz",
+      "integrity": "sha512-X99VbqvAXOMdVyfFmksMy3u8p8yoRGITgU1joBJPzeYa0rhdf5ok9S56/itRoUSh99fiDoMtarSIJXo7H/SnOg==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -7630,13 +6840,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.27.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.27.1.tgz",
-      "integrity": "sha512-DnZvvq3TAJ5ke+hk0LklvxwYsnXpRdqUY5gaVS0D4raKtbznPz71UJGnPTHEFo0GDxqLOLdMkkmVZjSpET1hFw==",
+      "version": "5.29.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.29.0.tgz",
+      "integrity": "sha512-mQvSUJ/JjGBdvo+1LwC+GY2XmSYjK1nAaVw2emp/E61wEVYEyibRHCqm1I1vEKbXCpUKuW4G7u9ZCaZhJbLoNQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.27.1",
-        "@typescript-eslint/visitor-keys": "5.27.1",
+        "@typescript-eslint/types": "5.29.0",
+        "@typescript-eslint/visitor-keys": "5.29.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -7672,15 +6882,15 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "5.27.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.27.1.tgz",
-      "integrity": "sha512-mZ9WEn1ZLDaVrhRaYgzbkXBkTPghPFsup8zDbbsYTxC5OmqrFE7skkKS/sraVsLP3TcT3Ki5CSyEFBRkLH/H/w==",
+      "version": "5.29.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.29.0.tgz",
+      "integrity": "sha512-3Eos6uP1nyLOBayc/VUdKZikV90HahXE5Dx9L5YlSd/7ylQPXhLk1BYb29SDgnBnTp+jmSZUU0QxUiyHgW4p7A==",
       "dev": true,
       "dependencies": {
         "@types/json-schema": "^7.0.9",
-        "@typescript-eslint/scope-manager": "5.27.1",
-        "@typescript-eslint/types": "5.27.1",
-        "@typescript-eslint/typescript-estree": "5.27.1",
+        "@typescript-eslint/scope-manager": "5.29.0",
+        "@typescript-eslint/types": "5.29.0",
+        "@typescript-eslint/typescript-estree": "5.29.0",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^3.0.0"
       },
@@ -7696,12 +6906,12 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.27.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.27.1.tgz",
-      "integrity": "sha512-xYs6ffo01nhdJgPieyk7HAOpjhTsx7r/oB9LWEhwAXgwn33tkr+W8DI2ChboqhZlC4q3TC6geDYPoiX8ROqyOQ==",
+      "version": "5.29.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.29.0.tgz",
+      "integrity": "sha512-Hpb/mCWsjILvikMQoZIE3voc9wtQcS0A9FUw3h8bhr9UxBdtI/tw1ZDZUOXHXLOVMedKCH5NxyzATwnU78bWCQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.27.1",
+        "@typescript-eslint/types": "5.29.0",
         "eslint-visitor-keys": "^3.3.0"
       },
       "engines": {
@@ -8301,6 +7511,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true
     },
     "node_modules/argparse": {
       "version": "1.0.10",
@@ -10702,6 +9918,20 @@
         "node": ">=10"
       }
     },
+    "node_modules/conventional-changelog-conventionalcommits": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-5.0.0.tgz",
+      "integrity": "sha512-lCDbA+ZqVFQGUj7h9QBKoIpLhl8iihkO0nCTyRNzuXtcd7ubODpYB04IFy31JloiJgG0Uovu8ot8oxRzn7Nwtw==",
+      "dev": true,
+      "dependencies": {
+        "compare-func": "^2.0.0",
+        "lodash": "^4.17.15",
+        "q": "^1.5.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/conventional-changelog-writer": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-5.0.1.tgz",
@@ -10997,6 +10227,25 @@
         "node": ">=10"
       }
     },
+    "node_modules/cosmiconfig-typescript-loader": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-2.0.1.tgz",
+      "integrity": "sha512-B9s6sX/omXq7I6gC6+YgLmrBFMJhPWew7ty/X5Tuwtd2zOSgWaUdXjkuVwbe3qqcdETo60+1nSVMekq//LIXVA==",
+      "dev": true,
+      "dependencies": {
+        "cosmiconfig": "^7",
+        "ts-node": "^10.8.0"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@types/node": "*",
+        "cosmiconfig": ">=7",
+        "typescript": ">=3"
+      }
+    },
     "node_modules/coveralls": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.1.1.tgz",
@@ -11015,6 +10264,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true
     },
     "node_modules/cross-fetch": {
       "version": "3.1.5",
@@ -11218,6 +10473,15 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/d3-voronoi/-/d3-voronoi-1.1.2.tgz",
       "integrity": "sha1-Fodmfo8TotFYyAwUgMWinLDYlzw="
+    },
+    "node_modules/dargs": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/dargs/-/dargs-7.0.0.tgz",
+      "integrity": "sha512-2iy1EkLdlBzQGvbweYRFxmFath8+K7+AKB0TlhHWkNuH+TmovaMH/Wp7V7R4u7f4SnX3OgLsU9t1NI9ioDnUpg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/dashdash": {
       "version": "1.14.1",
@@ -11713,13 +10977,22 @@
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
     },
-    "node_modules/diff-sequences": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-27.5.1.tgz",
-      "integrity": "sha512-k1gCAXAsNgLwEL+Y8Wvl+M6oEFj5bgazfZULpS5CneoPPXRaCCW7dm+q21Ky2VEE5X+VeRDBVg1Pcvvsr4TtNQ==",
+    "node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
       "dev": true,
       "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/diff-sequences": {
+      "version": "28.1.1",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-28.1.1.tgz",
+      "integrity": "sha512-FU0iFaH/E23a+a718l8Qa/19bF9p06kgE0KipMOMadwa3SjnaElKzPaUC0vnibs6/B/9ni97s61mcejk8W1fQw==",
+      "dev": true,
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
       }
     },
     "node_modules/dir-glob": {
@@ -12307,9 +11580,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.17.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.17.0.tgz",
-      "integrity": "sha512-gq0m0BTJfci60Fz4nczYxNAlED+sMcihltndR8t9t1evnU/azx53x3t2UHXC/uRjcbvRw/XctpaNygSTcQD+Iw==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.18.0.tgz",
+      "integrity": "sha512-As1EfFMVk7Xc6/CvhssHUjsAQSkpfXvUGMFC3ce8JDe6WvqCgRrLOBQbVpsBFr1X1V+RACOadnzVvcUS5ni2bA==",
       "dev": true,
       "dependencies": {
         "@eslint/eslintrc": "^1.3.0",
@@ -12421,9 +11694,9 @@
       }
     },
     "node_modules/eslint-plugin-react-hooks": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.5.0.tgz",
-      "integrity": "sha512-8k1gRt7D7h03kd+SAAlzXkQwWK22BnK6GKZG+FJA6BAGy22CFvl8kCIXKpVux0cCxMWDQUPqSok0LKaZ0aOcCw==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz",
+      "integrity": "sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==",
       "dev": true,
       "engines": {
         "node": ">=10"
@@ -13006,157 +12279,6 @@
       },
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
-      }
-    },
-    "node_modules/expect/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/expect/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/expect/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/expect/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
-    },
-    "node_modules/expect/node_modules/diff-sequences": {
-      "version": "28.1.1",
-      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-28.1.1.tgz",
-      "integrity": "sha512-FU0iFaH/E23a+a718l8Qa/19bF9p06kgE0KipMOMadwa3SjnaElKzPaUC0vnibs6/B/9ni97s61mcejk8W1fQw==",
-      "dev": true,
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
-      }
-    },
-    "node_modules/expect/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/expect/node_modules/jest-diff": {
-      "version": "28.1.1",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-28.1.1.tgz",
-      "integrity": "sha512-/MUUxeR2fHbqHoMMiffe/Afm+U8U4olFRJ0hiVG2lZatPJcnGxx292ustVu7bULhjV65IYMxRdploAKLbcrsyg==",
-      "dev": true,
-      "dependencies": {
-        "chalk": "^4.0.0",
-        "diff-sequences": "^28.1.1",
-        "jest-get-type": "^28.0.2",
-        "pretty-format": "^28.1.1"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
-      }
-    },
-    "node_modules/expect/node_modules/jest-get-type": {
-      "version": "28.0.2",
-      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-28.0.2.tgz",
-      "integrity": "sha512-ioj2w9/DxSYHfOm5lJKCdcAmPJzQXmbM/Url3rhlghrPvT3tt+7a/+oXc9azkKmLvoiXjtV83bEWqi+vs5nlPA==",
-      "dev": true,
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
-      }
-    },
-    "node_modules/expect/node_modules/jest-matcher-utils": {
-      "version": "28.1.1",
-      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-28.1.1.tgz",
-      "integrity": "sha512-NPJPRWrbmR2nAJ+1nmnfcKKzSwgfaciCCrYZzVnNoxVoyusYWIjkBMNvu0RHJe7dNj4hH3uZOPZsQA+xAYWqsw==",
-      "dev": true,
-      "dependencies": {
-        "chalk": "^4.0.0",
-        "jest-diff": "^28.1.1",
-        "jest-get-type": "^28.0.2",
-        "pretty-format": "^28.1.1"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
-      }
-    },
-    "node_modules/expect/node_modules/pretty-format": {
-      "version": "28.1.1",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-28.1.1.tgz",
-      "integrity": "sha512-wwJbVTGFHeucr5Jw2bQ9P+VYHyLdAqedFLEkdQUVaBF/eiidDwH5OpilINq4mEfhbCjLnirt6HTTDhv1HaTIQw==",
-      "dev": true,
-      "dependencies": {
-        "@jest/schemas": "^28.0.2",
-        "ansi-regex": "^5.0.1",
-        "ansi-styles": "^5.0.0",
-        "react-is": "^18.0.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
-      }
-    },
-    "node_modules/expect/node_modules/pretty-format/node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/expect/node_modules/react-is": {
-      "version": "18.1.0",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.1.0.tgz",
-      "integrity": "sha512-Fl7FuabXsJnV5Q1qIOQwx/sagGF18kogb4gpfcG4gjLBWO0WDiiz1ko/ExayuxE7InyQkBLkxRFG5oxY6Uu3Kg==",
-      "dev": true
-    },
-    "node_modules/expect/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/express": {
@@ -14124,27 +13246,1405 @@
       }
     },
     "node_modules/geostyler-openlayers-parser": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/geostyler-openlayers-parser/-/geostyler-openlayers-parser-3.1.0.tgz",
-      "integrity": "sha512-TidTBmvlM/yVUWuarjO5mb9uiBmRDeWxCkdnvktuUrezWUWsVZWUXk9faA9s9D8o3IQMKJtI5UzIcSGuCB6H0Q==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/geostyler-openlayers-parser/-/geostyler-openlayers-parser-2.5.0.tgz",
+      "integrity": "sha512-Uum/lDci8oqhBA/c0RZbD91aXP4ycjlsAp4ZoVAPDHT6Og0XyF5Tze8wg0Ux44CerE6W+m2DfWkOTAP+iaakzQ==",
       "dependencies": {
-        "color-name": "^1.1.4",
-        "geostyler-style": "^5.0.2",
-        "lodash": "^4.17.21"
+        "@terrestris/ol-util": "^4.0.1",
+        "geostyler-style": "^4.0.0",
+        "lodash": "^4.17.15"
       },
       "peerDependencies": {
         "ol": "^6.0.0"
       }
     },
-    "node_modules/geostyler-openlayers-parser/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    "node_modules/geostyler-openlayers-parser/node_modules/@terrestris/ol-util": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@terrestris/ol-util/-/ol-util-4.1.3.tgz",
+      "integrity": "sha512-vTS7rXxOcvTpXQzRGR6DVldEYcbFjADQ9/ArSKeq9yCmmY9wb3dkeGKw+rN/dltu6oZbaswjsUsBQe060kiMOQ==",
+      "dependencies": {
+        "@terrestris/base-util": "^1.0.0",
+        "@turf/turf": "^5.1.6",
+        "lodash": "^4.17.20",
+        "proj4": "^2.7.0",
+        "shpjs": "^3.6.3"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "ol": "~6.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/along": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/along/-/along-5.1.5.tgz",
+      "integrity": "sha512-N7BN1xvj6VWMe3UpjQDdVI0j0oY/EZ0bWgOgBXc4DlJ411uEsKCh6iBv0b2MSxQ3YUXEez3oc5FcgO9eVSs7iQ==",
+      "dependencies": {
+        "@turf/bearing": "^5.1.5",
+        "@turf/destination": "^5.1.5",
+        "@turf/distance": "^5.1.5",
+        "@turf/helpers": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/area": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/area/-/area-5.1.5.tgz",
+      "integrity": "sha512-lz16gqtvoz+j1jD9y3zj0Z5JnGNd3YfS0h+DQY1EcZymvi75Frm9i5YbEyth0RfxYZeOVufY7YIS3LXbJlI57g==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/bbox": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/bbox/-/bbox-5.1.5.tgz",
+      "integrity": "sha512-sYQU4fqsOYYJoD8UndC1n2hy8hV/lGIAmMLKWuzwmPUWqWOuSKWUcoRWDi9mGB0GvQQe/ow2IxZr8UaVaGz3sQ==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/bbox-clip": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/bbox-clip/-/bbox-clip-5.1.5.tgz",
+      "integrity": "sha512-KP64aoTvjcXxWHeM/Hs25vOQUBJgyJi7DlRVEoZofFJiR1kPnmDQrK7Xj+60lAk5cxuqzFnaPPxUk9Q+3v4p1Q==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "lineclip": "^1.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/bbox-polygon": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/bbox-polygon/-/bbox-polygon-5.1.5.tgz",
+      "integrity": "sha512-PKVPF5LABFWZJud8KzzfesLGm5ihiwLbVa54HJjYySe6yqU/cr5q/qcN9TWptynOFhNktG1dr0KXVG0I2FZmfw==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/bearing": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/bearing/-/bearing-5.1.5.tgz",
+      "integrity": "sha512-PrvZuJjnXGseB8hUatIjsrK3tgD3wttyRnVYXTbSfXYJZzaOfHDMplgO4lxXQp7diraZhGhCdSlbMvRRXItbUQ==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/bezier-spline": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/bezier-spline/-/bezier-spline-5.1.5.tgz",
+      "integrity": "sha512-Y9NoComaGgFFFe9TWWE/cEMg2+EnBfU1R3112ec2wlx21ygDmFGXs4boOS71WM4ySwm/dbS3wxnbVxs4j68sKw==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/boolean-clockwise": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-clockwise/-/boolean-clockwise-5.1.5.tgz",
+      "integrity": "sha512-FqbmEEOJ4rU4/2t7FKx0HUWmjFEVqR+NJrFP7ymGSjja2SQ7Q91nnBihGuT+yuHHl6ElMjQ3ttsB/eTmyCycxA==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/boolean-contains": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-contains/-/boolean-contains-5.1.5.tgz",
+      "integrity": "sha512-x2HeEieeE9vBQrTdCuj4swnAXlpKbj9ChxMdDTV479c0m2gVmfea83ocmkj3w+9cvAaS63L8WqFyNVSmkwqljQ==",
+      "dependencies": {
+        "@turf/bbox": "^5.1.5",
+        "@turf/boolean-point-in-polygon": "^5.1.5",
+        "@turf/boolean-point-on-line": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/boolean-crosses": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-crosses/-/boolean-crosses-5.1.5.tgz",
+      "integrity": "sha512-odljvS7INr9k/8yXeyXQVry7GqEaChOmXawP0+SoTfGO3hgptiik59TLU/Yjn/SLFjE2Ul54Ga1jKFSL7vvH0Q==",
+      "dependencies": {
+        "@turf/boolean-point-in-polygon": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/line-intersect": "^5.1.5",
+        "@turf/polygon-to-line": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/boolean-disjoint": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-disjoint/-/boolean-disjoint-5.1.6.tgz",
+      "integrity": "sha512-KHvUS6SBNYHBCLIJEJrg04pF5Oy+Fqn8V5G9U+9pti5vI9tyX7Ln2g7RSB7iJ1Cxsz8QAi6OukhXjEF2/8ZpGg==",
+      "dependencies": {
+        "@turf/boolean-point-in-polygon": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/line-intersect": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "@turf/polygon-to-line": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/boolean-equal": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-equal/-/boolean-equal-5.1.5.tgz",
+      "integrity": "sha512-QEMbhDPV+J8PlRkMlVg6m5oSLaYUpOx2VUhDDekQ73FlpnhFBKRIlidhvHtS6CYnEw8d+/zA3h8Z18B4W4mq9Q==",
+      "dependencies": {
+        "@turf/clean-coords": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "geojson-equality": "0.1.6"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/boolean-overlap": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-overlap/-/boolean-overlap-5.1.5.tgz",
+      "integrity": "sha512-lizojgU559KME0G705YAgWVa0B3/tsWNobMzOEWDx/1rABWTojCY4uxw2rFxpOsP++s8JJHrGWXRLh1PbdAvRQ==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/line-intersect": "^5.1.5",
+        "@turf/line-overlap": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "geojson-equality": "0.1.6"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/boolean-parallel": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-parallel/-/boolean-parallel-5.1.5.tgz",
+      "integrity": "sha512-eeuGgDhnas3nJ22A/DD8aiH0kg9dSzbQChIMAqYRPGg3pWNK41aGAbeh5z0GO5N/EVFX1+ga5a0vsPmiRgQB5g==",
+      "dependencies": {
+        "@turf/clean-coords": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/line-segment": "^5.1.5",
+        "@turf/rhumb-bearing": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/boolean-parallel/node_modules/@turf/rhumb-bearing": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/rhumb-bearing/-/rhumb-bearing-5.1.5.tgz",
+      "integrity": "sha512-zXTl2khjwf7mx2D1uPo5vgpGgP4sM2VrKDbJNKyulPu4TO4ELt8x7FsKyCBlRTzzQf284t/xnNcZOfUbkkd70g==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/boolean-point-in-polygon": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-point-in-polygon/-/boolean-point-in-polygon-5.1.5.tgz",
+      "integrity": "sha512-y+gbAhLmsAZH9uYhv+C68pu06mxsGIm3o7l0hzVkc/PXYdbkr+vKe7n7PfSN3xpVA3qoDLKLpCGOqeW8/ThaJA==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/boolean-point-on-line": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-point-on-line/-/boolean-point-on-line-5.1.5.tgz",
+      "integrity": "sha512-Zf4d28mckV2tYfLWf2iqxQ8eeLZqi2HGimM26mptf1OCEIwc1wfkKgLRRJXMu94Crvd/pJxjRAjoYGcGliP6Vg==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/boolean-within": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-within/-/boolean-within-5.1.5.tgz",
+      "integrity": "sha512-CNAtrvm4HiUwV/vhpGhvJzfhV9CN7VhPC5y4tTfQicK82fYY6ifPz0iaNpUOmshU6+TAot/fsVQVgDJ4t7HXcA==",
+      "dependencies": {
+        "@turf/bbox": "^5.1.5",
+        "@turf/boolean-point-in-polygon": "^5.1.5",
+        "@turf/boolean-point-on-line": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/buffer": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/buffer/-/buffer-5.1.5.tgz",
+      "integrity": "sha512-U3LU0HF/JNFUNabpB5ArpNG6yPla7yR5XPrZvzZRH48vvbr/N0rkSRI0tJFRWTz7ntugVm9X0OD9Y382NTJRhA==",
+      "dependencies": {
+        "@turf/bbox": "^5.1.5",
+        "@turf/center": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "@turf/projection": "^5.1.5",
+        "d3-geo": "1.7.1",
+        "turf-jsts": "*"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/buffer/node_modules/@turf/projection": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/projection/-/projection-5.1.5.tgz",
+      "integrity": "sha512-TWKJDFeEKQhI4Ce1+2PuOSDggn4cnMibqyUoCpIW+4KxUC1R88SE3/SYomqzwxMn00O09glHSycPkGD5JzHd8A==",
+      "dependencies": {
+        "@turf/clone": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/center": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/center/-/center-5.1.5.tgz",
+      "integrity": "sha512-Dy1TvAv2oHKFddZcWqlVsanxurfcZV1Mmb1E+7H7GRKI+fXZTfRjwCdbiZCbO/tPwxt8jWQHWdLHn8E9lecc3A==",
+      "dependencies": {
+        "@turf/bbox": "^5.1.5",
+        "@turf/helpers": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/center-mean": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/center-mean/-/center-mean-5.1.5.tgz",
+      "integrity": "sha512-XdkBXzFUuyCqu5EPlBwgkv8FLA8pIGBnt7xy5cxxhxKOYLMrKqwMPPHPA84TjeQpNti0gH0CVuOk2r1f/Pp8iQ==",
+      "dependencies": {
+        "@turf/bbox": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/center-median": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/center-median/-/center-median-5.1.5.tgz",
+      "integrity": "sha512-M+O6bSNsIDKZ4utk/YzSOIg6W0isjLVWud+TCLWyrDCWTSERlSJlhOaVE1y7cObhG8nYBHvmszqZyoAY6nufQw==",
+      "dependencies": {
+        "@turf/center-mean": "^5.1.5",
+        "@turf/centroid": "^5.1.5",
+        "@turf/distance": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/center-of-mass": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/center-of-mass/-/center-of-mass-5.1.5.tgz",
+      "integrity": "sha512-UvI7q6GgW3afCVIDOyTRuLT54v9Xwv65Xudxh4FIT6w7HNU4KUBtTGnx0NuhODZcgvZgWVWVakhmIcHQTMjYYA==",
+      "dependencies": {
+        "@turf/centroid": "^5.1.5",
+        "@turf/convex": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/centroid": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/centroid/-/centroid-5.1.5.tgz",
+      "integrity": "sha512-0m9ZAZJB4YXLDxF2fWGqlE/g9Y68cebeWaRNOMN+e6Bti1fz0JKQuaEqJV+J8xOmODPHSMbZZ1SqSDVRgVHP2Q==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/circle": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/circle/-/circle-5.1.5.tgz",
+      "integrity": "sha512-CNaEtvp38Q+TSFJHdzdl5iYNjBFZRluRTFikIuEcennSeMJD60nP0dMubP58TR/QQn541eNDUyED90V4KuOjyQ==",
+      "dependencies": {
+        "@turf/destination": "^5.1.5",
+        "@turf/helpers": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/clean-coords": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/clean-coords/-/clean-coords-5.1.5.tgz",
+      "integrity": "sha512-xd/iSM0McVUxbu81KCKDqirCsYkKk3EAwpDjYI8vIQ+eKf/MLSdteRcm3PB7wo2y6JcYp4dMGv2cr9IP7V+dXQ==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/clone": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/clone/-/clone-5.1.5.tgz",
+      "integrity": "sha512-//pITsQ8xUdcQ9pVb4JqXiSqG4dos5Q9N4sYFoWghX21tfOV2dhc5TGqYOhnHrQS7RiKQL1vQ48kIK34gQ5oRg==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/clusters": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/clusters/-/clusters-5.1.5.tgz",
+      "integrity": "sha512-+rQe+g66xfbIXz58tveXQCDdE9hzqRJtDVSw5xth92TvCcL4J60ZKN8mHNUSn1ZZvpUHtVPe4dYcbtk5bW8fXQ==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/clusters-dbscan": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/clusters-dbscan/-/clusters-dbscan-5.1.5.tgz",
+      "integrity": "sha512-X3qLLHJkwMuv+xdWQ08NtOc6BgeqCKKSAltyyAZ7iImE65f0C+sW024DfHSbTMsZVXBFst2Q6RQY8RVUf3QBeQ==",
+      "dependencies": {
+        "@turf/clone": "^5.1.5",
+        "@turf/distance": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "density-clustering": "1.3.0"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/clusters-kmeans": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/clusters-kmeans/-/clusters-kmeans-5.1.5.tgz",
+      "integrity": "sha512-W6raiv9+fRgmJxCvKrpSacbLXzh7beZUk0A1pjF82Fv3CFTrXAJbgAyIbdlmgXezYSXhOT5NMUugnbkUy2oBZw==",
+      "dependencies": {
+        "@turf/clone": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "skmeans": "0.9.7"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/collect": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/collect/-/collect-5.1.5.tgz",
+      "integrity": "sha512-voFWu6EGPcNuIbAp43yvGf2Ip4/q8TTeWhOSJ2yDEHgOfbAwrNUwUJCclEjcUVsnc7ypKNrFn3/8bmR9tI0NQg==",
+      "dependencies": {
+        "@turf/bbox": "^5.1.5",
+        "@turf/boolean-point-in-polygon": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "rbush": "^2.0.1"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/combine": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/combine/-/combine-5.1.5.tgz",
+      "integrity": "sha512-/RqmfCvduHquINVyNmzKOcZtZjfaEHMhghgmj8MYnzepN3ro+E2QXoaQGGrQ7nChAvGgWPAvN8EveVSc1MvzPg==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/concave": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/concave/-/concave-5.1.5.tgz",
+      "integrity": "sha512-NvR5vmAunmgjEPjNzmvjLRvPcj7C6WuqCf+vu/aqyc4h2c1B/x399bDsSM64iFT+PYesFuoS1ZhJHWivXG8Y5g==",
+      "dependencies": {
+        "@turf/clone": "^5.1.5",
+        "@turf/distance": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "@turf/tin": "^5.1.5",
+        "topojson-client": "3.x",
+        "topojson-server": "3.x"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/convex": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/convex/-/convex-5.1.5.tgz",
+      "integrity": "sha512-ZEk4kIAoYR/mjO3C8rMe2StgmwhdwmbxVvNxg3udeahe2m0ZzbfkRC4HiJAaBgfR4TLJUAEewynESReTPwASBQ==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "concaveman": "*"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/destination": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/destination/-/destination-5.1.5.tgz",
+      "integrity": "sha512-EWwZnd4wxUO9d8UWzJt88jQlFf6W/6SE1930MMzzIR9o+RfqhrS/BL1eUDrg5I5drsymf6PZsK0j/V0q6jqkFQ==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/difference": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/difference/-/difference-5.1.5.tgz",
+      "integrity": "sha512-hIjiUHS8WiDfnmADQrhh6QcXWc3zNtjIpPQ5g/2NZ3k1mjnOdmGBVObkSJG4WEUNqyj3PKlsZ8W9xnSu+lLF1Q==",
+      "dependencies": {
+        "@turf/area": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "turf-jsts": "*"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/dissolve": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/dissolve/-/dissolve-5.1.5.tgz",
+      "integrity": "sha512-YcQgyp7pvhyZHCmbqqItVH6vHs43R9N0jzP/LnAG03oMiY4wves/BO1du6VDDbnJSXeRKf1afmY9tRGKYrm9ag==",
+      "dependencies": {
+        "@turf/boolean-overlap": "^5.1.5",
+        "@turf/clone": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/line-intersect": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "@turf/union": "^5.1.5",
+        "geojson-rbush": "2.1.0",
+        "get-closest": "*"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/distance": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/distance/-/distance-5.1.5.tgz",
+      "integrity": "sha512-sYCAgYZ2MjNKMtx17EijHlK9qHwpA0MuuQWbR4P30LTCl52UlG/reBfV899wKyF3HuDL9ux78IbILwOfeQ4zgA==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/ellipse": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/ellipse/-/ellipse-5.1.5.tgz",
+      "integrity": "sha512-oVTzEyDOi3d9isgB7Ah+YiOoUKB1eHMtMDXVl1oT+vC/T+6KR2aq+HjjbF11A0cjuh3VhjSWUZaS+2TYY0pu0w==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/rhumb-destination": "^5.1.5",
+        "@turf/transform-rotate": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/envelope": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/envelope/-/envelope-5.1.5.tgz",
+      "integrity": "sha512-Mxl5A2euAxq3RZVN65/MVyaO91kzGU8MJXfegPdep6SN4bONDadEp0olwW5qSRf2U3cJ8Jppl089X6AeifD3IA==",
+      "dependencies": {
+        "@turf/bbox": "^5.1.5",
+        "@turf/bbox-polygon": "^5.1.5",
+        "@turf/helpers": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/explode": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/explode/-/explode-5.1.5.tgz",
+      "integrity": "sha512-v/hC9DB9RKRW9/ZjnKoQelIp08JNa5wew0889465s//tfgY8+JEGkSGMag2L2NnVARWmzI/vlLgMK36qwkyDIA==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/flatten": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/flatten/-/flatten-5.1.5.tgz",
+      "integrity": "sha512-aagHz5tjHmOtb8eMb5fd10+HJwdlhkhsPql1vRXQNnpv0Q9xL/4SsbvXZ6lPqkRAjiZuy087mvaz+ERml76/jg==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/flip": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/flip/-/flip-5.1.5.tgz",
+      "integrity": "sha512-7+IYM3QQAkV4co3wjEmM726/OkXqUCCHWWyIqrI9hiK+LR628qkoqP1hk6rQ4vZJrAYuvSlK+FZnr24OtgY0cw==",
+      "dependencies": {
+        "@turf/clone": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/great-circle": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/great-circle/-/great-circle-5.1.5.tgz",
+      "integrity": "sha512-k6FWwlt+YCQoD5VS1NybQjriNL7apYHO+tm2HbIFQ85blPUX4IyLppHIFevfD/k+K2bJqhFCze8JNVMBwdrzVw==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/helpers": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-5.1.5.tgz",
+      "integrity": "sha512-/lF+JR+qNDHZ8bF9d+Cp58nxtZWJ3sqFe6n3u3Vpj+/0cqkjk4nXKYBSY0azm+GIYB5mWKxUXvuP/m0ZnKj1bw=="
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/hex-grid": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/hex-grid/-/hex-grid-5.1.5.tgz",
+      "integrity": "sha512-rwDL+DlUyxDNL1aVHIKKCmrt1131ZULF3irExYIO/um6/SwRzsBw+522/RcxD/mg/Shtrpozb6bz8aJJ/3RXHA==",
+      "dependencies": {
+        "@turf/distance": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/intersect": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/interpolate": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/interpolate/-/interpolate-5.1.5.tgz",
+      "integrity": "sha512-LfmvtIUWc3NVkqPkX6j3CAIjF7y1LAZqfDd+2Ii+0fN7XOOGMWcb1uiTTAb8zDQjhTsygcUYgaz6mMYDCWYKPg==",
+      "dependencies": {
+        "@turf/bbox": "^5.1.5",
+        "@turf/centroid": "^5.1.5",
+        "@turf/clone": "^5.1.5",
+        "@turf/distance": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/hex-grid": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "@turf/point-grid": "^5.1.5",
+        "@turf/square-grid": "^5.1.5",
+        "@turf/triangle-grid": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/intersect": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/@turf/intersect/-/intersect-5.1.6.tgz",
+      "integrity": "sha512-KXyNv/GXdoGAOy03qZF53rgtXC2tNhF/4jLwTKiVRrBQH6kcEpipGStdJ+QkYIlarQPa8f7I9UlVAB19et4MfQ==",
+      "dependencies": {
+        "@turf/clean-coords": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/truncate": "^5.1.5",
+        "turf-jsts": "*"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/invariant": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-5.1.5.tgz",
+      "integrity": "sha512-4elbC8GVQ8XxrnWLWpFFXTK3qnzIYzIVtSkJrY9eefA8WNZzwcwT3WGFY3xte4BB48o5oEjihjoJharWRis78w==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/isobands": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/isobands/-/isobands-5.1.5.tgz",
+      "integrity": "sha512-0n3NPfDYQyqjOch00I4hVCCqjKn9Sm+a8qlWOKbkuhmGa9dCDzsu2bZL0ahT+LjwlS4c8/owQXqe6KE2GWqT1Q==",
+      "dependencies": {
+        "@turf/area": "^5.1.5",
+        "@turf/bbox": "^5.1.5",
+        "@turf/boolean-point-in-polygon": "^5.1.5",
+        "@turf/explode": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/isolines": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/isolines/-/isolines-5.1.5.tgz",
+      "integrity": "sha512-Ehn5pJmiq4hAn2+2jPB2rLt3iF8DDp8zciw9z2pAt5IGVRU/K+x3z4aYG5ra5vbFB/E4G3aHr/X4QPIb9LCJtA==",
+      "dependencies": {
+        "@turf/bbox": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/kinks": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/kinks/-/kinks-5.1.5.tgz",
+      "integrity": "sha512-G38sC8/+MYqQpVocT3XahhV42cqEAVJAZwUND9YOfKJZfjUn7FKmWhPURs5py95me48UuI0C0jLLAMzBkUc2nQ==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/length": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/length/-/length-5.1.5.tgz",
+      "integrity": "sha512-0ryx68h512wCoNfwyksLdabxEfwkGNTPg61/QiY+QfGFUOUNhHbP+QimViFpwF5hyX7qmroaSHVclLUqyLGRbg==",
+      "dependencies": {
+        "@turf/distance": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/line-arc": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/line-arc/-/line-arc-5.1.5.tgz",
+      "integrity": "sha512-Kz5RX/qRIHVrGNqF3BRlD3ACuuCr0G5lpaVyPjNvN+vA7Q4bEDyWIYeqm3DdTn7X2MXitpTNgr2uvX4WoUy4yA==",
+      "dependencies": {
+        "@turf/circle": "^5.1.5",
+        "@turf/destination": "^5.1.5",
+        "@turf/helpers": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/line-chunk": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/line-chunk/-/line-chunk-5.1.5.tgz",
+      "integrity": "sha512-mKvTUMahnb3EsYUMI8tQmygsliQkgQ1FZAY915zoTrm+WV246loa+84+h7i5d8W2O8gGJWuY7jQTpM7toTeL5w==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/length": "^5.1.5",
+        "@turf/line-slice-along": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/line-intersect": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/line-intersect/-/line-intersect-5.1.5.tgz",
+      "integrity": "sha512-9DajJbHhJauLI2qVMnqZ7SeFsinFroVICOSUheODk7j5teuwNABuZ2Z6WmKATzEsPkEJ1iVykqB+F9vGMVKB6g==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/line-segment": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "geojson-rbush": "2.1.0"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/line-offset": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/line-offset/-/line-offset-5.1.5.tgz",
+      "integrity": "sha512-VccGDgFfBSiCTqrHdQgxD7Rs9lnJmDOJ5gqQRculKPsCNUyRFMYIZud7l2dTs83g66evfOwkZCrTxtSoBY3Jxg==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/line-overlap": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/line-overlap/-/line-overlap-5.1.5.tgz",
+      "integrity": "sha512-hMz3XARXEbfGwLF9WXyErqQjzhZYMKvGQwlPGOoth+2o9Uga9mfWfevduJvozJAE1MKxtFttMjIXMzcShW3O8A==",
+      "dependencies": {
+        "@turf/boolean-point-on-line": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/line-segment": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "@turf/nearest-point-on-line": "^5.1.5",
+        "geojson-rbush": "2.1.0"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/line-segment": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/line-segment/-/line-segment-5.1.5.tgz",
+      "integrity": "sha512-wIrRtWuLuLXhnSkqdVG1SDayTU0/CmZf+a+BBhEf0vFIsAedJnrY3a2cbCEvtfuk6ZsAbhOi7/kYiaR/F+rEzg==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/line-slice": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/line-slice/-/line-slice-5.1.5.tgz",
+      "integrity": "sha512-Fo+CuD+fj6T702BofHO+rgiXUgzCk0iO2JqMPtttMtgzfKkVTUOQoauMNS1LNNaG/7n/TfKGh5gRCEDRNaNwYA==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/nearest-point-on-line": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/line-slice-along": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/line-slice-along/-/line-slice-along-5.1.5.tgz",
+      "integrity": "sha512-yKvSDtULztLtlPIMowm9l8pS6XLAEpCPmrARZA0sIWFX8XrcSzISBaXZbiMMzg3nxQJMXfGIgWDk10B7+J8Tqw==",
+      "dependencies": {
+        "@turf/bearing": "^5.1.5",
+        "@turf/destination": "^5.1.5",
+        "@turf/distance": "^5.1.5",
+        "@turf/helpers": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/line-split": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/line-split/-/line-split-5.1.5.tgz",
+      "integrity": "sha512-gtUUBwZL3hcSu5MpqHTl68hgAJBNHcr1APDj8E5o6iX5xFX+wvl4ohQXyMs5HOATCI8Iy83wLuggcY6maNw7LQ==",
+      "dependencies": {
+        "@turf/bbox": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/line-intersect": "^5.1.5",
+        "@turf/line-segment": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "@turf/nearest-point-on-line": "^5.1.5",
+        "@turf/square": "^5.1.5",
+        "@turf/truncate": "^5.1.5",
+        "geojson-rbush": "2.1.0"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/line-to-polygon": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/line-to-polygon/-/line-to-polygon-5.1.5.tgz",
+      "integrity": "sha512-hGiDAPd6j986kZZLDgEAkVD7O6DmIqHQliBedspoKperPJOUJJzdzSnF6OAWSsxY+j8fWtQnIo5TTqdO/KfamA==",
+      "dependencies": {
+        "@turf/bbox": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/mask": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/mask/-/mask-5.1.5.tgz",
+      "integrity": "sha512-2eOuxA3ammZAGsjlsy/H7IpeJxjl3hrgkcKM6kTKRJGft4QyKwCxqQP7RN5j0zIYvAurgs9JOLe/dpd5sE5HXQ==",
+      "dependencies": {
+        "@turf/bbox": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "@turf/union": "^5.1.5",
+        "rbush": "^2.0.1"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/meta": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-5.1.6.tgz",
+      "integrity": "sha512-lv+6LCgoc3LVitQZ4TScN/8a/fcctq8bIoxBTMJVq4aU8xoHeY1851Dq8MCU37EzbH33utkx8/jENaQP+aeElg==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/midpoint": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/midpoint/-/midpoint-5.1.5.tgz",
+      "integrity": "sha512-0pDQAKHyK/zxlvUx3XNxwvqftf4sV32QxnHfqSs4AXaODUGUbPhzAD7aXgDScBeUOVLwpAzFRQfitUvUMTGC6A==",
+      "dependencies": {
+        "@turf/bearing": "^5.1.5",
+        "@turf/destination": "^5.1.5",
+        "@turf/distance": "^5.1.5",
+        "@turf/helpers": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/nearest-point": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/nearest-point/-/nearest-point-5.1.5.tgz",
+      "integrity": "sha512-tZQXI7OE7keNKK4OvYOJ5gervCEuu2pJ6psu59QW9yhe2Di3Gl+HAdLvVa6RZ8s5Fndr3u0JWKsmxve3fCxc9g==",
+      "dependencies": {
+        "@turf/clone": "^5.1.5",
+        "@turf/distance": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/nearest-point-on-line": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/nearest-point-on-line/-/nearest-point-on-line-5.1.5.tgz",
+      "integrity": "sha512-qT7BLTwToo8cq0oNoz921oLlRPJamyRg/rZgll+kNBadyDPmJI4W66riHcpM9RQcAJ6TPvDveIIBeGJH7iG88w==",
+      "dependencies": {
+        "@turf/bearing": "^5.1.5",
+        "@turf/destination": "^5.1.5",
+        "@turf/distance": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/line-intersect": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/nearest-point-to-line": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/@turf/nearest-point-to-line/-/nearest-point-to-line-5.1.6.tgz",
+      "integrity": "sha512-ZSvDIEiHhifn/vNwLXZI/E8xmEz5yBPqfUR7BVHRZrB1cP7jLhKZvkbidjG//uW8Fr1Ulc+PFOXczLspIcx/lw==",
+      "dependencies": {
+        "@turf/helpers": "6.x",
+        "@turf/invariant": "6.x",
+        "@turf/meta": "6.x",
+        "@turf/point-to-line-distance": "^5.1.5",
+        "object-assign": "*"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/nearest-point-to-line/node_modules/@turf/helpers": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.5.0.tgz",
+      "integrity": "sha512-VbI1dV5bLFzohYYdgqwikdMVpe7pJ9X3E+dlr425wa2/sMJqYDhTO++ec38/pcPvPE6oD9WEEeU3Xu3gza+VPw==",
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/nearest-point-to-line/node_modules/@turf/invariant": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-6.5.0.tgz",
+      "integrity": "sha512-Wv8PRNCtPD31UVbdJE/KVAWKe7l6US+lJItRR/HOEW3eh+U/JwRCSUl/KZ7bmjM/C+zLNoreM2TU6OoLACs4eg==",
+      "dependencies": {
+        "@turf/helpers": "^6.5.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/nearest-point-to-line/node_modules/@turf/meta": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-6.5.0.tgz",
+      "integrity": "sha512-RrArvtsV0vdsCBegoBtOalgdSOfkBrTJ07VkpiCnq/491W67hnMWmDu7e6Ztw0C3WldRYTXkg3SumfdzZxLBHA==",
+      "dependencies": {
+        "@turf/helpers": "^6.5.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/planepoint": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/planepoint/-/planepoint-5.1.5.tgz",
+      "integrity": "sha512-+Tp+SQ0Db2tqwLbxfXJPysT9IxcOHSMIin2dJb/j3Qn5+g0LRus6rczZl6dWNAIjqBPMawj/V/dZhMu6Q9O9wA==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/point-grid": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/point-grid/-/point-grid-5.1.5.tgz",
+      "integrity": "sha512-4ibozguP9YJ297Q7i9e8/ypGSycvt1re2jrPXTxeuZ4/L/NE5B1nOBLG+tw121nMjD+S+v2RWOtqD+FZ3Ga+ew==",
+      "dependencies": {
+        "@turf/boolean-within": "^5.1.5",
+        "@turf/distance": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/point-on-feature": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/point-on-feature/-/point-on-feature-5.1.5.tgz",
+      "integrity": "sha512-NTcpe5xZjybRh0aTL+7td1cm0s49GGbAt5u8Cdec4W9ix2PsehRcLUbmQIQsODN2kiVyUSpnhECIpsyN5MjX7A==",
+      "dependencies": {
+        "@turf/boolean-point-in-polygon": "^5.1.5",
+        "@turf/center": "^5.1.5",
+        "@turf/explode": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/nearest-point": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/point-to-line-distance": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/@turf/point-to-line-distance/-/point-to-line-distance-5.1.6.tgz",
+      "integrity": "sha512-PE3hiTeeDEi4ZLPtI8XAzFYW9nHo1EVsZGm/4ZVV8jo39d3X1oLVHxY3e1PkCmWwRapXy4QLqvnTQ7nU4wspNw==",
+      "dependencies": {
+        "@turf/bearing": "6.x",
+        "@turf/distance": "6.x",
+        "@turf/helpers": "6.x",
+        "@turf/invariant": "6.x",
+        "@turf/meta": "6.x",
+        "@turf/projection": "6.x",
+        "@turf/rhumb-bearing": "6.x",
+        "@turf/rhumb-distance": "6.x"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/point-to-line-distance/node_modules/@turf/bearing": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/bearing/-/bearing-6.5.0.tgz",
+      "integrity": "sha512-dxINYhIEMzgDOztyMZc20I7ssYVNEpSv04VbMo5YPQsqa80KO3TFvbuCahMsCAW5z8Tncc8dwBlEFrmRjJG33A==",
+      "dependencies": {
+        "@turf/helpers": "^6.5.0",
+        "@turf/invariant": "^6.5.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/point-to-line-distance/node_modules/@turf/distance": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/distance/-/distance-6.5.0.tgz",
+      "integrity": "sha512-xzykSLfoURec5qvQJcfifw/1mJa+5UwByZZ5TZ8iaqjGYN0vomhV9aiSLeYdUGtYRESZ+DYC/OzY+4RclZYgMg==",
+      "dependencies": {
+        "@turf/helpers": "^6.5.0",
+        "@turf/invariant": "^6.5.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/point-to-line-distance/node_modules/@turf/helpers": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.5.0.tgz",
+      "integrity": "sha512-VbI1dV5bLFzohYYdgqwikdMVpe7pJ9X3E+dlr425wa2/sMJqYDhTO++ec38/pcPvPE6oD9WEEeU3Xu3gza+VPw==",
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/point-to-line-distance/node_modules/@turf/invariant": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-6.5.0.tgz",
+      "integrity": "sha512-Wv8PRNCtPD31UVbdJE/KVAWKe7l6US+lJItRR/HOEW3eh+U/JwRCSUl/KZ7bmjM/C+zLNoreM2TU6OoLACs4eg==",
+      "dependencies": {
+        "@turf/helpers": "^6.5.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/point-to-line-distance/node_modules/@turf/meta": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-6.5.0.tgz",
+      "integrity": "sha512-RrArvtsV0vdsCBegoBtOalgdSOfkBrTJ07VkpiCnq/491W67hnMWmDu7e6Ztw0C3WldRYTXkg3SumfdzZxLBHA==",
+      "dependencies": {
+        "@turf/helpers": "^6.5.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/points-within-polygon": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/points-within-polygon/-/points-within-polygon-5.1.5.tgz",
+      "integrity": "sha512-nexe2AHVOY8wEBvs+CYSOp10NyOCkyZ1gkhIfsx0mzU8LPYBxD9ctjlKveheKh4AAldLcFupd/gSCBTKF1JS7A==",
+      "dependencies": {
+        "@turf/boolean-point-in-polygon": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/polygon-tangents": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/polygon-tangents/-/polygon-tangents-5.1.5.tgz",
+      "integrity": "sha512-uoZfKvFhl6rf0+CDWucru9fZ4mJB5Nsg37TS/7emrzjoVxXyOdxc/s1HFCjcKflMue7MjU/gT6AitJyrvdztDg==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/polygon-to-line": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/polygon-to-line/-/polygon-to-line-5.1.5.tgz",
+      "integrity": "sha512-kVo0owPqyccy5+qZGvaxGvMsYkgueKE2OOgX2UV/HyrXF3uI3TomK1txjApqeFsLvwuSANxesvVbYLrYiIwvGw==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/polygonize": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/polygonize/-/polygonize-5.1.5.tgz",
+      "integrity": "sha512-qzhtuzoOhldqZHm+ZPsWAs9nDpnkcDfsr+I0twmBF+wjAmo0HKiy9++sRQ4kEePpdwbMpF07D/NdZqYdmOJkGQ==",
+      "dependencies": {
+        "@turf/boolean-point-in-polygon": "^5.1.5",
+        "@turf/envelope": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/random": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/random/-/random-5.1.5.tgz",
+      "integrity": "sha512-oitpBwEb6YXqoUkIAOVMK+vrTPxUi2rqITmtTa/FBHr6J8TDwMWq6bufE3Gmgjxsss50O2ITJunOksxrouWGDQ==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/rewind": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/rewind/-/rewind-5.1.5.tgz",
+      "integrity": "sha512-Gdem7JXNu+G4hMllQHXRFRihJl3+pNl7qY+l4qhQFxq+hiU1cQoVFnyoleIqWKIrdK/i2YubaSwc3SCM7N5mMw==",
+      "dependencies": {
+        "@turf/boolean-clockwise": "^5.1.5",
+        "@turf/clone": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/rhumb-destination": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/rhumb-destination/-/rhumb-destination-5.1.5.tgz",
+      "integrity": "sha512-FdDUCSRfRAfsRmUaWjc76Wk32QYFJ6ckmSt6Ls6nEczO6eg/RgH1atF8CIYwR5ifl0Sk1rQzKiOSbpCyvVwQtw==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/sample": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/sample/-/sample-5.1.5.tgz",
+      "integrity": "sha512-EJE8yx+5x7rXejTzwBdOKpvT4tOCS0jwYJfycyTVDuLUSh2rETeYdjy7EeJbofnxm9CRPXqWQMPWIBKWxNTjow==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/sector": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/sector/-/sector-5.1.5.tgz",
+      "integrity": "sha512-dnWVifL3xWTqPPs8mfbbV9muDimNJtxRk4ogrkOLEDQ9ZZ1ALQMtQdYrg7kI3iC+L+LscV37tl+E8bayWyX8YA==",
+      "dependencies": {
+        "@turf/circle": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/line-arc": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/shortest-path": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/shortest-path/-/shortest-path-5.1.5.tgz",
+      "integrity": "sha512-ZGC8kSBj02GKWiI56Z5FNdrZ+fS0xyeOUNrPJWzudAlrv9wKGaRuWoIVRLGBu0j0OuO1HCwggic2c6WV/AhP0A==",
+      "dependencies": {
+        "@turf/bbox": "^5.1.5",
+        "@turf/bbox-polygon": "^5.1.5",
+        "@turf/boolean-point-in-polygon": "^5.1.5",
+        "@turf/clean-coords": "^5.1.5",
+        "@turf/distance": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "@turf/transform-scale": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/simplify": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/simplify/-/simplify-5.1.5.tgz",
+      "integrity": "sha512-IuBXEYdGSxbDOK3v949ajaPvs6NhjhTCTbKA6mSGuVbwGS7gzAuRiPSG4K/MvCVuQy3PKpkPcUGD+Uvt2Ov2PQ==",
+      "dependencies": {
+        "@turf/clean-coords": "^5.1.5",
+        "@turf/clone": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/square": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/square/-/square-5.1.5.tgz",
+      "integrity": "sha512-GgP2le9ksoW6vsVef5wFkjmWQiLPTJvcjGXqmoGWT4oMwDpvTJVQ91RBLs8qQbI4KACCQevz94N69klk3ah30Q==",
+      "dependencies": {
+        "@turf/distance": "^5.1.5",
+        "@turf/helpers": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/square-grid": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/square-grid/-/square-grid-5.1.5.tgz",
+      "integrity": "sha512-/pusEL4FmOwNWLcZfIXUyqUe0fOdkfaLO4wLhDlg/ZL1jWr/wZjhVlMU0tQ27kVN6dJTvlzNc9e0JWNw6yt2eQ==",
+      "dependencies": {
+        "@turf/boolean-contains": "^5.1.5",
+        "@turf/boolean-overlap": "^5.1.5",
+        "@turf/distance": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/intersect": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/standard-deviational-ellipse": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/standard-deviational-ellipse/-/standard-deviational-ellipse-5.1.5.tgz",
+      "integrity": "sha512-GOaxGKeeJAXV1H3Zz2fjQ5XeSbMKz1OkFRlTDBUipiAawe/9qTCF55L87I2ZPnO80B5BaaIT+AN2n0lMcAklzA==",
+      "dependencies": {
+        "@turf/center-mean": "^5.1.5",
+        "@turf/ellipse": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "@turf/points-within-polygon": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/tag": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/tag/-/tag-5.1.5.tgz",
+      "integrity": "sha512-XI3QFpva6tEsRnzFe1tJGdAAWlzjnXZPfJ9EKShTxEW8ZgPzm92b2odjiSAt2KuQusK82ltNfdw5Frlna5xGYQ==",
+      "dependencies": {
+        "@turf/boolean-point-in-polygon": "^5.1.5",
+        "@turf/clone": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/tesselate": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/tesselate/-/tesselate-5.1.5.tgz",
+      "integrity": "sha512-Rs/jAij26bcU4OzvFXkWDase1G3kSwyuuKZPFU0t7OmJu7eQJOR12WOZLGcVxd5oBlklo4xPE4EBQUqpQUsQgg==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "earcut": "^2.0.0"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/tin": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/tin/-/tin-5.1.5.tgz",
+      "integrity": "sha512-lDyCTYKoThBIKmkBxBMupqEpFbvTDAYuZIs8qrWnmux2vntSb8OFGi7ZbGPC6apS2hdVwZZae3YB88Tp+Fg+xw==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/transform-rotate": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/transform-rotate/-/transform-rotate-5.1.5.tgz",
+      "integrity": "sha512-3QKckeHKPXu5O5vEuT+nkszGDI6aknDD06ePb00+6H2oA7MZj7nj+fVQIJLs41MRb76IyKr4n5NvuKZU6idESA==",
+      "dependencies": {
+        "@turf/centroid": "^5.1.5",
+        "@turf/clone": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "@turf/rhumb-bearing": "^5.1.5",
+        "@turf/rhumb-destination": "^5.1.5",
+        "@turf/rhumb-distance": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/transform-rotate/node_modules/@turf/rhumb-bearing": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/rhumb-bearing/-/rhumb-bearing-5.1.5.tgz",
+      "integrity": "sha512-zXTl2khjwf7mx2D1uPo5vgpGgP4sM2VrKDbJNKyulPu4TO4ELt8x7FsKyCBlRTzzQf284t/xnNcZOfUbkkd70g==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/transform-rotate/node_modules/@turf/rhumb-distance": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/rhumb-distance/-/rhumb-distance-5.1.5.tgz",
+      "integrity": "sha512-AGA/ky5/BJJZtzQqafy2GvJfcUXSzCCrPFp8sDRPSKBoUN4gMBHN15ijDWYYLFoWFFj0urcauVx7chQlHZ/Qfw==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/transform-scale": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/transform-scale/-/transform-scale-5.1.5.tgz",
+      "integrity": "sha512-t1fCZX29ONA7DJiqCKA4YZy0+hCzhppWNOZhglBUv9vKHsWCFYZDUKfFInciaypUInsZyvm8eKxxixBVPdPGsw==",
+      "dependencies": {
+        "@turf/bbox": "^5.1.5",
+        "@turf/center": "^5.1.5",
+        "@turf/centroid": "^5.1.5",
+        "@turf/clone": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "@turf/rhumb-bearing": "^5.1.5",
+        "@turf/rhumb-destination": "^5.1.5",
+        "@turf/rhumb-distance": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/transform-scale/node_modules/@turf/rhumb-bearing": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/rhumb-bearing/-/rhumb-bearing-5.1.5.tgz",
+      "integrity": "sha512-zXTl2khjwf7mx2D1uPo5vgpGgP4sM2VrKDbJNKyulPu4TO4ELt8x7FsKyCBlRTzzQf284t/xnNcZOfUbkkd70g==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/transform-scale/node_modules/@turf/rhumb-distance": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/rhumb-distance/-/rhumb-distance-5.1.5.tgz",
+      "integrity": "sha512-AGA/ky5/BJJZtzQqafy2GvJfcUXSzCCrPFp8sDRPSKBoUN4gMBHN15ijDWYYLFoWFFj0urcauVx7chQlHZ/Qfw==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/transform-translate": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/transform-translate/-/transform-translate-5.1.5.tgz",
+      "integrity": "sha512-GdLFp7I7198oRQt311B8EjiqHupndeMSQ3Zclzki5L/niUrb1ptOIpo+mxSidSy03m+1Q5ylWlENroI1WBcQ3Q==",
+      "dependencies": {
+        "@turf/clone": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "@turf/rhumb-destination": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/triangle-grid": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/triangle-grid/-/triangle-grid-5.1.5.tgz",
+      "integrity": "sha512-jmCRcynI80xsVqd+0rv0YxP6mvZn4BAaJv8dwthg2T3WfHB9OD+rNUMohMuUY8HmI0zRT3s/Ypdy2Cdri9u/tw==",
+      "dependencies": {
+        "@turf/distance": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/intersect": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/truncate": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/truncate/-/truncate-5.1.5.tgz",
+      "integrity": "sha512-WjWGsRE6o1vUqULGb/O7O1eK6B4Eu6R/RBZWnF0rH0Os6WVel6tHktkeJdlKwz9WElIEO12wDIu6uKd54t7DDQ==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/turf": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/@turf/turf/-/turf-5.1.6.tgz",
+      "integrity": "sha512-NIjkt5jAbOrom+56ELw9ERZF6qsdf1xAIHyC9/PkDMIOQAxe7FVe2HaqbQ+x88F0q5FaSX4dtpIEf08md6h5/A==",
+      "dependencies": {
+        "@turf/along": "5.1.x",
+        "@turf/area": "5.1.x",
+        "@turf/bbox": "5.1.x",
+        "@turf/bbox-clip": "5.1.x",
+        "@turf/bbox-polygon": "5.1.x",
+        "@turf/bearing": "5.1.x",
+        "@turf/bezier-spline": "5.1.x",
+        "@turf/boolean-clockwise": "5.1.x",
+        "@turf/boolean-contains": "5.1.x",
+        "@turf/boolean-crosses": "5.1.x",
+        "@turf/boolean-disjoint": "5.1.x",
+        "@turf/boolean-equal": "5.1.x",
+        "@turf/boolean-overlap": "5.1.x",
+        "@turf/boolean-parallel": "5.1.x",
+        "@turf/boolean-point-in-polygon": "5.1.x",
+        "@turf/boolean-point-on-line": "5.1.x",
+        "@turf/boolean-within": "5.1.x",
+        "@turf/buffer": "5.1.x",
+        "@turf/center": "5.1.x",
+        "@turf/center-mean": "5.1.x",
+        "@turf/center-median": "5.1.x",
+        "@turf/center-of-mass": "5.1.x",
+        "@turf/centroid": "5.1.x",
+        "@turf/circle": "5.1.x",
+        "@turf/clean-coords": "5.1.x",
+        "@turf/clone": "5.1.x",
+        "@turf/clusters": "5.1.x",
+        "@turf/clusters-dbscan": "5.1.x",
+        "@turf/clusters-kmeans": "5.1.x",
+        "@turf/collect": "5.1.x",
+        "@turf/combine": "5.1.x",
+        "@turf/concave": "5.1.x",
+        "@turf/convex": "5.1.x",
+        "@turf/destination": "5.1.x",
+        "@turf/difference": "5.1.x",
+        "@turf/dissolve": "5.1.x",
+        "@turf/distance": "5.1.x",
+        "@turf/ellipse": "5.1.x",
+        "@turf/envelope": "5.1.x",
+        "@turf/explode": "5.1.x",
+        "@turf/flatten": "5.1.x",
+        "@turf/flip": "5.1.x",
+        "@turf/great-circle": "5.1.x",
+        "@turf/helpers": "5.1.x",
+        "@turf/hex-grid": "5.1.x",
+        "@turf/interpolate": "5.1.x",
+        "@turf/intersect": "5.1.x",
+        "@turf/invariant": "5.1.x",
+        "@turf/isobands": "5.1.x",
+        "@turf/isolines": "5.1.x",
+        "@turf/kinks": "5.1.x",
+        "@turf/length": "5.1.x",
+        "@turf/line-arc": "5.1.x",
+        "@turf/line-chunk": "5.1.x",
+        "@turf/line-intersect": "5.1.x",
+        "@turf/line-offset": "5.1.x",
+        "@turf/line-overlap": "5.1.x",
+        "@turf/line-segment": "5.1.x",
+        "@turf/line-slice": "5.1.x",
+        "@turf/line-slice-along": "5.1.x",
+        "@turf/line-split": "5.1.x",
+        "@turf/line-to-polygon": "5.1.x",
+        "@turf/mask": "5.1.x",
+        "@turf/meta": "5.1.x",
+        "@turf/midpoint": "5.1.x",
+        "@turf/nearest-point": "5.1.x",
+        "@turf/nearest-point-on-line": "5.1.x",
+        "@turf/nearest-point-to-line": "5.1.x",
+        "@turf/planepoint": "5.1.x",
+        "@turf/point-grid": "5.1.x",
+        "@turf/point-on-feature": "5.1.x",
+        "@turf/point-to-line-distance": "5.1.x",
+        "@turf/points-within-polygon": "5.1.x",
+        "@turf/polygon-tangents": "5.1.x",
+        "@turf/polygon-to-line": "5.1.x",
+        "@turf/polygonize": "5.1.x",
+        "@turf/projection": "5.1.x",
+        "@turf/random": "5.1.x",
+        "@turf/rewind": "5.1.x",
+        "@turf/rhumb-bearing": "5.1.x",
+        "@turf/rhumb-destination": "5.1.x",
+        "@turf/rhumb-distance": "5.1.x",
+        "@turf/sample": "5.1.x",
+        "@turf/sector": "5.1.x",
+        "@turf/shortest-path": "5.1.x",
+        "@turf/simplify": "5.1.x",
+        "@turf/square": "5.1.x",
+        "@turf/square-grid": "5.1.x",
+        "@turf/standard-deviational-ellipse": "5.1.x",
+        "@turf/tag": "5.1.x",
+        "@turf/tesselate": "5.1.x",
+        "@turf/tin": "5.1.x",
+        "@turf/transform-rotate": "5.1.x",
+        "@turf/transform-scale": "5.1.x",
+        "@turf/transform-translate": "5.1.x",
+        "@turf/triangle-grid": "5.1.x",
+        "@turf/truncate": "5.1.x",
+        "@turf/union": "5.1.x",
+        "@turf/unkink-polygon": "5.1.x",
+        "@turf/voronoi": "5.1.x"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/turf/node_modules/@turf/projection": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/projection/-/projection-5.1.5.tgz",
+      "integrity": "sha512-TWKJDFeEKQhI4Ce1+2PuOSDggn4cnMibqyUoCpIW+4KxUC1R88SE3/SYomqzwxMn00O09glHSycPkGD5JzHd8A==",
+      "dependencies": {
+        "@turf/clone": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/turf/node_modules/@turf/rhumb-bearing": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/rhumb-bearing/-/rhumb-bearing-5.1.5.tgz",
+      "integrity": "sha512-zXTl2khjwf7mx2D1uPo5vgpGgP4sM2VrKDbJNKyulPu4TO4ELt8x7FsKyCBlRTzzQf284t/xnNcZOfUbkkd70g==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/turf/node_modules/@turf/rhumb-distance": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/rhumb-distance/-/rhumb-distance-5.1.5.tgz",
+      "integrity": "sha512-AGA/ky5/BJJZtzQqafy2GvJfcUXSzCCrPFp8sDRPSKBoUN4gMBHN15ijDWYYLFoWFFj0urcauVx7chQlHZ/Qfw==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/union": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/union/-/union-5.1.5.tgz",
+      "integrity": "sha512-wBy1ixxC68PpsTeEDebk/EfnbI1Za5dCyY7xFY9NMzrtVEOy0l0lQ5syOsaqY4Ire+dbsDM66p2GGxmefoyIEA==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "turf-jsts": "*"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/unkink-polygon": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/unkink-polygon/-/unkink-polygon-5.1.5.tgz",
+      "integrity": "sha512-lzSrgsfSuyxIc4pkE2qyM2dsHxR992e6oItoZAT8G58A2Ef4qc5gRocmXPWZakGx41fQobegSo7wlo4I49wyHg==",
+      "dependencies": {
+        "@turf/area": "^5.1.5",
+        "@turf/boolean-point-in-polygon": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "rbush": "^2.0.1"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/voronoi": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/voronoi/-/voronoi-5.1.5.tgz",
+      "integrity": "sha512-Ad0HZAyYjOpMIZfDGV+Q+30M9PQHIirTyn32kWyTjEI1O6uhL5NOYjzSha4Sr77xOls3hGzKOj+JET7eDtOvsg==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "d3-voronoi": "1.1.2"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/geojson-rbush": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/geojson-rbush/-/geojson-rbush-2.1.0.tgz",
+      "integrity": "sha512-9HvLGhmAJBYkYYDdPlCrlfkKGwNW3PapiS0xPekdJLobkZE4rjtduKJXsO7+kUr97SsUlz4VtMcPuSIbjjJaQg==",
+      "dependencies": {
+        "@turf/helpers": "*",
+        "@turf/meta": "*",
+        "rbush": "*"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/jszip": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-2.6.1.tgz",
+      "integrity": "sha512-C4Z++nYQv+CudUkCWUdz+yKVhQiFJjuWSmRJ5Sg3d3/OzcJ6U4ooUYlmE3+rJXrVk89KWQaiJ9mPp/VLQ4D66g==",
+      "dependencies": {
+        "pako": "~1.0.2"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/lru-cache": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+      "integrity": "sha512-WpibWJ60c3AgAz8a2iYErDrcT2C7OmKnsWhIcHOjkUHFjkXncJhtLxNSqUmxRxRunpb5I8Vprd7aNSd2NtksJQ=="
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/shpjs": {
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/shpjs/-/shpjs-3.6.3.tgz",
+      "integrity": "sha512-wcR2S3WL/7RnEIm+YO+H/mZR9z9FCV46op+SZt+W5PtPs26Omb9U93f+EPI1DOpNKBuAIrWjHWh0SxlnBahJkg==",
+      "dependencies": {
+        "jszip": "^2.4.0",
+        "lie": "^3.0.1",
+        "lru-cache": "^2.7.0",
+        "parsedbf": "^1.1.0",
+        "proj4": "^2.1.4"
+      }
     },
     "node_modules/geostyler-style": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/geostyler-style/-/geostyler-style-5.1.0.tgz",
-      "integrity": "sha512-AJzQBomzuTGr01uRYvu7bocJTBB6vrgBdxsIoSHDATbnNF07XnAtsrbkjXlMsKaRnbqE2MGLhQqBmBx6C2Gubg==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/geostyler-style/-/geostyler-style-4.0.3.tgz",
+      "integrity": "sha512-51esHVZz86HFoSvKRA/Kfqd2Mytek88zgHSSt8ZZg30o4dqyZuQluxwIjqkSLp5hdvmA0nwCAyqxHy6aMyJ5lQ==",
       "dependencies": {
         "@types/lodash": "^4.14.168",
         "lodash": "^4.17.21"
@@ -33404,1429 +33904,438 @@
         "ol": "^6.5.0",
         "proj4": "^2.6.3",
         "rxjs": "^6.6.3"
+      }
+    },
+    "@commitlint/cli": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-17.0.2.tgz",
+      "integrity": "sha512-Axe89Js0YzGGd4gxo3JLlF7yIdjOVpG1LbOorGc6PfYF+drBh14PvarSDLzyd2TNqdylUCq9wb9/A88ZjIdyhA==",
+      "dev": true,
+      "requires": {
+        "@commitlint/format": "^17.0.0",
+        "@commitlint/lint": "^17.0.0",
+        "@commitlint/load": "^17.0.0",
+        "@commitlint/read": "^17.0.0",
+        "@commitlint/types": "^17.0.0",
+        "execa": "^5.0.0",
+        "lodash": "^4.17.19",
+        "resolve-from": "5.0.0",
+        "resolve-global": "1.0.0",
+        "yargs": "^17.0.0"
       },
       "dependencies": {
-        "@terrestris/ol-util": {
-          "version": "4.1.3",
-          "resolved": "https://registry.npmjs.org/@terrestris/ol-util/-/ol-util-4.1.3.tgz",
-          "integrity": "sha512-vTS7rXxOcvTpXQzRGR6DVldEYcbFjADQ9/ArSKeq9yCmmY9wb3dkeGKw+rN/dltu6oZbaswjsUsBQe060kiMOQ==",
-          "requires": {
-            "@terrestris/base-util": "^1.0.0",
-            "@turf/turf": "^5.1.6",
-            "lodash": "^4.17.20",
-            "proj4": "^2.7.0",
-            "shpjs": "^3.6.3"
-          }
-        },
-        "@turf/along": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/along/-/along-5.1.5.tgz",
-          "integrity": "sha512-N7BN1xvj6VWMe3UpjQDdVI0j0oY/EZ0bWgOgBXc4DlJ411uEsKCh6iBv0b2MSxQ3YUXEez3oc5FcgO9eVSs7iQ==",
-          "requires": {
-            "@turf/bearing": "^5.1.5",
-            "@turf/destination": "^5.1.5",
-            "@turf/distance": "^5.1.5",
-            "@turf/helpers": "^5.1.5"
-          }
-        },
-        "@turf/area": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/area/-/area-5.1.5.tgz",
-          "integrity": "sha512-lz16gqtvoz+j1jD9y3zj0Z5JnGNd3YfS0h+DQY1EcZymvi75Frm9i5YbEyth0RfxYZeOVufY7YIS3LXbJlI57g==",
-          "requires": {
-            "@turf/helpers": "^5.1.5",
-            "@turf/meta": "^5.1.5"
-          }
-        },
-        "@turf/bbox": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/bbox/-/bbox-5.1.5.tgz",
-          "integrity": "sha512-sYQU4fqsOYYJoD8UndC1n2hy8hV/lGIAmMLKWuzwmPUWqWOuSKWUcoRWDi9mGB0GvQQe/ow2IxZr8UaVaGz3sQ==",
-          "requires": {
-            "@turf/helpers": "^5.1.5",
-            "@turf/meta": "^5.1.5"
-          }
-        },
-        "@turf/bbox-clip": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/bbox-clip/-/bbox-clip-5.1.5.tgz",
-          "integrity": "sha512-KP64aoTvjcXxWHeM/Hs25vOQUBJgyJi7DlRVEoZofFJiR1kPnmDQrK7Xj+60lAk5cxuqzFnaPPxUk9Q+3v4p1Q==",
-          "requires": {
-            "@turf/helpers": "^5.1.5",
-            "@turf/invariant": "^5.1.5",
-            "lineclip": "^1.1.5"
-          }
-        },
-        "@turf/bbox-polygon": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/bbox-polygon/-/bbox-polygon-5.1.5.tgz",
-          "integrity": "sha512-PKVPF5LABFWZJud8KzzfesLGm5ihiwLbVa54HJjYySe6yqU/cr5q/qcN9TWptynOFhNktG1dr0KXVG0I2FZmfw==",
-          "requires": {
-            "@turf/helpers": "^5.1.5"
-          }
-        },
-        "@turf/bearing": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/bearing/-/bearing-5.1.5.tgz",
-          "integrity": "sha512-PrvZuJjnXGseB8hUatIjsrK3tgD3wttyRnVYXTbSfXYJZzaOfHDMplgO4lxXQp7diraZhGhCdSlbMvRRXItbUQ==",
-          "requires": {
-            "@turf/helpers": "^5.1.5",
-            "@turf/invariant": "^5.1.5"
-          }
-        },
-        "@turf/bezier-spline": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/bezier-spline/-/bezier-spline-5.1.5.tgz",
-          "integrity": "sha512-Y9NoComaGgFFFe9TWWE/cEMg2+EnBfU1R3112ec2wlx21ygDmFGXs4boOS71WM4ySwm/dbS3wxnbVxs4j68sKw==",
-          "requires": {
-            "@turf/helpers": "^5.1.5",
-            "@turf/invariant": "^5.1.5"
-          }
-        },
-        "@turf/boolean-clockwise": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/boolean-clockwise/-/boolean-clockwise-5.1.5.tgz",
-          "integrity": "sha512-FqbmEEOJ4rU4/2t7FKx0HUWmjFEVqR+NJrFP7ymGSjja2SQ7Q91nnBihGuT+yuHHl6ElMjQ3ttsB/eTmyCycxA==",
-          "requires": {
-            "@turf/helpers": "^5.1.5",
-            "@turf/invariant": "^5.1.5"
-          }
-        },
-        "@turf/boolean-contains": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/boolean-contains/-/boolean-contains-5.1.5.tgz",
-          "integrity": "sha512-x2HeEieeE9vBQrTdCuj4swnAXlpKbj9ChxMdDTV479c0m2gVmfea83ocmkj3w+9cvAaS63L8WqFyNVSmkwqljQ==",
-          "requires": {
-            "@turf/bbox": "^5.1.5",
-            "@turf/boolean-point-in-polygon": "^5.1.5",
-            "@turf/boolean-point-on-line": "^5.1.5",
-            "@turf/helpers": "^5.1.5",
-            "@turf/invariant": "^5.1.5"
-          }
-        },
-        "@turf/boolean-crosses": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/boolean-crosses/-/boolean-crosses-5.1.5.tgz",
-          "integrity": "sha512-odljvS7INr9k/8yXeyXQVry7GqEaChOmXawP0+SoTfGO3hgptiik59TLU/Yjn/SLFjE2Ul54Ga1jKFSL7vvH0Q==",
-          "requires": {
-            "@turf/boolean-point-in-polygon": "^5.1.5",
-            "@turf/helpers": "^5.1.5",
-            "@turf/invariant": "^5.1.5",
-            "@turf/line-intersect": "^5.1.5",
-            "@turf/polygon-to-line": "^5.1.5"
-          }
-        },
-        "@turf/boolean-disjoint": {
-          "version": "5.1.6",
-          "resolved": "https://registry.npmjs.org/@turf/boolean-disjoint/-/boolean-disjoint-5.1.6.tgz",
-          "integrity": "sha512-KHvUS6SBNYHBCLIJEJrg04pF5Oy+Fqn8V5G9U+9pti5vI9tyX7Ln2g7RSB7iJ1Cxsz8QAi6OukhXjEF2/8ZpGg==",
-          "requires": {
-            "@turf/boolean-point-in-polygon": "^5.1.5",
-            "@turf/helpers": "^5.1.5",
-            "@turf/line-intersect": "^5.1.5",
-            "@turf/meta": "^5.1.5",
-            "@turf/polygon-to-line": "^5.1.5"
-          }
-        },
-        "@turf/boolean-equal": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/boolean-equal/-/boolean-equal-5.1.5.tgz",
-          "integrity": "sha512-QEMbhDPV+J8PlRkMlVg6m5oSLaYUpOx2VUhDDekQ73FlpnhFBKRIlidhvHtS6CYnEw8d+/zA3h8Z18B4W4mq9Q==",
-          "requires": {
-            "@turf/clean-coords": "^5.1.5",
-            "@turf/helpers": "^5.1.5",
-            "@turf/invariant": "^5.1.5",
-            "geojson-equality": "0.1.6"
-          }
-        },
-        "@turf/boolean-overlap": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/boolean-overlap/-/boolean-overlap-5.1.5.tgz",
-          "integrity": "sha512-lizojgU559KME0G705YAgWVa0B3/tsWNobMzOEWDx/1rABWTojCY4uxw2rFxpOsP++s8JJHrGWXRLh1PbdAvRQ==",
-          "requires": {
-            "@turf/helpers": "^5.1.5",
-            "@turf/invariant": "^5.1.5",
-            "@turf/line-intersect": "^5.1.5",
-            "@turf/line-overlap": "^5.1.5",
-            "@turf/meta": "^5.1.5",
-            "geojson-equality": "0.1.6"
-          }
-        },
-        "@turf/boolean-parallel": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/boolean-parallel/-/boolean-parallel-5.1.5.tgz",
-          "integrity": "sha512-eeuGgDhnas3nJ22A/DD8aiH0kg9dSzbQChIMAqYRPGg3pWNK41aGAbeh5z0GO5N/EVFX1+ga5a0vsPmiRgQB5g==",
-          "requires": {
-            "@turf/clean-coords": "^5.1.5",
-            "@turf/helpers": "^5.1.5",
-            "@turf/line-segment": "^5.1.5",
-            "@turf/rhumb-bearing": "^5.1.5"
-          },
-          "dependencies": {
-            "@turf/rhumb-bearing": {
-              "version": "5.1.5",
-              "resolved": "https://registry.npmjs.org/@turf/rhumb-bearing/-/rhumb-bearing-5.1.5.tgz",
-              "integrity": "sha512-zXTl2khjwf7mx2D1uPo5vgpGgP4sM2VrKDbJNKyulPu4TO4ELt8x7FsKyCBlRTzzQf284t/xnNcZOfUbkkd70g==",
-              "requires": {
-                "@turf/helpers": "^5.1.5",
-                "@turf/invariant": "^5.1.5"
-              }
-            }
-          }
-        },
-        "@turf/boolean-point-in-polygon": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/boolean-point-in-polygon/-/boolean-point-in-polygon-5.1.5.tgz",
-          "integrity": "sha512-y+gbAhLmsAZH9uYhv+C68pu06mxsGIm3o7l0hzVkc/PXYdbkr+vKe7n7PfSN3xpVA3qoDLKLpCGOqeW8/ThaJA==",
-          "requires": {
-            "@turf/helpers": "^5.1.5",
-            "@turf/invariant": "^5.1.5"
-          }
-        },
-        "@turf/boolean-point-on-line": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/boolean-point-on-line/-/boolean-point-on-line-5.1.5.tgz",
-          "integrity": "sha512-Zf4d28mckV2tYfLWf2iqxQ8eeLZqi2HGimM26mptf1OCEIwc1wfkKgLRRJXMu94Crvd/pJxjRAjoYGcGliP6Vg==",
-          "requires": {
-            "@turf/helpers": "^5.1.5",
-            "@turf/invariant": "^5.1.5"
-          }
-        },
-        "@turf/boolean-within": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/boolean-within/-/boolean-within-5.1.5.tgz",
-          "integrity": "sha512-CNAtrvm4HiUwV/vhpGhvJzfhV9CN7VhPC5y4tTfQicK82fYY6ifPz0iaNpUOmshU6+TAot/fsVQVgDJ4t7HXcA==",
-          "requires": {
-            "@turf/bbox": "^5.1.5",
-            "@turf/boolean-point-in-polygon": "^5.1.5",
-            "@turf/boolean-point-on-line": "^5.1.5",
-            "@turf/helpers": "^5.1.5",
-            "@turf/invariant": "^5.1.5"
-          }
-        },
-        "@turf/buffer": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/buffer/-/buffer-5.1.5.tgz",
-          "integrity": "sha512-U3LU0HF/JNFUNabpB5ArpNG6yPla7yR5XPrZvzZRH48vvbr/N0rkSRI0tJFRWTz7ntugVm9X0OD9Y382NTJRhA==",
-          "requires": {
-            "@turf/bbox": "^5.1.5",
-            "@turf/center": "^5.1.5",
-            "@turf/helpers": "^5.1.5",
-            "@turf/meta": "^5.1.5",
-            "@turf/projection": "^5.1.5",
-            "d3-geo": "1.7.1",
-            "turf-jsts": "*"
-          },
-          "dependencies": {
-            "@turf/projection": {
-              "version": "5.1.5",
-              "resolved": "https://registry.npmjs.org/@turf/projection/-/projection-5.1.5.tgz",
-              "integrity": "sha512-TWKJDFeEKQhI4Ce1+2PuOSDggn4cnMibqyUoCpIW+4KxUC1R88SE3/SYomqzwxMn00O09glHSycPkGD5JzHd8A==",
-              "requires": {
-                "@turf/clone": "^5.1.5",
-                "@turf/helpers": "^5.1.5",
-                "@turf/meta": "^5.1.5"
-              }
-            }
-          }
-        },
-        "@turf/center": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/center/-/center-5.1.5.tgz",
-          "integrity": "sha512-Dy1TvAv2oHKFddZcWqlVsanxurfcZV1Mmb1E+7H7GRKI+fXZTfRjwCdbiZCbO/tPwxt8jWQHWdLHn8E9lecc3A==",
-          "requires": {
-            "@turf/bbox": "^5.1.5",
-            "@turf/helpers": "^5.1.5"
-          }
-        },
-        "@turf/center-mean": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/center-mean/-/center-mean-5.1.5.tgz",
-          "integrity": "sha512-XdkBXzFUuyCqu5EPlBwgkv8FLA8pIGBnt7xy5cxxhxKOYLMrKqwMPPHPA84TjeQpNti0gH0CVuOk2r1f/Pp8iQ==",
-          "requires": {
-            "@turf/bbox": "^5.1.5",
-            "@turf/helpers": "^5.1.5",
-            "@turf/meta": "^5.1.5"
-          }
-        },
-        "@turf/center-median": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/center-median/-/center-median-5.1.5.tgz",
-          "integrity": "sha512-M+O6bSNsIDKZ4utk/YzSOIg6W0isjLVWud+TCLWyrDCWTSERlSJlhOaVE1y7cObhG8nYBHvmszqZyoAY6nufQw==",
-          "requires": {
-            "@turf/center-mean": "^5.1.5",
-            "@turf/centroid": "^5.1.5",
-            "@turf/distance": "^5.1.5",
-            "@turf/helpers": "^5.1.5",
-            "@turf/meta": "^5.1.5"
-          }
-        },
-        "@turf/center-of-mass": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/center-of-mass/-/center-of-mass-5.1.5.tgz",
-          "integrity": "sha512-UvI7q6GgW3afCVIDOyTRuLT54v9Xwv65Xudxh4FIT6w7HNU4KUBtTGnx0NuhODZcgvZgWVWVakhmIcHQTMjYYA==",
-          "requires": {
-            "@turf/centroid": "^5.1.5",
-            "@turf/convex": "^5.1.5",
-            "@turf/helpers": "^5.1.5",
-            "@turf/invariant": "^5.1.5",
-            "@turf/meta": "^5.1.5"
-          }
-        },
-        "@turf/centroid": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/centroid/-/centroid-5.1.5.tgz",
-          "integrity": "sha512-0m9ZAZJB4YXLDxF2fWGqlE/g9Y68cebeWaRNOMN+e6Bti1fz0JKQuaEqJV+J8xOmODPHSMbZZ1SqSDVRgVHP2Q==",
-          "requires": {
-            "@turf/helpers": "^5.1.5",
-            "@turf/meta": "^5.1.5"
-          }
-        },
-        "@turf/circle": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/circle/-/circle-5.1.5.tgz",
-          "integrity": "sha512-CNaEtvp38Q+TSFJHdzdl5iYNjBFZRluRTFikIuEcennSeMJD60nP0dMubP58TR/QQn541eNDUyED90V4KuOjyQ==",
-          "requires": {
-            "@turf/destination": "^5.1.5",
-            "@turf/helpers": "^5.1.5"
-          }
-        },
-        "@turf/clean-coords": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/clean-coords/-/clean-coords-5.1.5.tgz",
-          "integrity": "sha512-xd/iSM0McVUxbu81KCKDqirCsYkKk3EAwpDjYI8vIQ+eKf/MLSdteRcm3PB7wo2y6JcYp4dMGv2cr9IP7V+dXQ==",
-          "requires": {
-            "@turf/helpers": "^5.1.5",
-            "@turf/invariant": "^5.1.5"
-          }
-        },
-        "@turf/clone": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/clone/-/clone-5.1.5.tgz",
-          "integrity": "sha512-//pITsQ8xUdcQ9pVb4JqXiSqG4dos5Q9N4sYFoWghX21tfOV2dhc5TGqYOhnHrQS7RiKQL1vQ48kIK34gQ5oRg==",
-          "requires": {
-            "@turf/helpers": "^5.1.5"
-          }
-        },
-        "@turf/clusters": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/clusters/-/clusters-5.1.5.tgz",
-          "integrity": "sha512-+rQe+g66xfbIXz58tveXQCDdE9hzqRJtDVSw5xth92TvCcL4J60ZKN8mHNUSn1ZZvpUHtVPe4dYcbtk5bW8fXQ==",
-          "requires": {
-            "@turf/helpers": "^5.1.5",
-            "@turf/meta": "^5.1.5"
-          }
-        },
-        "@turf/clusters-dbscan": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/clusters-dbscan/-/clusters-dbscan-5.1.5.tgz",
-          "integrity": "sha512-X3qLLHJkwMuv+xdWQ08NtOc6BgeqCKKSAltyyAZ7iImE65f0C+sW024DfHSbTMsZVXBFst2Q6RQY8RVUf3QBeQ==",
-          "requires": {
-            "@turf/clone": "^5.1.5",
-            "@turf/distance": "^5.1.5",
-            "@turf/helpers": "^5.1.5",
-            "@turf/invariant": "^5.1.5",
-            "@turf/meta": "^5.1.5",
-            "density-clustering": "1.3.0"
-          }
-        },
-        "@turf/clusters-kmeans": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/clusters-kmeans/-/clusters-kmeans-5.1.5.tgz",
-          "integrity": "sha512-W6raiv9+fRgmJxCvKrpSacbLXzh7beZUk0A1pjF82Fv3CFTrXAJbgAyIbdlmgXezYSXhOT5NMUugnbkUy2oBZw==",
-          "requires": {
-            "@turf/clone": "^5.1.5",
-            "@turf/helpers": "^5.1.5",
-            "@turf/invariant": "^5.1.5",
-            "@turf/meta": "^5.1.5",
-            "skmeans": "0.9.7"
-          }
-        },
-        "@turf/collect": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/collect/-/collect-5.1.5.tgz",
-          "integrity": "sha512-voFWu6EGPcNuIbAp43yvGf2Ip4/q8TTeWhOSJ2yDEHgOfbAwrNUwUJCclEjcUVsnc7ypKNrFn3/8bmR9tI0NQg==",
-          "requires": {
-            "@turf/bbox": "^5.1.5",
-            "@turf/boolean-point-in-polygon": "^5.1.5",
-            "@turf/helpers": "^5.1.5",
-            "rbush": "^2.0.1"
-          }
-        },
-        "@turf/combine": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/combine/-/combine-5.1.5.tgz",
-          "integrity": "sha512-/RqmfCvduHquINVyNmzKOcZtZjfaEHMhghgmj8MYnzepN3ro+E2QXoaQGGrQ7nChAvGgWPAvN8EveVSc1MvzPg==",
-          "requires": {
-            "@turf/helpers": "^5.1.5",
-            "@turf/meta": "^5.1.5"
-          }
-        },
-        "@turf/concave": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/concave/-/concave-5.1.5.tgz",
-          "integrity": "sha512-NvR5vmAunmgjEPjNzmvjLRvPcj7C6WuqCf+vu/aqyc4h2c1B/x399bDsSM64iFT+PYesFuoS1ZhJHWivXG8Y5g==",
-          "requires": {
-            "@turf/clone": "^5.1.5",
-            "@turf/distance": "^5.1.5",
-            "@turf/helpers": "^5.1.5",
-            "@turf/invariant": "^5.1.5",
-            "@turf/meta": "^5.1.5",
-            "@turf/tin": "^5.1.5",
-            "topojson-client": "3.x",
-            "topojson-server": "3.x"
-          }
-        },
-        "@turf/convex": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/convex/-/convex-5.1.5.tgz",
-          "integrity": "sha512-ZEk4kIAoYR/mjO3C8rMe2StgmwhdwmbxVvNxg3udeahe2m0ZzbfkRC4HiJAaBgfR4TLJUAEewynESReTPwASBQ==",
-          "requires": {
-            "@turf/helpers": "^5.1.5",
-            "@turf/meta": "^5.1.5",
-            "concaveman": "*"
-          }
-        },
-        "@turf/destination": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/destination/-/destination-5.1.5.tgz",
-          "integrity": "sha512-EWwZnd4wxUO9d8UWzJt88jQlFf6W/6SE1930MMzzIR9o+RfqhrS/BL1eUDrg5I5drsymf6PZsK0j/V0q6jqkFQ==",
-          "requires": {
-            "@turf/helpers": "^5.1.5",
-            "@turf/invariant": "^5.1.5"
-          }
-        },
-        "@turf/difference": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/difference/-/difference-5.1.5.tgz",
-          "integrity": "sha512-hIjiUHS8WiDfnmADQrhh6QcXWc3zNtjIpPQ5g/2NZ3k1mjnOdmGBVObkSJG4WEUNqyj3PKlsZ8W9xnSu+lLF1Q==",
-          "requires": {
-            "@turf/area": "^5.1.5",
-            "@turf/helpers": "^5.1.5",
-            "@turf/invariant": "^5.1.5",
-            "@turf/meta": "^5.1.5",
-            "turf-jsts": "*"
-          }
-        },
-        "@turf/dissolve": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/dissolve/-/dissolve-5.1.5.tgz",
-          "integrity": "sha512-YcQgyp7pvhyZHCmbqqItVH6vHs43R9N0jzP/LnAG03oMiY4wves/BO1du6VDDbnJSXeRKf1afmY9tRGKYrm9ag==",
-          "requires": {
-            "@turf/boolean-overlap": "^5.1.5",
-            "@turf/clone": "^5.1.5",
-            "@turf/helpers": "^5.1.5",
-            "@turf/invariant": "^5.1.5",
-            "@turf/line-intersect": "^5.1.5",
-            "@turf/meta": "^5.1.5",
-            "@turf/union": "^5.1.5",
-            "geojson-rbush": "2.1.0",
-            "get-closest": "*"
-          }
-        },
-        "@turf/distance": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/distance/-/distance-5.1.5.tgz",
-          "integrity": "sha512-sYCAgYZ2MjNKMtx17EijHlK9qHwpA0MuuQWbR4P30LTCl52UlG/reBfV899wKyF3HuDL9ux78IbILwOfeQ4zgA==",
-          "requires": {
-            "@turf/helpers": "^5.1.5",
-            "@turf/invariant": "^5.1.5"
-          }
-        },
-        "@turf/ellipse": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/ellipse/-/ellipse-5.1.5.tgz",
-          "integrity": "sha512-oVTzEyDOi3d9isgB7Ah+YiOoUKB1eHMtMDXVl1oT+vC/T+6KR2aq+HjjbF11A0cjuh3VhjSWUZaS+2TYY0pu0w==",
-          "requires": {
-            "@turf/helpers": "^5.1.5",
-            "@turf/invariant": "^5.1.5",
-            "@turf/rhumb-destination": "^5.1.5",
-            "@turf/transform-rotate": "^5.1.5"
-          }
-        },
-        "@turf/envelope": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/envelope/-/envelope-5.1.5.tgz",
-          "integrity": "sha512-Mxl5A2euAxq3RZVN65/MVyaO91kzGU8MJXfegPdep6SN4bONDadEp0olwW5qSRf2U3cJ8Jppl089X6AeifD3IA==",
-          "requires": {
-            "@turf/bbox": "^5.1.5",
-            "@turf/bbox-polygon": "^5.1.5",
-            "@turf/helpers": "^5.1.5"
-          }
-        },
-        "@turf/explode": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/explode/-/explode-5.1.5.tgz",
-          "integrity": "sha512-v/hC9DB9RKRW9/ZjnKoQelIp08JNa5wew0889465s//tfgY8+JEGkSGMag2L2NnVARWmzI/vlLgMK36qwkyDIA==",
-          "requires": {
-            "@turf/helpers": "^5.1.5",
-            "@turf/meta": "^5.1.5"
-          }
-        },
-        "@turf/flatten": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/flatten/-/flatten-5.1.5.tgz",
-          "integrity": "sha512-aagHz5tjHmOtb8eMb5fd10+HJwdlhkhsPql1vRXQNnpv0Q9xL/4SsbvXZ6lPqkRAjiZuy087mvaz+ERml76/jg==",
-          "requires": {
-            "@turf/helpers": "^5.1.5",
-            "@turf/meta": "^5.1.5"
-          }
-        },
-        "@turf/flip": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/flip/-/flip-5.1.5.tgz",
-          "integrity": "sha512-7+IYM3QQAkV4co3wjEmM726/OkXqUCCHWWyIqrI9hiK+LR628qkoqP1hk6rQ4vZJrAYuvSlK+FZnr24OtgY0cw==",
-          "requires": {
-            "@turf/clone": "^5.1.5",
-            "@turf/helpers": "^5.1.5",
-            "@turf/meta": "^5.1.5"
-          }
-        },
-        "@turf/great-circle": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/great-circle/-/great-circle-5.1.5.tgz",
-          "integrity": "sha512-k6FWwlt+YCQoD5VS1NybQjriNL7apYHO+tm2HbIFQ85blPUX4IyLppHIFevfD/k+K2bJqhFCze8JNVMBwdrzVw==",
-          "requires": {
-            "@turf/helpers": "^5.1.5",
-            "@turf/invariant": "^5.1.5"
-          }
-        },
-        "@turf/helpers": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-5.1.5.tgz",
-          "integrity": "sha512-/lF+JR+qNDHZ8bF9d+Cp58nxtZWJ3sqFe6n3u3Vpj+/0cqkjk4nXKYBSY0azm+GIYB5mWKxUXvuP/m0ZnKj1bw=="
-        },
-        "@turf/hex-grid": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/hex-grid/-/hex-grid-5.1.5.tgz",
-          "integrity": "sha512-rwDL+DlUyxDNL1aVHIKKCmrt1131ZULF3irExYIO/um6/SwRzsBw+522/RcxD/mg/Shtrpozb6bz8aJJ/3RXHA==",
-          "requires": {
-            "@turf/distance": "^5.1.5",
-            "@turf/helpers": "^5.1.5",
-            "@turf/intersect": "^5.1.5",
-            "@turf/invariant": "^5.1.5"
-          }
-        },
-        "@turf/interpolate": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/interpolate/-/interpolate-5.1.5.tgz",
-          "integrity": "sha512-LfmvtIUWc3NVkqPkX6j3CAIjF7y1LAZqfDd+2Ii+0fN7XOOGMWcb1uiTTAb8zDQjhTsygcUYgaz6mMYDCWYKPg==",
-          "requires": {
-            "@turf/bbox": "^5.1.5",
-            "@turf/centroid": "^5.1.5",
-            "@turf/clone": "^5.1.5",
-            "@turf/distance": "^5.1.5",
-            "@turf/helpers": "^5.1.5",
-            "@turf/hex-grid": "^5.1.5",
-            "@turf/invariant": "^5.1.5",
-            "@turf/meta": "^5.1.5",
-            "@turf/point-grid": "^5.1.5",
-            "@turf/square-grid": "^5.1.5",
-            "@turf/triangle-grid": "^5.1.5"
-          }
-        },
-        "@turf/intersect": {
-          "version": "5.1.6",
-          "resolved": "https://registry.npmjs.org/@turf/intersect/-/intersect-5.1.6.tgz",
-          "integrity": "sha512-KXyNv/GXdoGAOy03qZF53rgtXC2tNhF/4jLwTKiVRrBQH6kcEpipGStdJ+QkYIlarQPa8f7I9UlVAB19et4MfQ==",
-          "requires": {
-            "@turf/clean-coords": "^5.1.5",
-            "@turf/helpers": "^5.1.5",
-            "@turf/invariant": "^5.1.5",
-            "@turf/truncate": "^5.1.5",
-            "turf-jsts": "*"
-          }
-        },
-        "@turf/invariant": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-5.1.5.tgz",
-          "integrity": "sha512-4elbC8GVQ8XxrnWLWpFFXTK3qnzIYzIVtSkJrY9eefA8WNZzwcwT3WGFY3xte4BB48o5oEjihjoJharWRis78w==",
-          "requires": {
-            "@turf/helpers": "^5.1.5"
-          }
-        },
-        "@turf/isobands": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/isobands/-/isobands-5.1.5.tgz",
-          "integrity": "sha512-0n3NPfDYQyqjOch00I4hVCCqjKn9Sm+a8qlWOKbkuhmGa9dCDzsu2bZL0ahT+LjwlS4c8/owQXqe6KE2GWqT1Q==",
-          "requires": {
-            "@turf/area": "^5.1.5",
-            "@turf/bbox": "^5.1.5",
-            "@turf/boolean-point-in-polygon": "^5.1.5",
-            "@turf/explode": "^5.1.5",
-            "@turf/helpers": "^5.1.5",
-            "@turf/invariant": "^5.1.5",
-            "@turf/meta": "^5.1.5"
-          }
-        },
-        "@turf/isolines": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/isolines/-/isolines-5.1.5.tgz",
-          "integrity": "sha512-Ehn5pJmiq4hAn2+2jPB2rLt3iF8DDp8zciw9z2pAt5IGVRU/K+x3z4aYG5ra5vbFB/E4G3aHr/X4QPIb9LCJtA==",
-          "requires": {
-            "@turf/bbox": "^5.1.5",
-            "@turf/helpers": "^5.1.5",
-            "@turf/invariant": "^5.1.5",
-            "@turf/meta": "^5.1.5"
-          }
-        },
-        "@turf/kinks": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/kinks/-/kinks-5.1.5.tgz",
-          "integrity": "sha512-G38sC8/+MYqQpVocT3XahhV42cqEAVJAZwUND9YOfKJZfjUn7FKmWhPURs5py95me48UuI0C0jLLAMzBkUc2nQ==",
-          "requires": {
-            "@turf/helpers": "^5.1.5"
-          }
-        },
-        "@turf/length": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/length/-/length-5.1.5.tgz",
-          "integrity": "sha512-0ryx68h512wCoNfwyksLdabxEfwkGNTPg61/QiY+QfGFUOUNhHbP+QimViFpwF5hyX7qmroaSHVclLUqyLGRbg==",
-          "requires": {
-            "@turf/distance": "^5.1.5",
-            "@turf/helpers": "^5.1.5",
-            "@turf/meta": "^5.1.5"
-          }
-        },
-        "@turf/line-arc": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/line-arc/-/line-arc-5.1.5.tgz",
-          "integrity": "sha512-Kz5RX/qRIHVrGNqF3BRlD3ACuuCr0G5lpaVyPjNvN+vA7Q4bEDyWIYeqm3DdTn7X2MXitpTNgr2uvX4WoUy4yA==",
-          "requires": {
-            "@turf/circle": "^5.1.5",
-            "@turf/destination": "^5.1.5",
-            "@turf/helpers": "^5.1.5"
-          }
-        },
-        "@turf/line-chunk": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/line-chunk/-/line-chunk-5.1.5.tgz",
-          "integrity": "sha512-mKvTUMahnb3EsYUMI8tQmygsliQkgQ1FZAY915zoTrm+WV246loa+84+h7i5d8W2O8gGJWuY7jQTpM7toTeL5w==",
-          "requires": {
-            "@turf/helpers": "^5.1.5",
-            "@turf/length": "^5.1.5",
-            "@turf/line-slice-along": "^5.1.5",
-            "@turf/meta": "^5.1.5"
-          }
-        },
-        "@turf/line-intersect": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/line-intersect/-/line-intersect-5.1.5.tgz",
-          "integrity": "sha512-9DajJbHhJauLI2qVMnqZ7SeFsinFroVICOSUheODk7j5teuwNABuZ2Z6WmKATzEsPkEJ1iVykqB+F9vGMVKB6g==",
-          "requires": {
-            "@turf/helpers": "^5.1.5",
-            "@turf/invariant": "^5.1.5",
-            "@turf/line-segment": "^5.1.5",
-            "@turf/meta": "^5.1.5",
-            "geojson-rbush": "2.1.0"
-          }
-        },
-        "@turf/line-offset": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/line-offset/-/line-offset-5.1.5.tgz",
-          "integrity": "sha512-VccGDgFfBSiCTqrHdQgxD7Rs9lnJmDOJ5gqQRculKPsCNUyRFMYIZud7l2dTs83g66evfOwkZCrTxtSoBY3Jxg==",
-          "requires": {
-            "@turf/helpers": "^5.1.5",
-            "@turf/invariant": "^5.1.5",
-            "@turf/meta": "^5.1.5"
-          }
-        },
-        "@turf/line-overlap": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/line-overlap/-/line-overlap-5.1.5.tgz",
-          "integrity": "sha512-hMz3XARXEbfGwLF9WXyErqQjzhZYMKvGQwlPGOoth+2o9Uga9mfWfevduJvozJAE1MKxtFttMjIXMzcShW3O8A==",
-          "requires": {
-            "@turf/boolean-point-on-line": "^5.1.5",
-            "@turf/helpers": "^5.1.5",
-            "@turf/invariant": "^5.1.5",
-            "@turf/line-segment": "^5.1.5",
-            "@turf/meta": "^5.1.5",
-            "@turf/nearest-point-on-line": "^5.1.5",
-            "geojson-rbush": "2.1.0"
-          }
-        },
-        "@turf/line-segment": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/line-segment/-/line-segment-5.1.5.tgz",
-          "integrity": "sha512-wIrRtWuLuLXhnSkqdVG1SDayTU0/CmZf+a+BBhEf0vFIsAedJnrY3a2cbCEvtfuk6ZsAbhOi7/kYiaR/F+rEzg==",
-          "requires": {
-            "@turf/helpers": "^5.1.5",
-            "@turf/invariant": "^5.1.5",
-            "@turf/meta": "^5.1.5"
-          }
-        },
-        "@turf/line-slice": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/line-slice/-/line-slice-5.1.5.tgz",
-          "integrity": "sha512-Fo+CuD+fj6T702BofHO+rgiXUgzCk0iO2JqMPtttMtgzfKkVTUOQoauMNS1LNNaG/7n/TfKGh5gRCEDRNaNwYA==",
-          "requires": {
-            "@turf/helpers": "^5.1.5",
-            "@turf/invariant": "^5.1.5",
-            "@turf/nearest-point-on-line": "^5.1.5"
-          }
-        },
-        "@turf/line-slice-along": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/line-slice-along/-/line-slice-along-5.1.5.tgz",
-          "integrity": "sha512-yKvSDtULztLtlPIMowm9l8pS6XLAEpCPmrARZA0sIWFX8XrcSzISBaXZbiMMzg3nxQJMXfGIgWDk10B7+J8Tqw==",
-          "requires": {
-            "@turf/bearing": "^5.1.5",
-            "@turf/destination": "^5.1.5",
-            "@turf/distance": "^5.1.5",
-            "@turf/helpers": "^5.1.5"
-          }
-        },
-        "@turf/line-split": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/line-split/-/line-split-5.1.5.tgz",
-          "integrity": "sha512-gtUUBwZL3hcSu5MpqHTl68hgAJBNHcr1APDj8E5o6iX5xFX+wvl4ohQXyMs5HOATCI8Iy83wLuggcY6maNw7LQ==",
-          "requires": {
-            "@turf/bbox": "^5.1.5",
-            "@turf/helpers": "^5.1.5",
-            "@turf/invariant": "^5.1.5",
-            "@turf/line-intersect": "^5.1.5",
-            "@turf/line-segment": "^5.1.5",
-            "@turf/meta": "^5.1.5",
-            "@turf/nearest-point-on-line": "^5.1.5",
-            "@turf/square": "^5.1.5",
-            "@turf/truncate": "^5.1.5",
-            "geojson-rbush": "2.1.0"
-          }
-        },
-        "@turf/line-to-polygon": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/line-to-polygon/-/line-to-polygon-5.1.5.tgz",
-          "integrity": "sha512-hGiDAPd6j986kZZLDgEAkVD7O6DmIqHQliBedspoKperPJOUJJzdzSnF6OAWSsxY+j8fWtQnIo5TTqdO/KfamA==",
-          "requires": {
-            "@turf/bbox": "^5.1.5",
-            "@turf/helpers": "^5.1.5",
-            "@turf/invariant": "^5.1.5"
-          }
-        },
-        "@turf/mask": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/mask/-/mask-5.1.5.tgz",
-          "integrity": "sha512-2eOuxA3ammZAGsjlsy/H7IpeJxjl3hrgkcKM6kTKRJGft4QyKwCxqQP7RN5j0zIYvAurgs9JOLe/dpd5sE5HXQ==",
-          "requires": {
-            "@turf/bbox": "^5.1.5",
-            "@turf/helpers": "^5.1.5",
-            "@turf/meta": "^5.1.5",
-            "@turf/union": "^5.1.5",
-            "rbush": "^2.0.1"
-          }
-        },
-        "@turf/meta": {
-          "version": "5.1.6",
-          "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-5.1.6.tgz",
-          "integrity": "sha512-lv+6LCgoc3LVitQZ4TScN/8a/fcctq8bIoxBTMJVq4aU8xoHeY1851Dq8MCU37EzbH33utkx8/jENaQP+aeElg==",
-          "requires": {
-            "@turf/helpers": "^5.1.5"
-          }
-        },
-        "@turf/midpoint": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/midpoint/-/midpoint-5.1.5.tgz",
-          "integrity": "sha512-0pDQAKHyK/zxlvUx3XNxwvqftf4sV32QxnHfqSs4AXaODUGUbPhzAD7aXgDScBeUOVLwpAzFRQfitUvUMTGC6A==",
-          "requires": {
-            "@turf/bearing": "^5.1.5",
-            "@turf/destination": "^5.1.5",
-            "@turf/distance": "^5.1.5",
-            "@turf/helpers": "^5.1.5"
-          }
-        },
-        "@turf/nearest-point": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/nearest-point/-/nearest-point-5.1.5.tgz",
-          "integrity": "sha512-tZQXI7OE7keNKK4OvYOJ5gervCEuu2pJ6psu59QW9yhe2Di3Gl+HAdLvVa6RZ8s5Fndr3u0JWKsmxve3fCxc9g==",
-          "requires": {
-            "@turf/clone": "^5.1.5",
-            "@turf/distance": "^5.1.5",
-            "@turf/helpers": "^5.1.5",
-            "@turf/meta": "^5.1.5"
-          }
-        },
-        "@turf/nearest-point-on-line": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/nearest-point-on-line/-/nearest-point-on-line-5.1.5.tgz",
-          "integrity": "sha512-qT7BLTwToo8cq0oNoz921oLlRPJamyRg/rZgll+kNBadyDPmJI4W66riHcpM9RQcAJ6TPvDveIIBeGJH7iG88w==",
-          "requires": {
-            "@turf/bearing": "^5.1.5",
-            "@turf/destination": "^5.1.5",
-            "@turf/distance": "^5.1.5",
-            "@turf/helpers": "^5.1.5",
-            "@turf/invariant": "^5.1.5",
-            "@turf/line-intersect": "^5.1.5",
-            "@turf/meta": "^5.1.5"
-          }
-        },
-        "@turf/nearest-point-to-line": {
-          "version": "5.1.6",
-          "resolved": "https://registry.npmjs.org/@turf/nearest-point-to-line/-/nearest-point-to-line-5.1.6.tgz",
-          "integrity": "sha512-ZSvDIEiHhifn/vNwLXZI/E8xmEz5yBPqfUR7BVHRZrB1cP7jLhKZvkbidjG//uW8Fr1Ulc+PFOXczLspIcx/lw==",
-          "requires": {
-            "@turf/helpers": "6.x",
-            "@turf/invariant": "6.x",
-            "@turf/meta": "6.x",
-            "@turf/point-to-line-distance": "^5.1.5",
-            "object-assign": "*"
-          },
-          "dependencies": {
-            "@turf/helpers": {
-              "version": "6.5.0",
-              "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.5.0.tgz",
-              "integrity": "sha512-VbI1dV5bLFzohYYdgqwikdMVpe7pJ9X3E+dlr425wa2/sMJqYDhTO++ec38/pcPvPE6oD9WEEeU3Xu3gza+VPw=="
-            },
-            "@turf/invariant": {
-              "version": "6.5.0",
-              "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-6.5.0.tgz",
-              "integrity": "sha512-Wv8PRNCtPD31UVbdJE/KVAWKe7l6US+lJItRR/HOEW3eh+U/JwRCSUl/KZ7bmjM/C+zLNoreM2TU6OoLACs4eg==",
-              "requires": {
-                "@turf/helpers": "^6.5.0"
-              }
-            },
-            "@turf/meta": {
-              "version": "6.5.0",
-              "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-6.5.0.tgz",
-              "integrity": "sha512-RrArvtsV0vdsCBegoBtOalgdSOfkBrTJ07VkpiCnq/491W67hnMWmDu7e6Ztw0C3WldRYTXkg3SumfdzZxLBHA==",
-              "requires": {
-                "@turf/helpers": "^6.5.0"
-              }
-            }
-          }
-        },
-        "@turf/planepoint": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/planepoint/-/planepoint-5.1.5.tgz",
-          "integrity": "sha512-+Tp+SQ0Db2tqwLbxfXJPysT9IxcOHSMIin2dJb/j3Qn5+g0LRus6rczZl6dWNAIjqBPMawj/V/dZhMu6Q9O9wA==",
-          "requires": {
-            "@turf/helpers": "^5.1.5",
-            "@turf/invariant": "^5.1.5"
-          }
-        },
-        "@turf/point-grid": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/point-grid/-/point-grid-5.1.5.tgz",
-          "integrity": "sha512-4ibozguP9YJ297Q7i9e8/ypGSycvt1re2jrPXTxeuZ4/L/NE5B1nOBLG+tw121nMjD+S+v2RWOtqD+FZ3Ga+ew==",
-          "requires": {
-            "@turf/boolean-within": "^5.1.5",
-            "@turf/distance": "^5.1.5",
-            "@turf/helpers": "^5.1.5",
-            "@turf/invariant": "^5.1.5"
-          }
-        },
-        "@turf/point-on-feature": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/point-on-feature/-/point-on-feature-5.1.5.tgz",
-          "integrity": "sha512-NTcpe5xZjybRh0aTL+7td1cm0s49GGbAt5u8Cdec4W9ix2PsehRcLUbmQIQsODN2kiVyUSpnhECIpsyN5MjX7A==",
-          "requires": {
-            "@turf/boolean-point-in-polygon": "^5.1.5",
-            "@turf/center": "^5.1.5",
-            "@turf/explode": "^5.1.5",
-            "@turf/helpers": "^5.1.5",
-            "@turf/nearest-point": "^5.1.5"
-          }
-        },
-        "@turf/point-to-line-distance": {
-          "version": "5.1.6",
-          "resolved": "https://registry.npmjs.org/@turf/point-to-line-distance/-/point-to-line-distance-5.1.6.tgz",
-          "integrity": "sha512-PE3hiTeeDEi4ZLPtI8XAzFYW9nHo1EVsZGm/4ZVV8jo39d3X1oLVHxY3e1PkCmWwRapXy4QLqvnTQ7nU4wspNw==",
-          "requires": {
-            "@turf/bearing": "6.x",
-            "@turf/distance": "6.x",
-            "@turf/helpers": "6.x",
-            "@turf/invariant": "6.x",
-            "@turf/meta": "6.x",
-            "@turf/projection": "6.x",
-            "@turf/rhumb-bearing": "6.x",
-            "@turf/rhumb-distance": "6.x"
-          },
-          "dependencies": {
-            "@turf/bearing": {
-              "version": "6.5.0",
-              "resolved": "https://registry.npmjs.org/@turf/bearing/-/bearing-6.5.0.tgz",
-              "integrity": "sha512-dxINYhIEMzgDOztyMZc20I7ssYVNEpSv04VbMo5YPQsqa80KO3TFvbuCahMsCAW5z8Tncc8dwBlEFrmRjJG33A==",
-              "requires": {
-                "@turf/helpers": "^6.5.0",
-                "@turf/invariant": "^6.5.0"
-              }
-            },
-            "@turf/distance": {
-              "version": "6.5.0",
-              "resolved": "https://registry.npmjs.org/@turf/distance/-/distance-6.5.0.tgz",
-              "integrity": "sha512-xzykSLfoURec5qvQJcfifw/1mJa+5UwByZZ5TZ8iaqjGYN0vomhV9aiSLeYdUGtYRESZ+DYC/OzY+4RclZYgMg==",
-              "requires": {
-                "@turf/helpers": "^6.5.0",
-                "@turf/invariant": "^6.5.0"
-              }
-            },
-            "@turf/helpers": {
-              "version": "6.5.0",
-              "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.5.0.tgz",
-              "integrity": "sha512-VbI1dV5bLFzohYYdgqwikdMVpe7pJ9X3E+dlr425wa2/sMJqYDhTO++ec38/pcPvPE6oD9WEEeU3Xu3gza+VPw=="
-            },
-            "@turf/invariant": {
-              "version": "6.5.0",
-              "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-6.5.0.tgz",
-              "integrity": "sha512-Wv8PRNCtPD31UVbdJE/KVAWKe7l6US+lJItRR/HOEW3eh+U/JwRCSUl/KZ7bmjM/C+zLNoreM2TU6OoLACs4eg==",
-              "requires": {
-                "@turf/helpers": "^6.5.0"
-              }
-            },
-            "@turf/meta": {
-              "version": "6.5.0",
-              "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-6.5.0.tgz",
-              "integrity": "sha512-RrArvtsV0vdsCBegoBtOalgdSOfkBrTJ07VkpiCnq/491W67hnMWmDu7e6Ztw0C3WldRYTXkg3SumfdzZxLBHA==",
-              "requires": {
-                "@turf/helpers": "^6.5.0"
-              }
-            }
-          }
-        },
-        "@turf/points-within-polygon": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/points-within-polygon/-/points-within-polygon-5.1.5.tgz",
-          "integrity": "sha512-nexe2AHVOY8wEBvs+CYSOp10NyOCkyZ1gkhIfsx0mzU8LPYBxD9ctjlKveheKh4AAldLcFupd/gSCBTKF1JS7A==",
-          "requires": {
-            "@turf/boolean-point-in-polygon": "^5.1.5",
-            "@turf/helpers": "^5.1.5",
-            "@turf/meta": "^5.1.5"
-          }
-        },
-        "@turf/polygon-tangents": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/polygon-tangents/-/polygon-tangents-5.1.5.tgz",
-          "integrity": "sha512-uoZfKvFhl6rf0+CDWucru9fZ4mJB5Nsg37TS/7emrzjoVxXyOdxc/s1HFCjcKflMue7MjU/gT6AitJyrvdztDg==",
-          "requires": {
-            "@turf/helpers": "^5.1.5",
-            "@turf/invariant": "^5.1.5"
-          }
-        },
-        "@turf/polygon-to-line": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/polygon-to-line/-/polygon-to-line-5.1.5.tgz",
-          "integrity": "sha512-kVo0owPqyccy5+qZGvaxGvMsYkgueKE2OOgX2UV/HyrXF3uI3TomK1txjApqeFsLvwuSANxesvVbYLrYiIwvGw==",
-          "requires": {
-            "@turf/helpers": "^5.1.5",
-            "@turf/invariant": "^5.1.5"
-          }
-        },
-        "@turf/polygonize": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/polygonize/-/polygonize-5.1.5.tgz",
-          "integrity": "sha512-qzhtuzoOhldqZHm+ZPsWAs9nDpnkcDfsr+I0twmBF+wjAmo0HKiy9++sRQ4kEePpdwbMpF07D/NdZqYdmOJkGQ==",
-          "requires": {
-            "@turf/boolean-point-in-polygon": "^5.1.5",
-            "@turf/envelope": "^5.1.5",
-            "@turf/helpers": "^5.1.5",
-            "@turf/invariant": "^5.1.5",
-            "@turf/meta": "^5.1.5"
-          }
-        },
-        "@turf/random": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/random/-/random-5.1.5.tgz",
-          "integrity": "sha512-oitpBwEb6YXqoUkIAOVMK+vrTPxUi2rqITmtTa/FBHr6J8TDwMWq6bufE3Gmgjxsss50O2ITJunOksxrouWGDQ==",
-          "requires": {
-            "@turf/helpers": "^5.1.5"
-          }
-        },
-        "@turf/rewind": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/rewind/-/rewind-5.1.5.tgz",
-          "integrity": "sha512-Gdem7JXNu+G4hMllQHXRFRihJl3+pNl7qY+l4qhQFxq+hiU1cQoVFnyoleIqWKIrdK/i2YubaSwc3SCM7N5mMw==",
-          "requires": {
-            "@turf/boolean-clockwise": "^5.1.5",
-            "@turf/clone": "^5.1.5",
-            "@turf/helpers": "^5.1.5",
-            "@turf/invariant": "^5.1.5",
-            "@turf/meta": "^5.1.5"
-          }
-        },
-        "@turf/rhumb-destination": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/rhumb-destination/-/rhumb-destination-5.1.5.tgz",
-          "integrity": "sha512-FdDUCSRfRAfsRmUaWjc76Wk32QYFJ6ckmSt6Ls6nEczO6eg/RgH1atF8CIYwR5ifl0Sk1rQzKiOSbpCyvVwQtw==",
-          "requires": {
-            "@turf/helpers": "^5.1.5",
-            "@turf/invariant": "^5.1.5"
-          }
-        },
-        "@turf/sample": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/sample/-/sample-5.1.5.tgz",
-          "integrity": "sha512-EJE8yx+5x7rXejTzwBdOKpvT4tOCS0jwYJfycyTVDuLUSh2rETeYdjy7EeJbofnxm9CRPXqWQMPWIBKWxNTjow==",
-          "requires": {
-            "@turf/helpers": "^5.1.5"
-          }
-        },
-        "@turf/sector": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/sector/-/sector-5.1.5.tgz",
-          "integrity": "sha512-dnWVifL3xWTqPPs8mfbbV9muDimNJtxRk4ogrkOLEDQ9ZZ1ALQMtQdYrg7kI3iC+L+LscV37tl+E8bayWyX8YA==",
-          "requires": {
-            "@turf/circle": "^5.1.5",
-            "@turf/helpers": "^5.1.5",
-            "@turf/invariant": "^5.1.5",
-            "@turf/line-arc": "^5.1.5",
-            "@turf/meta": "^5.1.5"
-          }
-        },
-        "@turf/shortest-path": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/shortest-path/-/shortest-path-5.1.5.tgz",
-          "integrity": "sha512-ZGC8kSBj02GKWiI56Z5FNdrZ+fS0xyeOUNrPJWzudAlrv9wKGaRuWoIVRLGBu0j0OuO1HCwggic2c6WV/AhP0A==",
-          "requires": {
-            "@turf/bbox": "^5.1.5",
-            "@turf/bbox-polygon": "^5.1.5",
-            "@turf/boolean-point-in-polygon": "^5.1.5",
-            "@turf/clean-coords": "^5.1.5",
-            "@turf/distance": "^5.1.5",
-            "@turf/helpers": "^5.1.5",
-            "@turf/invariant": "^5.1.5",
-            "@turf/meta": "^5.1.5",
-            "@turf/transform-scale": "^5.1.5"
-          }
-        },
-        "@turf/simplify": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/simplify/-/simplify-5.1.5.tgz",
-          "integrity": "sha512-IuBXEYdGSxbDOK3v949ajaPvs6NhjhTCTbKA6mSGuVbwGS7gzAuRiPSG4K/MvCVuQy3PKpkPcUGD+Uvt2Ov2PQ==",
-          "requires": {
-            "@turf/clean-coords": "^5.1.5",
-            "@turf/clone": "^5.1.5",
-            "@turf/helpers": "^5.1.5",
-            "@turf/meta": "^5.1.5"
-          }
-        },
-        "@turf/square": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/square/-/square-5.1.5.tgz",
-          "integrity": "sha512-GgP2le9ksoW6vsVef5wFkjmWQiLPTJvcjGXqmoGWT4oMwDpvTJVQ91RBLs8qQbI4KACCQevz94N69klk3ah30Q==",
-          "requires": {
-            "@turf/distance": "^5.1.5",
-            "@turf/helpers": "^5.1.5"
-          }
-        },
-        "@turf/square-grid": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/square-grid/-/square-grid-5.1.5.tgz",
-          "integrity": "sha512-/pusEL4FmOwNWLcZfIXUyqUe0fOdkfaLO4wLhDlg/ZL1jWr/wZjhVlMU0tQ27kVN6dJTvlzNc9e0JWNw6yt2eQ==",
-          "requires": {
-            "@turf/boolean-contains": "^5.1.5",
-            "@turf/boolean-overlap": "^5.1.5",
-            "@turf/distance": "^5.1.5",
-            "@turf/helpers": "^5.1.5",
-            "@turf/intersect": "^5.1.5",
-            "@turf/invariant": "^5.1.5"
-          }
-        },
-        "@turf/standard-deviational-ellipse": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/standard-deviational-ellipse/-/standard-deviational-ellipse-5.1.5.tgz",
-          "integrity": "sha512-GOaxGKeeJAXV1H3Zz2fjQ5XeSbMKz1OkFRlTDBUipiAawe/9qTCF55L87I2ZPnO80B5BaaIT+AN2n0lMcAklzA==",
-          "requires": {
-            "@turf/center-mean": "^5.1.5",
-            "@turf/ellipse": "^5.1.5",
-            "@turf/helpers": "^5.1.5",
-            "@turf/invariant": "^5.1.5",
-            "@turf/meta": "^5.1.5",
-            "@turf/points-within-polygon": "^5.1.5"
-          }
-        },
-        "@turf/tag": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/tag/-/tag-5.1.5.tgz",
-          "integrity": "sha512-XI3QFpva6tEsRnzFe1tJGdAAWlzjnXZPfJ9EKShTxEW8ZgPzm92b2odjiSAt2KuQusK82ltNfdw5Frlna5xGYQ==",
-          "requires": {
-            "@turf/boolean-point-in-polygon": "^5.1.5",
-            "@turf/clone": "^5.1.5",
-            "@turf/helpers": "^5.1.5",
-            "@turf/meta": "^5.1.5"
-          }
-        },
-        "@turf/tesselate": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/tesselate/-/tesselate-5.1.5.tgz",
-          "integrity": "sha512-Rs/jAij26bcU4OzvFXkWDase1G3kSwyuuKZPFU0t7OmJu7eQJOR12WOZLGcVxd5oBlklo4xPE4EBQUqpQUsQgg==",
-          "requires": {
-            "@turf/helpers": "^5.1.5",
-            "earcut": "^2.0.0"
-          }
-        },
-        "@turf/tin": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/tin/-/tin-5.1.5.tgz",
-          "integrity": "sha512-lDyCTYKoThBIKmkBxBMupqEpFbvTDAYuZIs8qrWnmux2vntSb8OFGi7ZbGPC6apS2hdVwZZae3YB88Tp+Fg+xw==",
-          "requires": {
-            "@turf/helpers": "^5.1.5"
-          }
-        },
-        "@turf/transform-rotate": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/transform-rotate/-/transform-rotate-5.1.5.tgz",
-          "integrity": "sha512-3QKckeHKPXu5O5vEuT+nkszGDI6aknDD06ePb00+6H2oA7MZj7nj+fVQIJLs41MRb76IyKr4n5NvuKZU6idESA==",
-          "requires": {
-            "@turf/centroid": "^5.1.5",
-            "@turf/clone": "^5.1.5",
-            "@turf/helpers": "^5.1.5",
-            "@turf/invariant": "^5.1.5",
-            "@turf/meta": "^5.1.5",
-            "@turf/rhumb-bearing": "^5.1.5",
-            "@turf/rhumb-destination": "^5.1.5",
-            "@turf/rhumb-distance": "^5.1.5"
-          },
-          "dependencies": {
-            "@turf/rhumb-bearing": {
-              "version": "5.1.5",
-              "resolved": "https://registry.npmjs.org/@turf/rhumb-bearing/-/rhumb-bearing-5.1.5.tgz",
-              "integrity": "sha512-zXTl2khjwf7mx2D1uPo5vgpGgP4sM2VrKDbJNKyulPu4TO4ELt8x7FsKyCBlRTzzQf284t/xnNcZOfUbkkd70g==",
-              "requires": {
-                "@turf/helpers": "^5.1.5",
-                "@turf/invariant": "^5.1.5"
-              }
-            },
-            "@turf/rhumb-distance": {
-              "version": "5.1.5",
-              "resolved": "https://registry.npmjs.org/@turf/rhumb-distance/-/rhumb-distance-5.1.5.tgz",
-              "integrity": "sha512-AGA/ky5/BJJZtzQqafy2GvJfcUXSzCCrPFp8sDRPSKBoUN4gMBHN15ijDWYYLFoWFFj0urcauVx7chQlHZ/Qfw==",
-              "requires": {
-                "@turf/helpers": "^5.1.5",
-                "@turf/invariant": "^5.1.5"
-              }
-            }
-          }
-        },
-        "@turf/transform-scale": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/transform-scale/-/transform-scale-5.1.5.tgz",
-          "integrity": "sha512-t1fCZX29ONA7DJiqCKA4YZy0+hCzhppWNOZhglBUv9vKHsWCFYZDUKfFInciaypUInsZyvm8eKxxixBVPdPGsw==",
-          "requires": {
-            "@turf/bbox": "^5.1.5",
-            "@turf/center": "^5.1.5",
-            "@turf/centroid": "^5.1.5",
-            "@turf/clone": "^5.1.5",
-            "@turf/helpers": "^5.1.5",
-            "@turf/invariant": "^5.1.5",
-            "@turf/meta": "^5.1.5",
-            "@turf/rhumb-bearing": "^5.1.5",
-            "@turf/rhumb-destination": "^5.1.5",
-            "@turf/rhumb-distance": "^5.1.5"
-          },
-          "dependencies": {
-            "@turf/rhumb-bearing": {
-              "version": "5.1.5",
-              "resolved": "https://registry.npmjs.org/@turf/rhumb-bearing/-/rhumb-bearing-5.1.5.tgz",
-              "integrity": "sha512-zXTl2khjwf7mx2D1uPo5vgpGgP4sM2VrKDbJNKyulPu4TO4ELt8x7FsKyCBlRTzzQf284t/xnNcZOfUbkkd70g==",
-              "requires": {
-                "@turf/helpers": "^5.1.5",
-                "@turf/invariant": "^5.1.5"
-              }
-            },
-            "@turf/rhumb-distance": {
-              "version": "5.1.5",
-              "resolved": "https://registry.npmjs.org/@turf/rhumb-distance/-/rhumb-distance-5.1.5.tgz",
-              "integrity": "sha512-AGA/ky5/BJJZtzQqafy2GvJfcUXSzCCrPFp8sDRPSKBoUN4gMBHN15ijDWYYLFoWFFj0urcauVx7chQlHZ/Qfw==",
-              "requires": {
-                "@turf/helpers": "^5.1.5",
-                "@turf/invariant": "^5.1.5"
-              }
-            }
-          }
-        },
-        "@turf/transform-translate": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/transform-translate/-/transform-translate-5.1.5.tgz",
-          "integrity": "sha512-GdLFp7I7198oRQt311B8EjiqHupndeMSQ3Zclzki5L/niUrb1ptOIpo+mxSidSy03m+1Q5ylWlENroI1WBcQ3Q==",
-          "requires": {
-            "@turf/clone": "^5.1.5",
-            "@turf/helpers": "^5.1.5",
-            "@turf/invariant": "^5.1.5",
-            "@turf/meta": "^5.1.5",
-            "@turf/rhumb-destination": "^5.1.5"
-          }
-        },
-        "@turf/triangle-grid": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/triangle-grid/-/triangle-grid-5.1.5.tgz",
-          "integrity": "sha512-jmCRcynI80xsVqd+0rv0YxP6mvZn4BAaJv8dwthg2T3WfHB9OD+rNUMohMuUY8HmI0zRT3s/Ypdy2Cdri9u/tw==",
-          "requires": {
-            "@turf/distance": "^5.1.5",
-            "@turf/helpers": "^5.1.5",
-            "@turf/intersect": "^5.1.5",
-            "@turf/invariant": "^5.1.5"
-          }
-        },
-        "@turf/truncate": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/truncate/-/truncate-5.1.5.tgz",
-          "integrity": "sha512-WjWGsRE6o1vUqULGb/O7O1eK6B4Eu6R/RBZWnF0rH0Os6WVel6tHktkeJdlKwz9WElIEO12wDIu6uKd54t7DDQ==",
-          "requires": {
-            "@turf/helpers": "^5.1.5",
-            "@turf/meta": "^5.1.5"
-          }
-        },
-        "@turf/turf": {
-          "version": "5.1.6",
-          "resolved": "https://registry.npmjs.org/@turf/turf/-/turf-5.1.6.tgz",
-          "integrity": "sha512-NIjkt5jAbOrom+56ELw9ERZF6qsdf1xAIHyC9/PkDMIOQAxe7FVe2HaqbQ+x88F0q5FaSX4dtpIEf08md6h5/A==",
-          "requires": {
-            "@turf/along": "5.1.x",
-            "@turf/area": "5.1.x",
-            "@turf/bbox": "5.1.x",
-            "@turf/bbox-clip": "5.1.x",
-            "@turf/bbox-polygon": "5.1.x",
-            "@turf/bearing": "5.1.x",
-            "@turf/bezier-spline": "5.1.x",
-            "@turf/boolean-clockwise": "5.1.x",
-            "@turf/boolean-contains": "5.1.x",
-            "@turf/boolean-crosses": "5.1.x",
-            "@turf/boolean-disjoint": "5.1.x",
-            "@turf/boolean-equal": "5.1.x",
-            "@turf/boolean-overlap": "5.1.x",
-            "@turf/boolean-parallel": "5.1.x",
-            "@turf/boolean-point-in-polygon": "5.1.x",
-            "@turf/boolean-point-on-line": "5.1.x",
-            "@turf/boolean-within": "5.1.x",
-            "@turf/buffer": "5.1.x",
-            "@turf/center": "5.1.x",
-            "@turf/center-mean": "5.1.x",
-            "@turf/center-median": "5.1.x",
-            "@turf/center-of-mass": "5.1.x",
-            "@turf/centroid": "5.1.x",
-            "@turf/circle": "5.1.x",
-            "@turf/clean-coords": "5.1.x",
-            "@turf/clone": "5.1.x",
-            "@turf/clusters": "5.1.x",
-            "@turf/clusters-dbscan": "5.1.x",
-            "@turf/clusters-kmeans": "5.1.x",
-            "@turf/collect": "5.1.x",
-            "@turf/combine": "5.1.x",
-            "@turf/concave": "5.1.x",
-            "@turf/convex": "5.1.x",
-            "@turf/destination": "5.1.x",
-            "@turf/difference": "5.1.x",
-            "@turf/dissolve": "5.1.x",
-            "@turf/distance": "5.1.x",
-            "@turf/ellipse": "5.1.x",
-            "@turf/envelope": "5.1.x",
-            "@turf/explode": "5.1.x",
-            "@turf/flatten": "5.1.x",
-            "@turf/flip": "5.1.x",
-            "@turf/great-circle": "5.1.x",
-            "@turf/helpers": "5.1.x",
-            "@turf/hex-grid": "5.1.x",
-            "@turf/interpolate": "5.1.x",
-            "@turf/intersect": "5.1.x",
-            "@turf/invariant": "5.1.x",
-            "@turf/isobands": "5.1.x",
-            "@turf/isolines": "5.1.x",
-            "@turf/kinks": "5.1.x",
-            "@turf/length": "5.1.x",
-            "@turf/line-arc": "5.1.x",
-            "@turf/line-chunk": "5.1.x",
-            "@turf/line-intersect": "5.1.x",
-            "@turf/line-offset": "5.1.x",
-            "@turf/line-overlap": "5.1.x",
-            "@turf/line-segment": "5.1.x",
-            "@turf/line-slice": "5.1.x",
-            "@turf/line-slice-along": "5.1.x",
-            "@turf/line-split": "5.1.x",
-            "@turf/line-to-polygon": "5.1.x",
-            "@turf/mask": "5.1.x",
-            "@turf/meta": "5.1.x",
-            "@turf/midpoint": "5.1.x",
-            "@turf/nearest-point": "5.1.x",
-            "@turf/nearest-point-on-line": "5.1.x",
-            "@turf/nearest-point-to-line": "5.1.x",
-            "@turf/planepoint": "5.1.x",
-            "@turf/point-grid": "5.1.x",
-            "@turf/point-on-feature": "5.1.x",
-            "@turf/point-to-line-distance": "5.1.x",
-            "@turf/points-within-polygon": "5.1.x",
-            "@turf/polygon-tangents": "5.1.x",
-            "@turf/polygon-to-line": "5.1.x",
-            "@turf/polygonize": "5.1.x",
-            "@turf/projection": "5.1.x",
-            "@turf/random": "5.1.x",
-            "@turf/rewind": "5.1.x",
-            "@turf/rhumb-bearing": "5.1.x",
-            "@turf/rhumb-destination": "5.1.x",
-            "@turf/rhumb-distance": "5.1.x",
-            "@turf/sample": "5.1.x",
-            "@turf/sector": "5.1.x",
-            "@turf/shortest-path": "5.1.x",
-            "@turf/simplify": "5.1.x",
-            "@turf/square": "5.1.x",
-            "@turf/square-grid": "5.1.x",
-            "@turf/standard-deviational-ellipse": "5.1.x",
-            "@turf/tag": "5.1.x",
-            "@turf/tesselate": "5.1.x",
-            "@turf/tin": "5.1.x",
-            "@turf/transform-rotate": "5.1.x",
-            "@turf/transform-scale": "5.1.x",
-            "@turf/transform-translate": "5.1.x",
-            "@turf/triangle-grid": "5.1.x",
-            "@turf/truncate": "5.1.x",
-            "@turf/union": "5.1.x",
-            "@turf/unkink-polygon": "5.1.x",
-            "@turf/voronoi": "5.1.x"
-          },
-          "dependencies": {
-            "@turf/projection": {
-              "version": "5.1.5",
-              "resolved": "https://registry.npmjs.org/@turf/projection/-/projection-5.1.5.tgz",
-              "integrity": "sha512-TWKJDFeEKQhI4Ce1+2PuOSDggn4cnMibqyUoCpIW+4KxUC1R88SE3/SYomqzwxMn00O09glHSycPkGD5JzHd8A==",
-              "requires": {
-                "@turf/clone": "^5.1.5",
-                "@turf/helpers": "^5.1.5",
-                "@turf/meta": "^5.1.5"
-              }
-            },
-            "@turf/rhumb-bearing": {
-              "version": "5.1.5",
-              "resolved": "https://registry.npmjs.org/@turf/rhumb-bearing/-/rhumb-bearing-5.1.5.tgz",
-              "integrity": "sha512-zXTl2khjwf7mx2D1uPo5vgpGgP4sM2VrKDbJNKyulPu4TO4ELt8x7FsKyCBlRTzzQf284t/xnNcZOfUbkkd70g==",
-              "requires": {
-                "@turf/helpers": "^5.1.5",
-                "@turf/invariant": "^5.1.5"
-              }
-            },
-            "@turf/rhumb-distance": {
-              "version": "5.1.5",
-              "resolved": "https://registry.npmjs.org/@turf/rhumb-distance/-/rhumb-distance-5.1.5.tgz",
-              "integrity": "sha512-AGA/ky5/BJJZtzQqafy2GvJfcUXSzCCrPFp8sDRPSKBoUN4gMBHN15ijDWYYLFoWFFj0urcauVx7chQlHZ/Qfw==",
-              "requires": {
-                "@turf/helpers": "^5.1.5",
-                "@turf/invariant": "^5.1.5"
-              }
-            }
-          }
-        },
-        "@turf/union": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/union/-/union-5.1.5.tgz",
-          "integrity": "sha512-wBy1ixxC68PpsTeEDebk/EfnbI1Za5dCyY7xFY9NMzrtVEOy0l0lQ5syOsaqY4Ire+dbsDM66p2GGxmefoyIEA==",
-          "requires": {
-            "@turf/helpers": "^5.1.5",
-            "turf-jsts": "*"
-          }
-        },
-        "@turf/unkink-polygon": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/unkink-polygon/-/unkink-polygon-5.1.5.tgz",
-          "integrity": "sha512-lzSrgsfSuyxIc4pkE2qyM2dsHxR992e6oItoZAT8G58A2Ef4qc5gRocmXPWZakGx41fQobegSo7wlo4I49wyHg==",
-          "requires": {
-            "@turf/area": "^5.1.5",
-            "@turf/boolean-point-in-polygon": "^5.1.5",
-            "@turf/helpers": "^5.1.5",
-            "@turf/meta": "^5.1.5",
-            "rbush": "^2.0.1"
-          }
-        },
-        "@turf/voronoi": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/voronoi/-/voronoi-5.1.5.tgz",
-          "integrity": "sha512-Ad0HZAyYjOpMIZfDGV+Q+30M9PQHIirTyn32kWyTjEI1O6uhL5NOYjzSha4Sr77xOls3hGzKOj+JET7eDtOvsg==",
-          "requires": {
-            "@turf/helpers": "^5.1.5",
-            "@turf/invariant": "^5.1.5",
-            "d3-voronoi": "1.1.2"
-          }
-        },
-        "geojson-rbush": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/geojson-rbush/-/geojson-rbush-2.1.0.tgz",
-          "integrity": "sha512-9HvLGhmAJBYkYYDdPlCrlfkKGwNW3PapiS0xPekdJLobkZE4rjtduKJXsO7+kUr97SsUlz4VtMcPuSIbjjJaQg==",
-          "requires": {
-            "@turf/helpers": "*",
-            "@turf/meta": "*",
-            "rbush": "*"
-          }
-        },
-        "geostyler-openlayers-parser": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/geostyler-openlayers-parser/-/geostyler-openlayers-parser-2.5.0.tgz",
-          "integrity": "sha512-Uum/lDci8oqhBA/c0RZbD91aXP4ycjlsAp4ZoVAPDHT6Og0XyF5Tze8wg0Ux44CerE6W+m2DfWkOTAP+iaakzQ==",
-          "requires": {
-            "@terrestris/ol-util": "^4.0.1",
-            "geostyler-style": "^4.0.0",
-            "lodash": "^4.17.15"
-          }
-        },
-        "geostyler-style": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/geostyler-style/-/geostyler-style-4.0.3.tgz",
-          "integrity": "sha512-51esHVZz86HFoSvKRA/Kfqd2Mytek88zgHSSt8ZZg30o4dqyZuQluxwIjqkSLp5hdvmA0nwCAyqxHy6aMyJ5lQ==",
-          "requires": {
-            "@types/lodash": "^4.14.168",
-            "lodash": "^4.17.21"
-          }
-        },
-        "jszip": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/jszip/-/jszip-2.6.1.tgz",
-          "integrity": "sha512-C4Z++nYQv+CudUkCWUdz+yKVhQiFJjuWSmRJ5Sg3d3/OzcJ6U4ooUYlmE3+rJXrVk89KWQaiJ9mPp/VLQ4D66g==",
-          "requires": {
-            "pako": "~1.0.2"
-          }
-        },
-        "lru-cache": {
-          "version": "2.7.3",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
-          "integrity": "sha512-WpibWJ60c3AgAz8a2iYErDrcT2C7OmKnsWhIcHOjkUHFjkXncJhtLxNSqUmxRxRunpb5I8Vprd7aNSd2NtksJQ=="
-        },
-        "ol": {
-          "version": "6.5.0",
-          "resolved": "https://registry.npmjs.org/ol/-/ol-6.5.0.tgz",
-          "integrity": "sha512-a5ebahrjF5yCPFle1rc0aHzKp/9A4LlUnjh+S3I+x4EgcvcddDhpOX3WDOs0Pg9/wEElrikHSGEvbeej2Hh4Ug==",
-          "requires": {
-            "ol-mapbox-style": "^6.1.1",
-            "pbf": "3.2.1",
-            "rbush": "^3.0.1"
-          },
-          "dependencies": {
-            "rbush": {
-              "version": "3.0.1",
-              "resolved": "https://registry.npmjs.org/rbush/-/rbush-3.0.1.tgz",
-              "integrity": "sha512-XRaVO0YecOpEuIvbhbpTrZgoiI6xBlz6hnlr6EHhd+0x9ase6EmeN+hdwwUaJvLcsFFQ8iWVF1GAK1yB0BWi0w==",
-              "requires": {
-                "quickselect": "^2.0.0"
-              }
-            }
-          }
-        },
-        "ol-mapbox-style": {
-          "version": "6.9.0",
-          "resolved": "https://registry.npmjs.org/ol-mapbox-style/-/ol-mapbox-style-6.9.0.tgz",
-          "integrity": "sha512-Isxk+IPB6pCBD2Pubz9cpQcZjEeuPhxyk/QsLZjb2+KwvyGaIFltdlxnxx/QXJ7rOxUiLvS/XhsOyiK0c7prEw==",
-          "requires": {
-            "@mapbox/mapbox-gl-style-spec": "^13.20.1",
-            "mapbox-to-css-font": "^2.4.1",
-            "webfont-matcher": "^1.1.0"
-          }
-        },
-        "pako": {
-          "version": "1.0.11",
-          "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
-          "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
-        },
-        "quickselect": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
-          "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw=="
-        },
-        "shpjs": {
-          "version": "3.6.3",
-          "resolved": "https://registry.npmjs.org/shpjs/-/shpjs-3.6.3.tgz",
-          "integrity": "sha512-wcR2S3WL/7RnEIm+YO+H/mZR9z9FCV46op+SZt+W5PtPs26Omb9U93f+EPI1DOpNKBuAIrWjHWh0SxlnBahJkg==",
-          "requires": {
-            "jszip": "^2.4.0",
-            "lie": "^3.0.1",
-            "lru-cache": "^2.7.0",
-            "parsedbf": "^1.1.0",
-            "proj4": "^2.1.4"
+        "yargs": {
+          "version": "17.5.1",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.5.1.tgz",
+          "integrity": "sha512-t6YAJcxDkNX7NFYiVtKvWUz8l+PaKTLiL63mJYWR2GnHq2gjEWISzsLp9wg3aY36dY1j+gfIEL3pIF+XlJJfbA==",
+          "dev": true,
+          "requires": {
+            "cliui": "^7.0.2",
+            "escalade": "^3.1.1",
+            "get-caller-file": "^2.0.5",
+            "require-directory": "^2.1.1",
+            "string-width": "^4.2.3",
+            "y18n": "^5.0.5",
+            "yargs-parser": "^21.0.0"
+          }
+        },
+        "yargs-parser": {
+          "version": "21.0.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.1.tgz",
+          "integrity": "sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg==",
+          "dev": true
+        }
+      }
+    },
+    "@commitlint/config-conventional": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-17.0.2.tgz",
+      "integrity": "sha512-MfP0I/JbxKkzo+HXWB7B3WstGS4BiniotU3d3xQ9gK8cR0DbeZ4MuyGCWF65YDyrcDTS3WlrJ3ndSPA1pqhoPw==",
+      "dev": true,
+      "requires": {
+        "conventional-changelog-conventionalcommits": "^5.0.0"
+      }
+    },
+    "@commitlint/config-validator": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/config-validator/-/config-validator-17.0.0.tgz",
+      "integrity": "sha512-78IQjoZWR4kDHp/U5y17euEWzswJpPkA9TDL5F6oZZZaLIEreWzrDZD5PWtM8MsSRl/K2LDU/UrzYju2bKLMpA==",
+      "dev": true,
+      "requires": {
+        "@commitlint/types": "^17.0.0",
+        "ajv": "^6.12.6"
+      }
+    },
+    "@commitlint/ensure": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-17.0.0.tgz",
+      "integrity": "sha512-M2hkJnNXvEni59S0QPOnqCKIK52G1XyXBGw51mvh7OXDudCmZ9tZiIPpU882p475Mhx48Ien1MbWjCP1zlyC0A==",
+      "dev": true,
+      "requires": {
+        "@commitlint/types": "^17.0.0",
+        "lodash": "^4.17.19"
+      }
+    },
+    "@commitlint/execute-rule": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/execute-rule/-/execute-rule-17.0.0.tgz",
+      "integrity": "sha512-nVjL/w/zuqjCqSJm8UfpNaw66V9WzuJtQvEnCrK4jDw6qKTmZB+1JQ8m6BQVZbNBcwfYdDNKnhIhqI0Rk7lgpQ==",
+      "dev": true
+    },
+    "@commitlint/format": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/format/-/format-17.0.0.tgz",
+      "integrity": "sha512-MZzJv7rBp/r6ZQJDEodoZvdRM0vXu1PfQvMTNWFb8jFraxnISMTnPBWMMjr2G/puoMashwaNM//fl7j8gGV5lA==",
+      "dev": true,
+      "requires": {
+        "@commitlint/types": "^17.0.0",
+        "chalk": "^4.1.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
           }
         }
+      }
+    },
+    "@commitlint/is-ignored": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-17.0.0.tgz",
+      "integrity": "sha512-UmacD0XM/wWykgdXn5CEWVS4XGuqzU+ZGvM2hwv85+SXGnIOaG88XHrt81u37ZeVt1riWW+YdOxcJW6+nd5v5w==",
+      "dev": true,
+      "requires": {
+        "@commitlint/types": "^17.0.0",
+        "semver": "7.3.7"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "7.3.7",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+          "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        }
+      }
+    },
+    "@commitlint/lint": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-17.0.0.tgz",
+      "integrity": "sha512-5FL7VLvGJQby24q0pd4UdM8FNFcL+ER1T/UBf8A9KRL5+QXV1Rkl6Zhcl7+SGpGlVo6Yo0pm6aLW716LVKWLGg==",
+      "dev": true,
+      "requires": {
+        "@commitlint/is-ignored": "^17.0.0",
+        "@commitlint/parse": "^17.0.0",
+        "@commitlint/rules": "^17.0.0",
+        "@commitlint/types": "^17.0.0"
+      }
+    },
+    "@commitlint/load": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-17.0.0.tgz",
+      "integrity": "sha512-XaiHF4yWQOPAI0O6wXvk+NYLtJn/Xb7jgZEeKd4C1ZWd7vR7u8z5h0PkWxSr0uLZGQsElGxv3fiZ32C5+q6M8w==",
+      "dev": true,
+      "requires": {
+        "@commitlint/config-validator": "^17.0.0",
+        "@commitlint/execute-rule": "^17.0.0",
+        "@commitlint/resolve-extends": "^17.0.0",
+        "@commitlint/types": "^17.0.0",
+        "@types/node": ">=12",
+        "chalk": "^4.1.0",
+        "cosmiconfig": "^7.0.0",
+        "cosmiconfig-typescript-loader": "^2.0.0",
+        "lodash": "^4.17.19",
+        "resolve-from": "^5.0.0",
+        "typescript": "^4.6.4"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "@commitlint/message": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/message/-/message-17.0.0.tgz",
+      "integrity": "sha512-LpcwYtN+lBlfZijHUdVr8aNFTVpHjuHI52BnfoV01TF7iSLnia0jttzpLkrLmI8HNQz6Vhr9UrxDWtKZiMGsBw==",
+      "dev": true
+    },
+    "@commitlint/parse": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-17.0.0.tgz",
+      "integrity": "sha512-cKcpfTIQYDG1ywTIr5AG0RAiLBr1gudqEsmAGCTtj8ffDChbBRxm6xXs2nv7GvmJN7msOt7vOKleLvcMmRa1+A==",
+      "dev": true,
+      "requires": {
+        "@commitlint/types": "^17.0.0",
+        "conventional-changelog-angular": "^5.0.11",
+        "conventional-commits-parser": "^3.2.2"
+      }
+    },
+    "@commitlint/read": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/read/-/read-17.0.0.tgz",
+      "integrity": "sha512-zkuOdZayKX3J6F6mPnVMzohK3OBrsEdOByIqp4zQjA9VLw1hMsDEFQ18rKgUc2adkZar+4S01QrFreDCfZgbxA==",
+      "dev": true,
+      "requires": {
+        "@commitlint/top-level": "^17.0.0",
+        "@commitlint/types": "^17.0.0",
+        "fs-extra": "^10.0.0",
+        "git-raw-commits": "^2.0.0"
+      },
+      "dependencies": {
+        "fs-extra": {
+          "version": "10.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+          "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^2.0.0"
+          }
+        }
+      }
+    },
+    "@commitlint/resolve-extends": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-17.0.0.tgz",
+      "integrity": "sha512-wi60WiJmwaQ7lzMXK8Vbc18Hq9tE2j/6iv2AFfPUGV7fvfY6Sf1iNKuUHirSqR0fquUyufIXe4y/K9A6LVIIvw==",
+      "dev": true,
+      "requires": {
+        "@commitlint/config-validator": "^17.0.0",
+        "@commitlint/types": "^17.0.0",
+        "import-fresh": "^3.0.0",
+        "lodash": "^4.17.19",
+        "resolve-from": "^5.0.0",
+        "resolve-global": "^1.0.0"
+      }
+    },
+    "@commitlint/rules": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-17.0.0.tgz",
+      "integrity": "sha512-45nIy3dERKXWpnwX9HeBzK5SepHwlDxdGBfmedXhL30fmFCkJOdxHyOJsh0+B0RaVsLGT01NELpfzJUmtpDwdQ==",
+      "dev": true,
+      "requires": {
+        "@commitlint/ensure": "^17.0.0",
+        "@commitlint/message": "^17.0.0",
+        "@commitlint/to-lines": "^17.0.0",
+        "@commitlint/types": "^17.0.0",
+        "execa": "^5.0.0"
+      }
+    },
+    "@commitlint/to-lines": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/to-lines/-/to-lines-17.0.0.tgz",
+      "integrity": "sha512-nEi4YEz04Rf2upFbpnEorG8iymyH7o9jYIVFBG1QdzebbIFET3ir+8kQvCZuBE5pKCtViE4XBUsRZz139uFrRQ==",
+      "dev": true
+    },
+    "@commitlint/top-level": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/top-level/-/top-level-17.0.0.tgz",
+      "integrity": "sha512-dZrEP1PBJvodNWYPOYiLWf6XZergdksKQaT6i1KSROLdjf5Ai0brLOv5/P+CPxBeoj3vBxK4Ax8H1Pg9t7sHIQ==",
+      "dev": true,
+      "requires": {
+        "find-up": "^5.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+          "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^6.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+          "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^5.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+          "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+          "dev": true,
+          "requires": {
+            "yocto-queue": "^0.1.0"
+          }
+        },
+        "p-locate": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+          "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^3.0.2"
+          }
+        }
+      }
+    },
+    "@commitlint/types": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-17.0.0.tgz",
+      "integrity": "sha512-hBAw6U+SkAT5h47zDMeOu3HSiD0SODw4Aq7rRNh1ceUmL7GyLKYhPbUvlRWqZ65XjBLPHZhFyQlRaPNz8qvUyQ==",
+      "dev": true,
+      "requires": {
+        "chalk": "^4.1.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/trace-mapping": "0.3.9"
       }
     },
     "@ctrl/tinycolor": {
@@ -35190,14 +34699,6 @@
       "dev": true,
       "requires": {
         "jest-get-type": "^28.0.2"
-      },
-      "dependencies": {
-        "jest-get-type": {
-          "version": "28.0.2",
-          "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-28.0.2.tgz",
-          "integrity": "sha512-ioj2w9/DxSYHfOm5lJKCdcAmPJzQXmbM/Url3rhlghrPvT3tt+7a/+oXc9azkKmLvoiXjtV83bEWqi+vs5nlPA==",
-          "dev": true
-        }
       }
     },
     "@jest/fake-timers": {
@@ -36118,13 +35619,13 @@
       }
     },
     "@terrestris/eslint-config-typescript": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@terrestris/eslint-config-typescript/-/eslint-config-typescript-2.1.0.tgz",
-      "integrity": "sha512-fRAAfa2bIht5Nf/GZBbhhgVwnxNc3VG8YdyYwsauCwAn5XPHl/JDeJkyMpIu/NVML9LGSFbQBZChUEpZRhntwg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@terrestris/eslint-config-typescript/-/eslint-config-typescript-3.0.0.tgz",
+      "integrity": "sha512-dpAztRrJ/M036lTI5eqJoNbX4/80zTh2fRWxrXRG16RHorQoIbBsd8WqWtF7K42yTrSHz2kmEwWX4Yo0YBc2rQ==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/parser": "^5.15.0",
-        "typescript": ">= 3"
+        "@typescript-eslint/parser": "^5.28.0",
+        "typescript": ">= ~4"
       }
     },
     "@terrestris/ol-util": {
@@ -36141,12 +35642,38 @@
         "proj4": "^2.7.5",
         "shpjs": "^4.0.2",
         "typescript": "^4.5.5"
+      },
+      "dependencies": {
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "geostyler-openlayers-parser": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/geostyler-openlayers-parser/-/geostyler-openlayers-parser-3.1.0.tgz",
+          "integrity": "sha512-TidTBmvlM/yVUWuarjO5mb9uiBmRDeWxCkdnvktuUrezWUWsVZWUXk9faA9s9D8o3IQMKJtI5UzIcSGuCB6H0Q==",
+          "requires": {
+            "color-name": "^1.1.4",
+            "geostyler-style": "^5.0.2",
+            "lodash": "^4.17.21"
+          }
+        },
+        "geostyler-style": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/geostyler-style/-/geostyler-style-5.1.0.tgz",
+          "integrity": "sha512-AJzQBomzuTGr01uRYvu7bocJTBB6vrgBdxsIoSHDATbnNF07XnAtsrbkjXlMsKaRnbqE2MGLhQqBmBx6C2Gubg==",
+          "requires": {
+            "@types/lodash": "^4.14.168",
+            "lodash": "^4.17.21"
+          }
+        }
       }
     },
     "@testing-library/dom": {
-      "version": "8.13.0",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.13.0.tgz",
-      "integrity": "sha512-9VHgfIatKNXQNaZTtLnalIy0jNZzY35a4S3oi08YAt9Hv1VsfZ/DfA45lM8D/UhtHBGJ4/lGwp0PZkVndRkoOQ==",
+      "version": "8.14.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.14.0.tgz",
+      "integrity": "sha512-m8FOdUo77iMTwVRCyzWcqxlEIk+GnopbrRI15a0EaLbpZSCinIVI4kSQzWhkShK83GogvEFJSsHF3Ws0z1vrqA==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.10.4",
@@ -36301,9 +35828,9 @@
       }
     },
     "@testing-library/user-event": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.2.0.tgz",
-      "integrity": "sha512-+hIlG4nJS6ivZrKnOP7OGsDu9Fxmryj9vCl8x0ZINtTJcCHs2zLsYif5GzuRiBF2ck5GZG2aQr7Msg+EHlnYVQ==",
+      "version": "14.2.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.2.1.tgz",
+      "integrity": "sha512-HOr1QiODrq+0j9lKU5i10y9TbhxMBMRMGimNx10asdmau9cb8Xb1Vyg0GvTwyIL2ziQyh2kAloOtAQFBQVuecA==",
       "dev": true,
       "requires": {}
     },
@@ -36320,6 +35847,30 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
       "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
+      "dev": true
+    },
+    "@tsconfig/node10": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
+      "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
+      "dev": true
+    },
+    "@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true
+    },
+    "@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true
+    },
+    "@tsconfig/node16": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
+      "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
       "dev": true
     },
     "@turf/along": {
@@ -37724,13 +37275,39 @@
       }
     },
     "@types/jest": {
-      "version": "28.1.1",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-28.1.1.tgz",
-      "integrity": "sha512-C2p7yqleUKtCkVjlOur9BWVA4HgUQmEj/HWCt5WzZ5mLXrWnyIfl0wGuArc+kBXsy0ZZfLp+7dywB4HtSVYGVA==",
+      "version": "28.1.3",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-28.1.3.tgz",
+      "integrity": "sha512-Tsbjk8Y2hkBaY/gJsataeb4q9Mubw9EOz7+4RjPkzD5KjTvHHs7cpws22InaoXxAVAhF5HfFbzJjo6oKWqSZLw==",
       "dev": true,
       "requires": {
-        "jest-matcher-utils": "^27.0.0",
-        "pretty-format": "^27.0.0"
+        "jest-matcher-utils": "^28.0.0",
+        "pretty-format": "^28.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+          "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+          "dev": true
+        },
+        "pretty-format": {
+          "version": "28.1.1",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-28.1.1.tgz",
+          "integrity": "sha512-wwJbVTGFHeucr5Jw2bQ9P+VYHyLdAqedFLEkdQUVaBF/eiidDwH5OpilINq4mEfhbCjLnirt6HTTDhv1HaTIQw==",
+          "dev": true,
+          "requires": {
+            "@jest/schemas": "^28.0.2",
+            "ansi-regex": "^5.0.1",
+            "ansi-styles": "^5.0.0",
+            "react-is": "^18.0.0"
+          }
+        },
+        "react-is": {
+          "version": "18.2.0",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+          "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
+          "dev": true
+        }
       }
     },
     "@types/jsdom": {
@@ -37814,9 +37391,9 @@
       }
     },
     "@types/node": {
-      "version": "17.0.42",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.42.tgz",
-      "integrity": "sha512-Q5BPGyGKcvQgAMbsr7qEGN/kIPN6zZecYYABeTDBizOsau+2NMdSVTar9UQw21A2+JyA2KRNDYaYrPB0Rpk2oQ=="
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.0.0.tgz",
+      "integrity": "sha512-cHlGmko4gWLVI27cGJntjs/Sj8th9aYwplmZFwmmgYQQvL5NUsgVJG7OddLvNfLqYS31KFN0s3qlaD9qCaxACA=="
     },
     "@types/normalize-package-data": {
       "version": "2.4.1",
@@ -38021,14 +37598,14 @@
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "5.27.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.27.1.tgz",
-      "integrity": "sha512-6dM5NKT57ZduNnJfpY81Phe9nc9wolnMCnknb1im6brWi1RYv84nbMS3olJa27B6+irUVV1X/Wb+Am0FjJdGFw==",
+      "version": "5.29.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.29.0.tgz",
+      "integrity": "sha512-kgTsISt9pM53yRFQmLZ4npj99yGl3x3Pl7z4eA66OuTzAGC4bQB5H5fuLwPnqTKU3yyrrg4MIhjF17UYnL4c0w==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "5.27.1",
-        "@typescript-eslint/type-utils": "5.27.1",
-        "@typescript-eslint/utils": "5.27.1",
+        "@typescript-eslint/scope-manager": "5.29.0",
+        "@typescript-eslint/type-utils": "5.29.0",
+        "@typescript-eslint/utils": "5.29.0",
         "debug": "^4.3.4",
         "functional-red-black-tree": "^1.0.1",
         "ignore": "^5.2.0",
@@ -38049,41 +37626,41 @@
       }
     },
     "@typescript-eslint/parser": {
-      "version": "5.27.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.27.1.tgz",
-      "integrity": "sha512-7Va2ZOkHi5NP+AZwb5ReLgNF6nWLGTeUJfxdkVUAPPSaAdbWNnFZzLZ4EGGmmiCTg+AwlbE1KyUYTBglosSLHQ==",
+      "version": "5.29.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.29.0.tgz",
+      "integrity": "sha512-ruKWTv+x0OOxbzIw9nW5oWlUopvP/IQDjB5ZqmTglLIoDTctLlAJpAQFpNPJP/ZI7hTT9sARBosEfaKbcFuECw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "5.27.1",
-        "@typescript-eslint/types": "5.27.1",
-        "@typescript-eslint/typescript-estree": "5.27.1",
+        "@typescript-eslint/scope-manager": "5.29.0",
+        "@typescript-eslint/types": "5.29.0",
+        "@typescript-eslint/typescript-estree": "5.29.0",
         "debug": "^4.3.4"
       },
       "dependencies": {
         "@typescript-eslint/scope-manager": {
-          "version": "5.27.1",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.27.1.tgz",
-          "integrity": "sha512-fQEOSa/QroWE6fAEg+bJxtRZJTH8NTskggybogHt4H9Da8zd4cJji76gA5SBlR0MgtwF7rebxTbDKB49YUCpAg==",
+          "version": "5.29.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.29.0.tgz",
+          "integrity": "sha512-etbXUT0FygFi2ihcxDZjz21LtC+Eps9V2xVx09zFoN44RRHPrkMflidGMI+2dUs821zR1tDS6Oc9IXxIjOUZwA==",
           "dev": true,
           "requires": {
-            "@typescript-eslint/types": "5.27.1",
-            "@typescript-eslint/visitor-keys": "5.27.1"
+            "@typescript-eslint/types": "5.29.0",
+            "@typescript-eslint/visitor-keys": "5.29.0"
           }
         },
         "@typescript-eslint/types": {
-          "version": "5.27.1",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.27.1.tgz",
-          "integrity": "sha512-LgogNVkBhCTZU/m8XgEYIWICD6m4dmEDbKXESCbqOXfKZxRKeqpiJXQIErv66sdopRKZPo5l32ymNqibYEH/xg==",
+          "version": "5.29.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.29.0.tgz",
+          "integrity": "sha512-X99VbqvAXOMdVyfFmksMy3u8p8yoRGITgU1joBJPzeYa0rhdf5ok9S56/itRoUSh99fiDoMtarSIJXo7H/SnOg==",
           "dev": true
         },
         "@typescript-eslint/typescript-estree": {
-          "version": "5.27.1",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.27.1.tgz",
-          "integrity": "sha512-DnZvvq3TAJ5ke+hk0LklvxwYsnXpRdqUY5gaVS0D4raKtbznPz71UJGnPTHEFo0GDxqLOLdMkkmVZjSpET1hFw==",
+          "version": "5.29.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.29.0.tgz",
+          "integrity": "sha512-mQvSUJ/JjGBdvo+1LwC+GY2XmSYjK1nAaVw2emp/E61wEVYEyibRHCqm1I1vEKbXCpUKuW4G7u9ZCaZhJbLoNQ==",
           "dev": true,
           "requires": {
-            "@typescript-eslint/types": "5.27.1",
-            "@typescript-eslint/visitor-keys": "5.27.1",
+            "@typescript-eslint/types": "5.29.0",
+            "@typescript-eslint/visitor-keys": "5.29.0",
             "debug": "^4.3.4",
             "globby": "^11.1.0",
             "is-glob": "^4.0.3",
@@ -38092,12 +37669,12 @@
           }
         },
         "@typescript-eslint/visitor-keys": {
-          "version": "5.27.1",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.27.1.tgz",
-          "integrity": "sha512-xYs6ffo01nhdJgPieyk7HAOpjhTsx7r/oB9LWEhwAXgwn33tkr+W8DI2ChboqhZlC4q3TC6geDYPoiX8ROqyOQ==",
+          "version": "5.29.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.29.0.tgz",
+          "integrity": "sha512-Hpb/mCWsjILvikMQoZIE3voc9wtQcS0A9FUw3h8bhr9UxBdtI/tw1ZDZUOXHXLOVMedKCH5NxyzATwnU78bWCQ==",
           "dev": true,
           "requires": {
-            "@typescript-eslint/types": "5.27.1",
+            "@typescript-eslint/types": "5.29.0",
             "eslint-visitor-keys": "^3.3.0"
           }
         },
@@ -38119,40 +37696,40 @@
       }
     },
     "@typescript-eslint/scope-manager": {
-      "version": "5.27.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.27.1.tgz",
-      "integrity": "sha512-fQEOSa/QroWE6fAEg+bJxtRZJTH8NTskggybogHt4H9Da8zd4cJji76gA5SBlR0MgtwF7rebxTbDKB49YUCpAg==",
+      "version": "5.29.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.29.0.tgz",
+      "integrity": "sha512-etbXUT0FygFi2ihcxDZjz21LtC+Eps9V2xVx09zFoN44RRHPrkMflidGMI+2dUs821zR1tDS6Oc9IXxIjOUZwA==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.27.1",
-        "@typescript-eslint/visitor-keys": "5.27.1"
+        "@typescript-eslint/types": "5.29.0",
+        "@typescript-eslint/visitor-keys": "5.29.0"
       }
     },
     "@typescript-eslint/type-utils": {
-      "version": "5.27.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.27.1.tgz",
-      "integrity": "sha512-+UC1vVUWaDHRnC2cQrCJ4QtVjpjjCgjNFpg8b03nERmkHv9JV9X5M19D7UFMd+/G7T/sgFwX2pGmWK38rqyvXw==",
+      "version": "5.29.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.29.0.tgz",
+      "integrity": "sha512-JK6bAaaiJozbox3K220VRfCzLa9n0ib/J+FHIwnaV3Enw/TO267qe0pM1b1QrrEuy6xun374XEAsRlA86JJnyg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/utils": "5.27.1",
+        "@typescript-eslint/utils": "5.29.0",
         "debug": "^4.3.4",
         "tsutils": "^3.21.0"
       }
     },
     "@typescript-eslint/types": {
-      "version": "5.27.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.27.1.tgz",
-      "integrity": "sha512-LgogNVkBhCTZU/m8XgEYIWICD6m4dmEDbKXESCbqOXfKZxRKeqpiJXQIErv66sdopRKZPo5l32ymNqibYEH/xg==",
+      "version": "5.29.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.29.0.tgz",
+      "integrity": "sha512-X99VbqvAXOMdVyfFmksMy3u8p8yoRGITgU1joBJPzeYa0rhdf5ok9S56/itRoUSh99fiDoMtarSIJXo7H/SnOg==",
       "dev": true
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "5.27.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.27.1.tgz",
-      "integrity": "sha512-DnZvvq3TAJ5ke+hk0LklvxwYsnXpRdqUY5gaVS0D4raKtbznPz71UJGnPTHEFo0GDxqLOLdMkkmVZjSpET1hFw==",
+      "version": "5.29.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.29.0.tgz",
+      "integrity": "sha512-mQvSUJ/JjGBdvo+1LwC+GY2XmSYjK1nAaVw2emp/E61wEVYEyibRHCqm1I1vEKbXCpUKuW4G7u9ZCaZhJbLoNQ==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.27.1",
-        "@typescript-eslint/visitor-keys": "5.27.1",
+        "@typescript-eslint/types": "5.29.0",
+        "@typescript-eslint/visitor-keys": "5.29.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -38172,26 +37749,26 @@
       }
     },
     "@typescript-eslint/utils": {
-      "version": "5.27.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.27.1.tgz",
-      "integrity": "sha512-mZ9WEn1ZLDaVrhRaYgzbkXBkTPghPFsup8zDbbsYTxC5OmqrFE7skkKS/sraVsLP3TcT3Ki5CSyEFBRkLH/H/w==",
+      "version": "5.29.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.29.0.tgz",
+      "integrity": "sha512-3Eos6uP1nyLOBayc/VUdKZikV90HahXE5Dx9L5YlSd/7ylQPXhLk1BYb29SDgnBnTp+jmSZUU0QxUiyHgW4p7A==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.9",
-        "@typescript-eslint/scope-manager": "5.27.1",
-        "@typescript-eslint/types": "5.27.1",
-        "@typescript-eslint/typescript-estree": "5.27.1",
+        "@typescript-eslint/scope-manager": "5.29.0",
+        "@typescript-eslint/types": "5.29.0",
+        "@typescript-eslint/typescript-estree": "5.29.0",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^3.0.0"
       }
     },
     "@typescript-eslint/visitor-keys": {
-      "version": "5.27.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.27.1.tgz",
-      "integrity": "sha512-xYs6ffo01nhdJgPieyk7HAOpjhTsx7r/oB9LWEhwAXgwn33tkr+W8DI2ChboqhZlC4q3TC6geDYPoiX8ROqyOQ==",
+      "version": "5.29.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.29.0.tgz",
+      "integrity": "sha512-Hpb/mCWsjILvikMQoZIE3voc9wtQcS0A9FUw3h8bhr9UxBdtI/tw1ZDZUOXHXLOVMedKCH5NxyzATwnU78bWCQ==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.27.1",
+        "@typescript-eslint/types": "5.29.0",
         "eslint-visitor-keys": "^3.3.0"
       },
       "dependencies": {
@@ -38676,6 +38253,12 @@
         "delegates": "^1.0.0",
         "readable-stream": "^3.6.0"
       }
+    },
+    "arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true
     },
     "argparse": {
       "version": "1.0.10",
@@ -40489,6 +40072,17 @@
         "q": "^1.5.1"
       }
     },
+    "conventional-changelog-conventionalcommits": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-5.0.0.tgz",
+      "integrity": "sha512-lCDbA+ZqVFQGUj7h9QBKoIpLhl8iihkO0nCTyRNzuXtcd7ubODpYB04IFy31JloiJgG0Uovu8ot8oxRzn7Nwtw==",
+      "dev": true,
+      "requires": {
+        "compare-func": "^2.0.0",
+        "lodash": "^4.17.15",
+        "q": "^1.5.1"
+      }
+    },
     "conventional-changelog-writer": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-5.0.1.tgz",
@@ -40710,6 +40304,16 @@
         "yaml": "^1.10.0"
       }
     },
+    "cosmiconfig-typescript-loader": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-2.0.1.tgz",
+      "integrity": "sha512-B9s6sX/omXq7I6gC6+YgLmrBFMJhPWew7ty/X5Tuwtd2zOSgWaUdXjkuVwbe3qqcdETo60+1nSVMekq//LIXVA==",
+      "dev": true,
+      "requires": {
+        "cosmiconfig": "^7",
+        "ts-node": "^10.8.0"
+      }
+    },
     "coveralls": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.1.1.tgz",
@@ -40722,6 +40326,12 @@
         "minimist": "^1.2.5",
         "request": "^2.88.2"
       }
+    },
+    "create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true
     },
     "cross-fetch": {
       "version": "3.1.5",
@@ -40888,6 +40498,12 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/d3-voronoi/-/d3-voronoi-1.1.2.tgz",
       "integrity": "sha1-Fodmfo8TotFYyAwUgMWinLDYlzw="
+    },
+    "dargs": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/dargs/-/dargs-7.0.0.tgz",
+      "integrity": "sha512-2iy1EkLdlBzQGvbweYRFxmFath8+K7+AKB0TlhHWkNuH+TmovaMH/Wp7V7R4u7f4SnX3OgLsU9t1NI9ioDnUpg==",
+      "dev": true
     },
     "dashdash": {
       "version": "1.14.1",
@@ -41273,10 +40889,16 @@
         }
       }
     },
+    "diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true
+    },
     "diff-sequences": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-27.5.1.tgz",
-      "integrity": "sha512-k1gCAXAsNgLwEL+Y8Wvl+M6oEFj5bgazfZULpS5CneoPPXRaCCW7dm+q21Ky2VEE5X+VeRDBVg1Pcvvsr4TtNQ==",
+      "version": "28.1.1",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-28.1.1.tgz",
+      "integrity": "sha512-FU0iFaH/E23a+a718l8Qa/19bF9p06kgE0KipMOMadwa3SjnaElKzPaUC0vnibs6/B/9ni97s61mcejk8W1fQw==",
       "dev": true
     },
     "dir-glob": {
@@ -41754,9 +41376,9 @@
       }
     },
     "eslint": {
-      "version": "8.17.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.17.0.tgz",
-      "integrity": "sha512-gq0m0BTJfci60Fz4nczYxNAlED+sMcihltndR8t9t1evnU/azx53x3t2UHXC/uRjcbvRw/XctpaNygSTcQD+Iw==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.18.0.tgz",
+      "integrity": "sha512-As1EfFMVk7Xc6/CvhssHUjsAQSkpfXvUGMFC3ce8JDe6WvqCgRrLOBQbVpsBFr1X1V+RACOadnzVvcUS5ni2bA==",
       "dev": true,
       "requires": {
         "@eslint/eslintrc": "^1.3.0",
@@ -41972,9 +41594,9 @@
       }
     },
     "eslint-plugin-react-hooks": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.5.0.tgz",
-      "integrity": "sha512-8k1gRt7D7h03kd+SAAlzXkQwWK22BnK6GKZG+FJA6BAGy22CFvl8kCIXKpVux0cCxMWDQUPqSok0LKaZ0aOcCw==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz",
+      "integrity": "sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==",
       "dev": true,
       "requires": {}
     },
@@ -42272,119 +41894,6 @@
         "jest-matcher-utils": "^28.1.1",
         "jest-message-util": "^28.1.1",
         "jest-util": "^28.1.1"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "chalk": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true
-        },
-        "diff-sequences": {
-          "version": "28.1.1",
-          "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-28.1.1.tgz",
-          "integrity": "sha512-FU0iFaH/E23a+a718l8Qa/19bF9p06kgE0KipMOMadwa3SjnaElKzPaUC0vnibs6/B/9ni97s61mcejk8W1fQw==",
-          "dev": true
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true
-        },
-        "jest-diff": {
-          "version": "28.1.1",
-          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-28.1.1.tgz",
-          "integrity": "sha512-/MUUxeR2fHbqHoMMiffe/Afm+U8U4olFRJ0hiVG2lZatPJcnGxx292ustVu7bULhjV65IYMxRdploAKLbcrsyg==",
-          "dev": true,
-          "requires": {
-            "chalk": "^4.0.0",
-            "diff-sequences": "^28.1.1",
-            "jest-get-type": "^28.0.2",
-            "pretty-format": "^28.1.1"
-          }
-        },
-        "jest-get-type": {
-          "version": "28.0.2",
-          "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-28.0.2.tgz",
-          "integrity": "sha512-ioj2w9/DxSYHfOm5lJKCdcAmPJzQXmbM/Url3rhlghrPvT3tt+7a/+oXc9azkKmLvoiXjtV83bEWqi+vs5nlPA==",
-          "dev": true
-        },
-        "jest-matcher-utils": {
-          "version": "28.1.1",
-          "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-28.1.1.tgz",
-          "integrity": "sha512-NPJPRWrbmR2nAJ+1nmnfcKKzSwgfaciCCrYZzVnNoxVoyusYWIjkBMNvu0RHJe7dNj4hH3uZOPZsQA+xAYWqsw==",
-          "dev": true,
-          "requires": {
-            "chalk": "^4.0.0",
-            "jest-diff": "^28.1.1",
-            "jest-get-type": "^28.0.2",
-            "pretty-format": "^28.1.1"
-          }
-        },
-        "pretty-format": {
-          "version": "28.1.1",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-28.1.1.tgz",
-          "integrity": "sha512-wwJbVTGFHeucr5Jw2bQ9P+VYHyLdAqedFLEkdQUVaBF/eiidDwH5OpilINq4mEfhbCjLnirt6HTTDhv1HaTIQw==",
-          "dev": true,
-          "requires": {
-            "@jest/schemas": "^28.0.2",
-            "ansi-regex": "^5.0.1",
-            "ansi-styles": "^5.0.0",
-            "react-is": "^18.0.0"
-          },
-          "dependencies": {
-            "ansi-styles": {
-              "version": "5.2.0",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-              "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-              "dev": true
-            }
-          }
-        },
-        "react-is": {
-          "version": "18.1.0",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.1.0.tgz",
-          "integrity": "sha512-Fl7FuabXsJnV5Q1qIOQwx/sagGF18kogb4gpfcG4gjLBWO0WDiiz1ko/ExayuxE7InyQkBLkxRFG5oxY6Uu3Kg==",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        }
       }
     },
     "express": {
@@ -43121,26 +42630,1388 @@
       }
     },
     "geostyler-openlayers-parser": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/geostyler-openlayers-parser/-/geostyler-openlayers-parser-3.1.0.tgz",
-      "integrity": "sha512-TidTBmvlM/yVUWuarjO5mb9uiBmRDeWxCkdnvktuUrezWUWsVZWUXk9faA9s9D8o3IQMKJtI5UzIcSGuCB6H0Q==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/geostyler-openlayers-parser/-/geostyler-openlayers-parser-2.5.0.tgz",
+      "integrity": "sha512-Uum/lDci8oqhBA/c0RZbD91aXP4ycjlsAp4ZoVAPDHT6Og0XyF5Tze8wg0Ux44CerE6W+m2DfWkOTAP+iaakzQ==",
       "requires": {
-        "color-name": "^1.1.4",
-        "geostyler-style": "^5.0.2",
-        "lodash": "^4.17.21"
+        "@terrestris/ol-util": "^4.0.1",
+        "geostyler-style": "^4.0.0",
+        "lodash": "^4.17.15"
       },
       "dependencies": {
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        "@terrestris/ol-util": {
+          "version": "4.1.3",
+          "resolved": "https://registry.npmjs.org/@terrestris/ol-util/-/ol-util-4.1.3.tgz",
+          "integrity": "sha512-vTS7rXxOcvTpXQzRGR6DVldEYcbFjADQ9/ArSKeq9yCmmY9wb3dkeGKw+rN/dltu6oZbaswjsUsBQe060kiMOQ==",
+          "requires": {
+            "@terrestris/base-util": "^1.0.0",
+            "@turf/turf": "^5.1.6",
+            "lodash": "^4.17.20",
+            "proj4": "^2.7.0",
+            "shpjs": "^3.6.3"
+          }
+        },
+        "@turf/along": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/along/-/along-5.1.5.tgz",
+          "integrity": "sha512-N7BN1xvj6VWMe3UpjQDdVI0j0oY/EZ0bWgOgBXc4DlJ411uEsKCh6iBv0b2MSxQ3YUXEez3oc5FcgO9eVSs7iQ==",
+          "requires": {
+            "@turf/bearing": "^5.1.5",
+            "@turf/destination": "^5.1.5",
+            "@turf/distance": "^5.1.5",
+            "@turf/helpers": "^5.1.5"
+          }
+        },
+        "@turf/area": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/area/-/area-5.1.5.tgz",
+          "integrity": "sha512-lz16gqtvoz+j1jD9y3zj0Z5JnGNd3YfS0h+DQY1EcZymvi75Frm9i5YbEyth0RfxYZeOVufY7YIS3LXbJlI57g==",
+          "requires": {
+            "@turf/helpers": "^5.1.5",
+            "@turf/meta": "^5.1.5"
+          }
+        },
+        "@turf/bbox": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/bbox/-/bbox-5.1.5.tgz",
+          "integrity": "sha512-sYQU4fqsOYYJoD8UndC1n2hy8hV/lGIAmMLKWuzwmPUWqWOuSKWUcoRWDi9mGB0GvQQe/ow2IxZr8UaVaGz3sQ==",
+          "requires": {
+            "@turf/helpers": "^5.1.5",
+            "@turf/meta": "^5.1.5"
+          }
+        },
+        "@turf/bbox-clip": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/bbox-clip/-/bbox-clip-5.1.5.tgz",
+          "integrity": "sha512-KP64aoTvjcXxWHeM/Hs25vOQUBJgyJi7DlRVEoZofFJiR1kPnmDQrK7Xj+60lAk5cxuqzFnaPPxUk9Q+3v4p1Q==",
+          "requires": {
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5",
+            "lineclip": "^1.1.5"
+          }
+        },
+        "@turf/bbox-polygon": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/bbox-polygon/-/bbox-polygon-5.1.5.tgz",
+          "integrity": "sha512-PKVPF5LABFWZJud8KzzfesLGm5ihiwLbVa54HJjYySe6yqU/cr5q/qcN9TWptynOFhNktG1dr0KXVG0I2FZmfw==",
+          "requires": {
+            "@turf/helpers": "^5.1.5"
+          }
+        },
+        "@turf/bearing": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/bearing/-/bearing-5.1.5.tgz",
+          "integrity": "sha512-PrvZuJjnXGseB8hUatIjsrK3tgD3wttyRnVYXTbSfXYJZzaOfHDMplgO4lxXQp7diraZhGhCdSlbMvRRXItbUQ==",
+          "requires": {
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5"
+          }
+        },
+        "@turf/bezier-spline": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/bezier-spline/-/bezier-spline-5.1.5.tgz",
+          "integrity": "sha512-Y9NoComaGgFFFe9TWWE/cEMg2+EnBfU1R3112ec2wlx21ygDmFGXs4boOS71WM4ySwm/dbS3wxnbVxs4j68sKw==",
+          "requires": {
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5"
+          }
+        },
+        "@turf/boolean-clockwise": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/boolean-clockwise/-/boolean-clockwise-5.1.5.tgz",
+          "integrity": "sha512-FqbmEEOJ4rU4/2t7FKx0HUWmjFEVqR+NJrFP7ymGSjja2SQ7Q91nnBihGuT+yuHHl6ElMjQ3ttsB/eTmyCycxA==",
+          "requires": {
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5"
+          }
+        },
+        "@turf/boolean-contains": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/boolean-contains/-/boolean-contains-5.1.5.tgz",
+          "integrity": "sha512-x2HeEieeE9vBQrTdCuj4swnAXlpKbj9ChxMdDTV479c0m2gVmfea83ocmkj3w+9cvAaS63L8WqFyNVSmkwqljQ==",
+          "requires": {
+            "@turf/bbox": "^5.1.5",
+            "@turf/boolean-point-in-polygon": "^5.1.5",
+            "@turf/boolean-point-on-line": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5"
+          }
+        },
+        "@turf/boolean-crosses": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/boolean-crosses/-/boolean-crosses-5.1.5.tgz",
+          "integrity": "sha512-odljvS7INr9k/8yXeyXQVry7GqEaChOmXawP0+SoTfGO3hgptiik59TLU/Yjn/SLFjE2Ul54Ga1jKFSL7vvH0Q==",
+          "requires": {
+            "@turf/boolean-point-in-polygon": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5",
+            "@turf/line-intersect": "^5.1.5",
+            "@turf/polygon-to-line": "^5.1.5"
+          }
+        },
+        "@turf/boolean-disjoint": {
+          "version": "5.1.6",
+          "resolved": "https://registry.npmjs.org/@turf/boolean-disjoint/-/boolean-disjoint-5.1.6.tgz",
+          "integrity": "sha512-KHvUS6SBNYHBCLIJEJrg04pF5Oy+Fqn8V5G9U+9pti5vI9tyX7Ln2g7RSB7iJ1Cxsz8QAi6OukhXjEF2/8ZpGg==",
+          "requires": {
+            "@turf/boolean-point-in-polygon": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/line-intersect": "^5.1.5",
+            "@turf/meta": "^5.1.5",
+            "@turf/polygon-to-line": "^5.1.5"
+          }
+        },
+        "@turf/boolean-equal": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/boolean-equal/-/boolean-equal-5.1.5.tgz",
+          "integrity": "sha512-QEMbhDPV+J8PlRkMlVg6m5oSLaYUpOx2VUhDDekQ73FlpnhFBKRIlidhvHtS6CYnEw8d+/zA3h8Z18B4W4mq9Q==",
+          "requires": {
+            "@turf/clean-coords": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5",
+            "geojson-equality": "0.1.6"
+          }
+        },
+        "@turf/boolean-overlap": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/boolean-overlap/-/boolean-overlap-5.1.5.tgz",
+          "integrity": "sha512-lizojgU559KME0G705YAgWVa0B3/tsWNobMzOEWDx/1rABWTojCY4uxw2rFxpOsP++s8JJHrGWXRLh1PbdAvRQ==",
+          "requires": {
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5",
+            "@turf/line-intersect": "^5.1.5",
+            "@turf/line-overlap": "^5.1.5",
+            "@turf/meta": "^5.1.5",
+            "geojson-equality": "0.1.6"
+          }
+        },
+        "@turf/boolean-parallel": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/boolean-parallel/-/boolean-parallel-5.1.5.tgz",
+          "integrity": "sha512-eeuGgDhnas3nJ22A/DD8aiH0kg9dSzbQChIMAqYRPGg3pWNK41aGAbeh5z0GO5N/EVFX1+ga5a0vsPmiRgQB5g==",
+          "requires": {
+            "@turf/clean-coords": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/line-segment": "^5.1.5",
+            "@turf/rhumb-bearing": "^5.1.5"
+          },
+          "dependencies": {
+            "@turf/rhumb-bearing": {
+              "version": "5.1.5",
+              "resolved": "https://registry.npmjs.org/@turf/rhumb-bearing/-/rhumb-bearing-5.1.5.tgz",
+              "integrity": "sha512-zXTl2khjwf7mx2D1uPo5vgpGgP4sM2VrKDbJNKyulPu4TO4ELt8x7FsKyCBlRTzzQf284t/xnNcZOfUbkkd70g==",
+              "requires": {
+                "@turf/helpers": "^5.1.5",
+                "@turf/invariant": "^5.1.5"
+              }
+            }
+          }
+        },
+        "@turf/boolean-point-in-polygon": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/boolean-point-in-polygon/-/boolean-point-in-polygon-5.1.5.tgz",
+          "integrity": "sha512-y+gbAhLmsAZH9uYhv+C68pu06mxsGIm3o7l0hzVkc/PXYdbkr+vKe7n7PfSN3xpVA3qoDLKLpCGOqeW8/ThaJA==",
+          "requires": {
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5"
+          }
+        },
+        "@turf/boolean-point-on-line": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/boolean-point-on-line/-/boolean-point-on-line-5.1.5.tgz",
+          "integrity": "sha512-Zf4d28mckV2tYfLWf2iqxQ8eeLZqi2HGimM26mptf1OCEIwc1wfkKgLRRJXMu94Crvd/pJxjRAjoYGcGliP6Vg==",
+          "requires": {
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5"
+          }
+        },
+        "@turf/boolean-within": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/boolean-within/-/boolean-within-5.1.5.tgz",
+          "integrity": "sha512-CNAtrvm4HiUwV/vhpGhvJzfhV9CN7VhPC5y4tTfQicK82fYY6ifPz0iaNpUOmshU6+TAot/fsVQVgDJ4t7HXcA==",
+          "requires": {
+            "@turf/bbox": "^5.1.5",
+            "@turf/boolean-point-in-polygon": "^5.1.5",
+            "@turf/boolean-point-on-line": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5"
+          }
+        },
+        "@turf/buffer": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/buffer/-/buffer-5.1.5.tgz",
+          "integrity": "sha512-U3LU0HF/JNFUNabpB5ArpNG6yPla7yR5XPrZvzZRH48vvbr/N0rkSRI0tJFRWTz7ntugVm9X0OD9Y382NTJRhA==",
+          "requires": {
+            "@turf/bbox": "^5.1.5",
+            "@turf/center": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/meta": "^5.1.5",
+            "@turf/projection": "^5.1.5",
+            "d3-geo": "1.7.1",
+            "turf-jsts": "*"
+          },
+          "dependencies": {
+            "@turf/projection": {
+              "version": "5.1.5",
+              "resolved": "https://registry.npmjs.org/@turf/projection/-/projection-5.1.5.tgz",
+              "integrity": "sha512-TWKJDFeEKQhI4Ce1+2PuOSDggn4cnMibqyUoCpIW+4KxUC1R88SE3/SYomqzwxMn00O09glHSycPkGD5JzHd8A==",
+              "requires": {
+                "@turf/clone": "^5.1.5",
+                "@turf/helpers": "^5.1.5",
+                "@turf/meta": "^5.1.5"
+              }
+            }
+          }
+        },
+        "@turf/center": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/center/-/center-5.1.5.tgz",
+          "integrity": "sha512-Dy1TvAv2oHKFddZcWqlVsanxurfcZV1Mmb1E+7H7GRKI+fXZTfRjwCdbiZCbO/tPwxt8jWQHWdLHn8E9lecc3A==",
+          "requires": {
+            "@turf/bbox": "^5.1.5",
+            "@turf/helpers": "^5.1.5"
+          }
+        },
+        "@turf/center-mean": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/center-mean/-/center-mean-5.1.5.tgz",
+          "integrity": "sha512-XdkBXzFUuyCqu5EPlBwgkv8FLA8pIGBnt7xy5cxxhxKOYLMrKqwMPPHPA84TjeQpNti0gH0CVuOk2r1f/Pp8iQ==",
+          "requires": {
+            "@turf/bbox": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/meta": "^5.1.5"
+          }
+        },
+        "@turf/center-median": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/center-median/-/center-median-5.1.5.tgz",
+          "integrity": "sha512-M+O6bSNsIDKZ4utk/YzSOIg6W0isjLVWud+TCLWyrDCWTSERlSJlhOaVE1y7cObhG8nYBHvmszqZyoAY6nufQw==",
+          "requires": {
+            "@turf/center-mean": "^5.1.5",
+            "@turf/centroid": "^5.1.5",
+            "@turf/distance": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/meta": "^5.1.5"
+          }
+        },
+        "@turf/center-of-mass": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/center-of-mass/-/center-of-mass-5.1.5.tgz",
+          "integrity": "sha512-UvI7q6GgW3afCVIDOyTRuLT54v9Xwv65Xudxh4FIT6w7HNU4KUBtTGnx0NuhODZcgvZgWVWVakhmIcHQTMjYYA==",
+          "requires": {
+            "@turf/centroid": "^5.1.5",
+            "@turf/convex": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5",
+            "@turf/meta": "^5.1.5"
+          }
+        },
+        "@turf/centroid": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/centroid/-/centroid-5.1.5.tgz",
+          "integrity": "sha512-0m9ZAZJB4YXLDxF2fWGqlE/g9Y68cebeWaRNOMN+e6Bti1fz0JKQuaEqJV+J8xOmODPHSMbZZ1SqSDVRgVHP2Q==",
+          "requires": {
+            "@turf/helpers": "^5.1.5",
+            "@turf/meta": "^5.1.5"
+          }
+        },
+        "@turf/circle": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/circle/-/circle-5.1.5.tgz",
+          "integrity": "sha512-CNaEtvp38Q+TSFJHdzdl5iYNjBFZRluRTFikIuEcennSeMJD60nP0dMubP58TR/QQn541eNDUyED90V4KuOjyQ==",
+          "requires": {
+            "@turf/destination": "^5.1.5",
+            "@turf/helpers": "^5.1.5"
+          }
+        },
+        "@turf/clean-coords": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/clean-coords/-/clean-coords-5.1.5.tgz",
+          "integrity": "sha512-xd/iSM0McVUxbu81KCKDqirCsYkKk3EAwpDjYI8vIQ+eKf/MLSdteRcm3PB7wo2y6JcYp4dMGv2cr9IP7V+dXQ==",
+          "requires": {
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5"
+          }
+        },
+        "@turf/clone": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/clone/-/clone-5.1.5.tgz",
+          "integrity": "sha512-//pITsQ8xUdcQ9pVb4JqXiSqG4dos5Q9N4sYFoWghX21tfOV2dhc5TGqYOhnHrQS7RiKQL1vQ48kIK34gQ5oRg==",
+          "requires": {
+            "@turf/helpers": "^5.1.5"
+          }
+        },
+        "@turf/clusters": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/clusters/-/clusters-5.1.5.tgz",
+          "integrity": "sha512-+rQe+g66xfbIXz58tveXQCDdE9hzqRJtDVSw5xth92TvCcL4J60ZKN8mHNUSn1ZZvpUHtVPe4dYcbtk5bW8fXQ==",
+          "requires": {
+            "@turf/helpers": "^5.1.5",
+            "@turf/meta": "^5.1.5"
+          }
+        },
+        "@turf/clusters-dbscan": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/clusters-dbscan/-/clusters-dbscan-5.1.5.tgz",
+          "integrity": "sha512-X3qLLHJkwMuv+xdWQ08NtOc6BgeqCKKSAltyyAZ7iImE65f0C+sW024DfHSbTMsZVXBFst2Q6RQY8RVUf3QBeQ==",
+          "requires": {
+            "@turf/clone": "^5.1.5",
+            "@turf/distance": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5",
+            "@turf/meta": "^5.1.5",
+            "density-clustering": "1.3.0"
+          }
+        },
+        "@turf/clusters-kmeans": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/clusters-kmeans/-/clusters-kmeans-5.1.5.tgz",
+          "integrity": "sha512-W6raiv9+fRgmJxCvKrpSacbLXzh7beZUk0A1pjF82Fv3CFTrXAJbgAyIbdlmgXezYSXhOT5NMUugnbkUy2oBZw==",
+          "requires": {
+            "@turf/clone": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5",
+            "@turf/meta": "^5.1.5",
+            "skmeans": "0.9.7"
+          }
+        },
+        "@turf/collect": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/collect/-/collect-5.1.5.tgz",
+          "integrity": "sha512-voFWu6EGPcNuIbAp43yvGf2Ip4/q8TTeWhOSJ2yDEHgOfbAwrNUwUJCclEjcUVsnc7ypKNrFn3/8bmR9tI0NQg==",
+          "requires": {
+            "@turf/bbox": "^5.1.5",
+            "@turf/boolean-point-in-polygon": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "rbush": "^2.0.1"
+          }
+        },
+        "@turf/combine": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/combine/-/combine-5.1.5.tgz",
+          "integrity": "sha512-/RqmfCvduHquINVyNmzKOcZtZjfaEHMhghgmj8MYnzepN3ro+E2QXoaQGGrQ7nChAvGgWPAvN8EveVSc1MvzPg==",
+          "requires": {
+            "@turf/helpers": "^5.1.5",
+            "@turf/meta": "^5.1.5"
+          }
+        },
+        "@turf/concave": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/concave/-/concave-5.1.5.tgz",
+          "integrity": "sha512-NvR5vmAunmgjEPjNzmvjLRvPcj7C6WuqCf+vu/aqyc4h2c1B/x399bDsSM64iFT+PYesFuoS1ZhJHWivXG8Y5g==",
+          "requires": {
+            "@turf/clone": "^5.1.5",
+            "@turf/distance": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5",
+            "@turf/meta": "^5.1.5",
+            "@turf/tin": "^5.1.5",
+            "topojson-client": "3.x",
+            "topojson-server": "3.x"
+          }
+        },
+        "@turf/convex": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/convex/-/convex-5.1.5.tgz",
+          "integrity": "sha512-ZEk4kIAoYR/mjO3C8rMe2StgmwhdwmbxVvNxg3udeahe2m0ZzbfkRC4HiJAaBgfR4TLJUAEewynESReTPwASBQ==",
+          "requires": {
+            "@turf/helpers": "^5.1.5",
+            "@turf/meta": "^5.1.5",
+            "concaveman": "*"
+          }
+        },
+        "@turf/destination": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/destination/-/destination-5.1.5.tgz",
+          "integrity": "sha512-EWwZnd4wxUO9d8UWzJt88jQlFf6W/6SE1930MMzzIR9o+RfqhrS/BL1eUDrg5I5drsymf6PZsK0j/V0q6jqkFQ==",
+          "requires": {
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5"
+          }
+        },
+        "@turf/difference": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/difference/-/difference-5.1.5.tgz",
+          "integrity": "sha512-hIjiUHS8WiDfnmADQrhh6QcXWc3zNtjIpPQ5g/2NZ3k1mjnOdmGBVObkSJG4WEUNqyj3PKlsZ8W9xnSu+lLF1Q==",
+          "requires": {
+            "@turf/area": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5",
+            "@turf/meta": "^5.1.5",
+            "turf-jsts": "*"
+          }
+        },
+        "@turf/dissolve": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/dissolve/-/dissolve-5.1.5.tgz",
+          "integrity": "sha512-YcQgyp7pvhyZHCmbqqItVH6vHs43R9N0jzP/LnAG03oMiY4wves/BO1du6VDDbnJSXeRKf1afmY9tRGKYrm9ag==",
+          "requires": {
+            "@turf/boolean-overlap": "^5.1.5",
+            "@turf/clone": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5",
+            "@turf/line-intersect": "^5.1.5",
+            "@turf/meta": "^5.1.5",
+            "@turf/union": "^5.1.5",
+            "geojson-rbush": "2.1.0",
+            "get-closest": "*"
+          }
+        },
+        "@turf/distance": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/distance/-/distance-5.1.5.tgz",
+          "integrity": "sha512-sYCAgYZ2MjNKMtx17EijHlK9qHwpA0MuuQWbR4P30LTCl52UlG/reBfV899wKyF3HuDL9ux78IbILwOfeQ4zgA==",
+          "requires": {
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5"
+          }
+        },
+        "@turf/ellipse": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/ellipse/-/ellipse-5.1.5.tgz",
+          "integrity": "sha512-oVTzEyDOi3d9isgB7Ah+YiOoUKB1eHMtMDXVl1oT+vC/T+6KR2aq+HjjbF11A0cjuh3VhjSWUZaS+2TYY0pu0w==",
+          "requires": {
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5",
+            "@turf/rhumb-destination": "^5.1.5",
+            "@turf/transform-rotate": "^5.1.5"
+          }
+        },
+        "@turf/envelope": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/envelope/-/envelope-5.1.5.tgz",
+          "integrity": "sha512-Mxl5A2euAxq3RZVN65/MVyaO91kzGU8MJXfegPdep6SN4bONDadEp0olwW5qSRf2U3cJ8Jppl089X6AeifD3IA==",
+          "requires": {
+            "@turf/bbox": "^5.1.5",
+            "@turf/bbox-polygon": "^5.1.5",
+            "@turf/helpers": "^5.1.5"
+          }
+        },
+        "@turf/explode": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/explode/-/explode-5.1.5.tgz",
+          "integrity": "sha512-v/hC9DB9RKRW9/ZjnKoQelIp08JNa5wew0889465s//tfgY8+JEGkSGMag2L2NnVARWmzI/vlLgMK36qwkyDIA==",
+          "requires": {
+            "@turf/helpers": "^5.1.5",
+            "@turf/meta": "^5.1.5"
+          }
+        },
+        "@turf/flatten": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/flatten/-/flatten-5.1.5.tgz",
+          "integrity": "sha512-aagHz5tjHmOtb8eMb5fd10+HJwdlhkhsPql1vRXQNnpv0Q9xL/4SsbvXZ6lPqkRAjiZuy087mvaz+ERml76/jg==",
+          "requires": {
+            "@turf/helpers": "^5.1.5",
+            "@turf/meta": "^5.1.5"
+          }
+        },
+        "@turf/flip": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/flip/-/flip-5.1.5.tgz",
+          "integrity": "sha512-7+IYM3QQAkV4co3wjEmM726/OkXqUCCHWWyIqrI9hiK+LR628qkoqP1hk6rQ4vZJrAYuvSlK+FZnr24OtgY0cw==",
+          "requires": {
+            "@turf/clone": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/meta": "^5.1.5"
+          }
+        },
+        "@turf/great-circle": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/great-circle/-/great-circle-5.1.5.tgz",
+          "integrity": "sha512-k6FWwlt+YCQoD5VS1NybQjriNL7apYHO+tm2HbIFQ85blPUX4IyLppHIFevfD/k+K2bJqhFCze8JNVMBwdrzVw==",
+          "requires": {
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5"
+          }
+        },
+        "@turf/helpers": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-5.1.5.tgz",
+          "integrity": "sha512-/lF+JR+qNDHZ8bF9d+Cp58nxtZWJ3sqFe6n3u3Vpj+/0cqkjk4nXKYBSY0azm+GIYB5mWKxUXvuP/m0ZnKj1bw=="
+        },
+        "@turf/hex-grid": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/hex-grid/-/hex-grid-5.1.5.tgz",
+          "integrity": "sha512-rwDL+DlUyxDNL1aVHIKKCmrt1131ZULF3irExYIO/um6/SwRzsBw+522/RcxD/mg/Shtrpozb6bz8aJJ/3RXHA==",
+          "requires": {
+            "@turf/distance": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/intersect": "^5.1.5",
+            "@turf/invariant": "^5.1.5"
+          }
+        },
+        "@turf/interpolate": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/interpolate/-/interpolate-5.1.5.tgz",
+          "integrity": "sha512-LfmvtIUWc3NVkqPkX6j3CAIjF7y1LAZqfDd+2Ii+0fN7XOOGMWcb1uiTTAb8zDQjhTsygcUYgaz6mMYDCWYKPg==",
+          "requires": {
+            "@turf/bbox": "^5.1.5",
+            "@turf/centroid": "^5.1.5",
+            "@turf/clone": "^5.1.5",
+            "@turf/distance": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/hex-grid": "^5.1.5",
+            "@turf/invariant": "^5.1.5",
+            "@turf/meta": "^5.1.5",
+            "@turf/point-grid": "^5.1.5",
+            "@turf/square-grid": "^5.1.5",
+            "@turf/triangle-grid": "^5.1.5"
+          }
+        },
+        "@turf/intersect": {
+          "version": "5.1.6",
+          "resolved": "https://registry.npmjs.org/@turf/intersect/-/intersect-5.1.6.tgz",
+          "integrity": "sha512-KXyNv/GXdoGAOy03qZF53rgtXC2tNhF/4jLwTKiVRrBQH6kcEpipGStdJ+QkYIlarQPa8f7I9UlVAB19et4MfQ==",
+          "requires": {
+            "@turf/clean-coords": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5",
+            "@turf/truncate": "^5.1.5",
+            "turf-jsts": "*"
+          }
+        },
+        "@turf/invariant": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-5.1.5.tgz",
+          "integrity": "sha512-4elbC8GVQ8XxrnWLWpFFXTK3qnzIYzIVtSkJrY9eefA8WNZzwcwT3WGFY3xte4BB48o5oEjihjoJharWRis78w==",
+          "requires": {
+            "@turf/helpers": "^5.1.5"
+          }
+        },
+        "@turf/isobands": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/isobands/-/isobands-5.1.5.tgz",
+          "integrity": "sha512-0n3NPfDYQyqjOch00I4hVCCqjKn9Sm+a8qlWOKbkuhmGa9dCDzsu2bZL0ahT+LjwlS4c8/owQXqe6KE2GWqT1Q==",
+          "requires": {
+            "@turf/area": "^5.1.5",
+            "@turf/bbox": "^5.1.5",
+            "@turf/boolean-point-in-polygon": "^5.1.5",
+            "@turf/explode": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5",
+            "@turf/meta": "^5.1.5"
+          }
+        },
+        "@turf/isolines": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/isolines/-/isolines-5.1.5.tgz",
+          "integrity": "sha512-Ehn5pJmiq4hAn2+2jPB2rLt3iF8DDp8zciw9z2pAt5IGVRU/K+x3z4aYG5ra5vbFB/E4G3aHr/X4QPIb9LCJtA==",
+          "requires": {
+            "@turf/bbox": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5",
+            "@turf/meta": "^5.1.5"
+          }
+        },
+        "@turf/kinks": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/kinks/-/kinks-5.1.5.tgz",
+          "integrity": "sha512-G38sC8/+MYqQpVocT3XahhV42cqEAVJAZwUND9YOfKJZfjUn7FKmWhPURs5py95me48UuI0C0jLLAMzBkUc2nQ==",
+          "requires": {
+            "@turf/helpers": "^5.1.5"
+          }
+        },
+        "@turf/length": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/length/-/length-5.1.5.tgz",
+          "integrity": "sha512-0ryx68h512wCoNfwyksLdabxEfwkGNTPg61/QiY+QfGFUOUNhHbP+QimViFpwF5hyX7qmroaSHVclLUqyLGRbg==",
+          "requires": {
+            "@turf/distance": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/meta": "^5.1.5"
+          }
+        },
+        "@turf/line-arc": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/line-arc/-/line-arc-5.1.5.tgz",
+          "integrity": "sha512-Kz5RX/qRIHVrGNqF3BRlD3ACuuCr0G5lpaVyPjNvN+vA7Q4bEDyWIYeqm3DdTn7X2MXitpTNgr2uvX4WoUy4yA==",
+          "requires": {
+            "@turf/circle": "^5.1.5",
+            "@turf/destination": "^5.1.5",
+            "@turf/helpers": "^5.1.5"
+          }
+        },
+        "@turf/line-chunk": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/line-chunk/-/line-chunk-5.1.5.tgz",
+          "integrity": "sha512-mKvTUMahnb3EsYUMI8tQmygsliQkgQ1FZAY915zoTrm+WV246loa+84+h7i5d8W2O8gGJWuY7jQTpM7toTeL5w==",
+          "requires": {
+            "@turf/helpers": "^5.1.5",
+            "@turf/length": "^5.1.5",
+            "@turf/line-slice-along": "^5.1.5",
+            "@turf/meta": "^5.1.5"
+          }
+        },
+        "@turf/line-intersect": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/line-intersect/-/line-intersect-5.1.5.tgz",
+          "integrity": "sha512-9DajJbHhJauLI2qVMnqZ7SeFsinFroVICOSUheODk7j5teuwNABuZ2Z6WmKATzEsPkEJ1iVykqB+F9vGMVKB6g==",
+          "requires": {
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5",
+            "@turf/line-segment": "^5.1.5",
+            "@turf/meta": "^5.1.5",
+            "geojson-rbush": "2.1.0"
+          }
+        },
+        "@turf/line-offset": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/line-offset/-/line-offset-5.1.5.tgz",
+          "integrity": "sha512-VccGDgFfBSiCTqrHdQgxD7Rs9lnJmDOJ5gqQRculKPsCNUyRFMYIZud7l2dTs83g66evfOwkZCrTxtSoBY3Jxg==",
+          "requires": {
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5",
+            "@turf/meta": "^5.1.5"
+          }
+        },
+        "@turf/line-overlap": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/line-overlap/-/line-overlap-5.1.5.tgz",
+          "integrity": "sha512-hMz3XARXEbfGwLF9WXyErqQjzhZYMKvGQwlPGOoth+2o9Uga9mfWfevduJvozJAE1MKxtFttMjIXMzcShW3O8A==",
+          "requires": {
+            "@turf/boolean-point-on-line": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5",
+            "@turf/line-segment": "^5.1.5",
+            "@turf/meta": "^5.1.5",
+            "@turf/nearest-point-on-line": "^5.1.5",
+            "geojson-rbush": "2.1.0"
+          }
+        },
+        "@turf/line-segment": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/line-segment/-/line-segment-5.1.5.tgz",
+          "integrity": "sha512-wIrRtWuLuLXhnSkqdVG1SDayTU0/CmZf+a+BBhEf0vFIsAedJnrY3a2cbCEvtfuk6ZsAbhOi7/kYiaR/F+rEzg==",
+          "requires": {
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5",
+            "@turf/meta": "^5.1.5"
+          }
+        },
+        "@turf/line-slice": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/line-slice/-/line-slice-5.1.5.tgz",
+          "integrity": "sha512-Fo+CuD+fj6T702BofHO+rgiXUgzCk0iO2JqMPtttMtgzfKkVTUOQoauMNS1LNNaG/7n/TfKGh5gRCEDRNaNwYA==",
+          "requires": {
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5",
+            "@turf/nearest-point-on-line": "^5.1.5"
+          }
+        },
+        "@turf/line-slice-along": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/line-slice-along/-/line-slice-along-5.1.5.tgz",
+          "integrity": "sha512-yKvSDtULztLtlPIMowm9l8pS6XLAEpCPmrARZA0sIWFX8XrcSzISBaXZbiMMzg3nxQJMXfGIgWDk10B7+J8Tqw==",
+          "requires": {
+            "@turf/bearing": "^5.1.5",
+            "@turf/destination": "^5.1.5",
+            "@turf/distance": "^5.1.5",
+            "@turf/helpers": "^5.1.5"
+          }
+        },
+        "@turf/line-split": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/line-split/-/line-split-5.1.5.tgz",
+          "integrity": "sha512-gtUUBwZL3hcSu5MpqHTl68hgAJBNHcr1APDj8E5o6iX5xFX+wvl4ohQXyMs5HOATCI8Iy83wLuggcY6maNw7LQ==",
+          "requires": {
+            "@turf/bbox": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5",
+            "@turf/line-intersect": "^5.1.5",
+            "@turf/line-segment": "^5.1.5",
+            "@turf/meta": "^5.1.5",
+            "@turf/nearest-point-on-line": "^5.1.5",
+            "@turf/square": "^5.1.5",
+            "@turf/truncate": "^5.1.5",
+            "geojson-rbush": "2.1.0"
+          }
+        },
+        "@turf/line-to-polygon": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/line-to-polygon/-/line-to-polygon-5.1.5.tgz",
+          "integrity": "sha512-hGiDAPd6j986kZZLDgEAkVD7O6DmIqHQliBedspoKperPJOUJJzdzSnF6OAWSsxY+j8fWtQnIo5TTqdO/KfamA==",
+          "requires": {
+            "@turf/bbox": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5"
+          }
+        },
+        "@turf/mask": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/mask/-/mask-5.1.5.tgz",
+          "integrity": "sha512-2eOuxA3ammZAGsjlsy/H7IpeJxjl3hrgkcKM6kTKRJGft4QyKwCxqQP7RN5j0zIYvAurgs9JOLe/dpd5sE5HXQ==",
+          "requires": {
+            "@turf/bbox": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/meta": "^5.1.5",
+            "@turf/union": "^5.1.5",
+            "rbush": "^2.0.1"
+          }
+        },
+        "@turf/meta": {
+          "version": "5.1.6",
+          "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-5.1.6.tgz",
+          "integrity": "sha512-lv+6LCgoc3LVitQZ4TScN/8a/fcctq8bIoxBTMJVq4aU8xoHeY1851Dq8MCU37EzbH33utkx8/jENaQP+aeElg==",
+          "requires": {
+            "@turf/helpers": "^5.1.5"
+          }
+        },
+        "@turf/midpoint": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/midpoint/-/midpoint-5.1.5.tgz",
+          "integrity": "sha512-0pDQAKHyK/zxlvUx3XNxwvqftf4sV32QxnHfqSs4AXaODUGUbPhzAD7aXgDScBeUOVLwpAzFRQfitUvUMTGC6A==",
+          "requires": {
+            "@turf/bearing": "^5.1.5",
+            "@turf/destination": "^5.1.5",
+            "@turf/distance": "^5.1.5",
+            "@turf/helpers": "^5.1.5"
+          }
+        },
+        "@turf/nearest-point": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/nearest-point/-/nearest-point-5.1.5.tgz",
+          "integrity": "sha512-tZQXI7OE7keNKK4OvYOJ5gervCEuu2pJ6psu59QW9yhe2Di3Gl+HAdLvVa6RZ8s5Fndr3u0JWKsmxve3fCxc9g==",
+          "requires": {
+            "@turf/clone": "^5.1.5",
+            "@turf/distance": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/meta": "^5.1.5"
+          }
+        },
+        "@turf/nearest-point-on-line": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/nearest-point-on-line/-/nearest-point-on-line-5.1.5.tgz",
+          "integrity": "sha512-qT7BLTwToo8cq0oNoz921oLlRPJamyRg/rZgll+kNBadyDPmJI4W66riHcpM9RQcAJ6TPvDveIIBeGJH7iG88w==",
+          "requires": {
+            "@turf/bearing": "^5.1.5",
+            "@turf/destination": "^5.1.5",
+            "@turf/distance": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5",
+            "@turf/line-intersect": "^5.1.5",
+            "@turf/meta": "^5.1.5"
+          }
+        },
+        "@turf/nearest-point-to-line": {
+          "version": "5.1.6",
+          "resolved": "https://registry.npmjs.org/@turf/nearest-point-to-line/-/nearest-point-to-line-5.1.6.tgz",
+          "integrity": "sha512-ZSvDIEiHhifn/vNwLXZI/E8xmEz5yBPqfUR7BVHRZrB1cP7jLhKZvkbidjG//uW8Fr1Ulc+PFOXczLspIcx/lw==",
+          "requires": {
+            "@turf/helpers": "6.x",
+            "@turf/invariant": "6.x",
+            "@turf/meta": "6.x",
+            "@turf/point-to-line-distance": "^5.1.5",
+            "object-assign": "*"
+          },
+          "dependencies": {
+            "@turf/helpers": {
+              "version": "6.5.0",
+              "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.5.0.tgz",
+              "integrity": "sha512-VbI1dV5bLFzohYYdgqwikdMVpe7pJ9X3E+dlr425wa2/sMJqYDhTO++ec38/pcPvPE6oD9WEEeU3Xu3gza+VPw=="
+            },
+            "@turf/invariant": {
+              "version": "6.5.0",
+              "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-6.5.0.tgz",
+              "integrity": "sha512-Wv8PRNCtPD31UVbdJE/KVAWKe7l6US+lJItRR/HOEW3eh+U/JwRCSUl/KZ7bmjM/C+zLNoreM2TU6OoLACs4eg==",
+              "requires": {
+                "@turf/helpers": "^6.5.0"
+              }
+            },
+            "@turf/meta": {
+              "version": "6.5.0",
+              "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-6.5.0.tgz",
+              "integrity": "sha512-RrArvtsV0vdsCBegoBtOalgdSOfkBrTJ07VkpiCnq/491W67hnMWmDu7e6Ztw0C3WldRYTXkg3SumfdzZxLBHA==",
+              "requires": {
+                "@turf/helpers": "^6.5.0"
+              }
+            }
+          }
+        },
+        "@turf/planepoint": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/planepoint/-/planepoint-5.1.5.tgz",
+          "integrity": "sha512-+Tp+SQ0Db2tqwLbxfXJPysT9IxcOHSMIin2dJb/j3Qn5+g0LRus6rczZl6dWNAIjqBPMawj/V/dZhMu6Q9O9wA==",
+          "requires": {
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5"
+          }
+        },
+        "@turf/point-grid": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/point-grid/-/point-grid-5.1.5.tgz",
+          "integrity": "sha512-4ibozguP9YJ297Q7i9e8/ypGSycvt1re2jrPXTxeuZ4/L/NE5B1nOBLG+tw121nMjD+S+v2RWOtqD+FZ3Ga+ew==",
+          "requires": {
+            "@turf/boolean-within": "^5.1.5",
+            "@turf/distance": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5"
+          }
+        },
+        "@turf/point-on-feature": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/point-on-feature/-/point-on-feature-5.1.5.tgz",
+          "integrity": "sha512-NTcpe5xZjybRh0aTL+7td1cm0s49GGbAt5u8Cdec4W9ix2PsehRcLUbmQIQsODN2kiVyUSpnhECIpsyN5MjX7A==",
+          "requires": {
+            "@turf/boolean-point-in-polygon": "^5.1.5",
+            "@turf/center": "^5.1.5",
+            "@turf/explode": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/nearest-point": "^5.1.5"
+          }
+        },
+        "@turf/point-to-line-distance": {
+          "version": "5.1.6",
+          "resolved": "https://registry.npmjs.org/@turf/point-to-line-distance/-/point-to-line-distance-5.1.6.tgz",
+          "integrity": "sha512-PE3hiTeeDEi4ZLPtI8XAzFYW9nHo1EVsZGm/4ZVV8jo39d3X1oLVHxY3e1PkCmWwRapXy4QLqvnTQ7nU4wspNw==",
+          "requires": {
+            "@turf/bearing": "6.x",
+            "@turf/distance": "6.x",
+            "@turf/helpers": "6.x",
+            "@turf/invariant": "6.x",
+            "@turf/meta": "6.x",
+            "@turf/projection": "6.x",
+            "@turf/rhumb-bearing": "6.x",
+            "@turf/rhumb-distance": "6.x"
+          },
+          "dependencies": {
+            "@turf/bearing": {
+              "version": "6.5.0",
+              "resolved": "https://registry.npmjs.org/@turf/bearing/-/bearing-6.5.0.tgz",
+              "integrity": "sha512-dxINYhIEMzgDOztyMZc20I7ssYVNEpSv04VbMo5YPQsqa80KO3TFvbuCahMsCAW5z8Tncc8dwBlEFrmRjJG33A==",
+              "requires": {
+                "@turf/helpers": "^6.5.0",
+                "@turf/invariant": "^6.5.0"
+              }
+            },
+            "@turf/distance": {
+              "version": "6.5.0",
+              "resolved": "https://registry.npmjs.org/@turf/distance/-/distance-6.5.0.tgz",
+              "integrity": "sha512-xzykSLfoURec5qvQJcfifw/1mJa+5UwByZZ5TZ8iaqjGYN0vomhV9aiSLeYdUGtYRESZ+DYC/OzY+4RclZYgMg==",
+              "requires": {
+                "@turf/helpers": "^6.5.0",
+                "@turf/invariant": "^6.5.0"
+              }
+            },
+            "@turf/helpers": {
+              "version": "6.5.0",
+              "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.5.0.tgz",
+              "integrity": "sha512-VbI1dV5bLFzohYYdgqwikdMVpe7pJ9X3E+dlr425wa2/sMJqYDhTO++ec38/pcPvPE6oD9WEEeU3Xu3gza+VPw=="
+            },
+            "@turf/invariant": {
+              "version": "6.5.0",
+              "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-6.5.0.tgz",
+              "integrity": "sha512-Wv8PRNCtPD31UVbdJE/KVAWKe7l6US+lJItRR/HOEW3eh+U/JwRCSUl/KZ7bmjM/C+zLNoreM2TU6OoLACs4eg==",
+              "requires": {
+                "@turf/helpers": "^6.5.0"
+              }
+            },
+            "@turf/meta": {
+              "version": "6.5.0",
+              "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-6.5.0.tgz",
+              "integrity": "sha512-RrArvtsV0vdsCBegoBtOalgdSOfkBrTJ07VkpiCnq/491W67hnMWmDu7e6Ztw0C3WldRYTXkg3SumfdzZxLBHA==",
+              "requires": {
+                "@turf/helpers": "^6.5.0"
+              }
+            }
+          }
+        },
+        "@turf/points-within-polygon": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/points-within-polygon/-/points-within-polygon-5.1.5.tgz",
+          "integrity": "sha512-nexe2AHVOY8wEBvs+CYSOp10NyOCkyZ1gkhIfsx0mzU8LPYBxD9ctjlKveheKh4AAldLcFupd/gSCBTKF1JS7A==",
+          "requires": {
+            "@turf/boolean-point-in-polygon": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/meta": "^5.1.5"
+          }
+        },
+        "@turf/polygon-tangents": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/polygon-tangents/-/polygon-tangents-5.1.5.tgz",
+          "integrity": "sha512-uoZfKvFhl6rf0+CDWucru9fZ4mJB5Nsg37TS/7emrzjoVxXyOdxc/s1HFCjcKflMue7MjU/gT6AitJyrvdztDg==",
+          "requires": {
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5"
+          }
+        },
+        "@turf/polygon-to-line": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/polygon-to-line/-/polygon-to-line-5.1.5.tgz",
+          "integrity": "sha512-kVo0owPqyccy5+qZGvaxGvMsYkgueKE2OOgX2UV/HyrXF3uI3TomK1txjApqeFsLvwuSANxesvVbYLrYiIwvGw==",
+          "requires": {
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5"
+          }
+        },
+        "@turf/polygonize": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/polygonize/-/polygonize-5.1.5.tgz",
+          "integrity": "sha512-qzhtuzoOhldqZHm+ZPsWAs9nDpnkcDfsr+I0twmBF+wjAmo0HKiy9++sRQ4kEePpdwbMpF07D/NdZqYdmOJkGQ==",
+          "requires": {
+            "@turf/boolean-point-in-polygon": "^5.1.5",
+            "@turf/envelope": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5",
+            "@turf/meta": "^5.1.5"
+          }
+        },
+        "@turf/random": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/random/-/random-5.1.5.tgz",
+          "integrity": "sha512-oitpBwEb6YXqoUkIAOVMK+vrTPxUi2rqITmtTa/FBHr6J8TDwMWq6bufE3Gmgjxsss50O2ITJunOksxrouWGDQ==",
+          "requires": {
+            "@turf/helpers": "^5.1.5"
+          }
+        },
+        "@turf/rewind": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/rewind/-/rewind-5.1.5.tgz",
+          "integrity": "sha512-Gdem7JXNu+G4hMllQHXRFRihJl3+pNl7qY+l4qhQFxq+hiU1cQoVFnyoleIqWKIrdK/i2YubaSwc3SCM7N5mMw==",
+          "requires": {
+            "@turf/boolean-clockwise": "^5.1.5",
+            "@turf/clone": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5",
+            "@turf/meta": "^5.1.5"
+          }
+        },
+        "@turf/rhumb-destination": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/rhumb-destination/-/rhumb-destination-5.1.5.tgz",
+          "integrity": "sha512-FdDUCSRfRAfsRmUaWjc76Wk32QYFJ6ckmSt6Ls6nEczO6eg/RgH1atF8CIYwR5ifl0Sk1rQzKiOSbpCyvVwQtw==",
+          "requires": {
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5"
+          }
+        },
+        "@turf/sample": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/sample/-/sample-5.1.5.tgz",
+          "integrity": "sha512-EJE8yx+5x7rXejTzwBdOKpvT4tOCS0jwYJfycyTVDuLUSh2rETeYdjy7EeJbofnxm9CRPXqWQMPWIBKWxNTjow==",
+          "requires": {
+            "@turf/helpers": "^5.1.5"
+          }
+        },
+        "@turf/sector": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/sector/-/sector-5.1.5.tgz",
+          "integrity": "sha512-dnWVifL3xWTqPPs8mfbbV9muDimNJtxRk4ogrkOLEDQ9ZZ1ALQMtQdYrg7kI3iC+L+LscV37tl+E8bayWyX8YA==",
+          "requires": {
+            "@turf/circle": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5",
+            "@turf/line-arc": "^5.1.5",
+            "@turf/meta": "^5.1.5"
+          }
+        },
+        "@turf/shortest-path": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/shortest-path/-/shortest-path-5.1.5.tgz",
+          "integrity": "sha512-ZGC8kSBj02GKWiI56Z5FNdrZ+fS0xyeOUNrPJWzudAlrv9wKGaRuWoIVRLGBu0j0OuO1HCwggic2c6WV/AhP0A==",
+          "requires": {
+            "@turf/bbox": "^5.1.5",
+            "@turf/bbox-polygon": "^5.1.5",
+            "@turf/boolean-point-in-polygon": "^5.1.5",
+            "@turf/clean-coords": "^5.1.5",
+            "@turf/distance": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5",
+            "@turf/meta": "^5.1.5",
+            "@turf/transform-scale": "^5.1.5"
+          }
+        },
+        "@turf/simplify": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/simplify/-/simplify-5.1.5.tgz",
+          "integrity": "sha512-IuBXEYdGSxbDOK3v949ajaPvs6NhjhTCTbKA6mSGuVbwGS7gzAuRiPSG4K/MvCVuQy3PKpkPcUGD+Uvt2Ov2PQ==",
+          "requires": {
+            "@turf/clean-coords": "^5.1.5",
+            "@turf/clone": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/meta": "^5.1.5"
+          }
+        },
+        "@turf/square": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/square/-/square-5.1.5.tgz",
+          "integrity": "sha512-GgP2le9ksoW6vsVef5wFkjmWQiLPTJvcjGXqmoGWT4oMwDpvTJVQ91RBLs8qQbI4KACCQevz94N69klk3ah30Q==",
+          "requires": {
+            "@turf/distance": "^5.1.5",
+            "@turf/helpers": "^5.1.5"
+          }
+        },
+        "@turf/square-grid": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/square-grid/-/square-grid-5.1.5.tgz",
+          "integrity": "sha512-/pusEL4FmOwNWLcZfIXUyqUe0fOdkfaLO4wLhDlg/ZL1jWr/wZjhVlMU0tQ27kVN6dJTvlzNc9e0JWNw6yt2eQ==",
+          "requires": {
+            "@turf/boolean-contains": "^5.1.5",
+            "@turf/boolean-overlap": "^5.1.5",
+            "@turf/distance": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/intersect": "^5.1.5",
+            "@turf/invariant": "^5.1.5"
+          }
+        },
+        "@turf/standard-deviational-ellipse": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/standard-deviational-ellipse/-/standard-deviational-ellipse-5.1.5.tgz",
+          "integrity": "sha512-GOaxGKeeJAXV1H3Zz2fjQ5XeSbMKz1OkFRlTDBUipiAawe/9qTCF55L87I2ZPnO80B5BaaIT+AN2n0lMcAklzA==",
+          "requires": {
+            "@turf/center-mean": "^5.1.5",
+            "@turf/ellipse": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5",
+            "@turf/meta": "^5.1.5",
+            "@turf/points-within-polygon": "^5.1.5"
+          }
+        },
+        "@turf/tag": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/tag/-/tag-5.1.5.tgz",
+          "integrity": "sha512-XI3QFpva6tEsRnzFe1tJGdAAWlzjnXZPfJ9EKShTxEW8ZgPzm92b2odjiSAt2KuQusK82ltNfdw5Frlna5xGYQ==",
+          "requires": {
+            "@turf/boolean-point-in-polygon": "^5.1.5",
+            "@turf/clone": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/meta": "^5.1.5"
+          }
+        },
+        "@turf/tesselate": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/tesselate/-/tesselate-5.1.5.tgz",
+          "integrity": "sha512-Rs/jAij26bcU4OzvFXkWDase1G3kSwyuuKZPFU0t7OmJu7eQJOR12WOZLGcVxd5oBlklo4xPE4EBQUqpQUsQgg==",
+          "requires": {
+            "@turf/helpers": "^5.1.5",
+            "earcut": "^2.0.0"
+          }
+        },
+        "@turf/tin": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/tin/-/tin-5.1.5.tgz",
+          "integrity": "sha512-lDyCTYKoThBIKmkBxBMupqEpFbvTDAYuZIs8qrWnmux2vntSb8OFGi7ZbGPC6apS2hdVwZZae3YB88Tp+Fg+xw==",
+          "requires": {
+            "@turf/helpers": "^5.1.5"
+          }
+        },
+        "@turf/transform-rotate": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/transform-rotate/-/transform-rotate-5.1.5.tgz",
+          "integrity": "sha512-3QKckeHKPXu5O5vEuT+nkszGDI6aknDD06ePb00+6H2oA7MZj7nj+fVQIJLs41MRb76IyKr4n5NvuKZU6idESA==",
+          "requires": {
+            "@turf/centroid": "^5.1.5",
+            "@turf/clone": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5",
+            "@turf/meta": "^5.1.5",
+            "@turf/rhumb-bearing": "^5.1.5",
+            "@turf/rhumb-destination": "^5.1.5",
+            "@turf/rhumb-distance": "^5.1.5"
+          },
+          "dependencies": {
+            "@turf/rhumb-bearing": {
+              "version": "5.1.5",
+              "resolved": "https://registry.npmjs.org/@turf/rhumb-bearing/-/rhumb-bearing-5.1.5.tgz",
+              "integrity": "sha512-zXTl2khjwf7mx2D1uPo5vgpGgP4sM2VrKDbJNKyulPu4TO4ELt8x7FsKyCBlRTzzQf284t/xnNcZOfUbkkd70g==",
+              "requires": {
+                "@turf/helpers": "^5.1.5",
+                "@turf/invariant": "^5.1.5"
+              }
+            },
+            "@turf/rhumb-distance": {
+              "version": "5.1.5",
+              "resolved": "https://registry.npmjs.org/@turf/rhumb-distance/-/rhumb-distance-5.1.5.tgz",
+              "integrity": "sha512-AGA/ky5/BJJZtzQqafy2GvJfcUXSzCCrPFp8sDRPSKBoUN4gMBHN15ijDWYYLFoWFFj0urcauVx7chQlHZ/Qfw==",
+              "requires": {
+                "@turf/helpers": "^5.1.5",
+                "@turf/invariant": "^5.1.5"
+              }
+            }
+          }
+        },
+        "@turf/transform-scale": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/transform-scale/-/transform-scale-5.1.5.tgz",
+          "integrity": "sha512-t1fCZX29ONA7DJiqCKA4YZy0+hCzhppWNOZhglBUv9vKHsWCFYZDUKfFInciaypUInsZyvm8eKxxixBVPdPGsw==",
+          "requires": {
+            "@turf/bbox": "^5.1.5",
+            "@turf/center": "^5.1.5",
+            "@turf/centroid": "^5.1.5",
+            "@turf/clone": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5",
+            "@turf/meta": "^5.1.5",
+            "@turf/rhumb-bearing": "^5.1.5",
+            "@turf/rhumb-destination": "^5.1.5",
+            "@turf/rhumb-distance": "^5.1.5"
+          },
+          "dependencies": {
+            "@turf/rhumb-bearing": {
+              "version": "5.1.5",
+              "resolved": "https://registry.npmjs.org/@turf/rhumb-bearing/-/rhumb-bearing-5.1.5.tgz",
+              "integrity": "sha512-zXTl2khjwf7mx2D1uPo5vgpGgP4sM2VrKDbJNKyulPu4TO4ELt8x7FsKyCBlRTzzQf284t/xnNcZOfUbkkd70g==",
+              "requires": {
+                "@turf/helpers": "^5.1.5",
+                "@turf/invariant": "^5.1.5"
+              }
+            },
+            "@turf/rhumb-distance": {
+              "version": "5.1.5",
+              "resolved": "https://registry.npmjs.org/@turf/rhumb-distance/-/rhumb-distance-5.1.5.tgz",
+              "integrity": "sha512-AGA/ky5/BJJZtzQqafy2GvJfcUXSzCCrPFp8sDRPSKBoUN4gMBHN15ijDWYYLFoWFFj0urcauVx7chQlHZ/Qfw==",
+              "requires": {
+                "@turf/helpers": "^5.1.5",
+                "@turf/invariant": "^5.1.5"
+              }
+            }
+          }
+        },
+        "@turf/transform-translate": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/transform-translate/-/transform-translate-5.1.5.tgz",
+          "integrity": "sha512-GdLFp7I7198oRQt311B8EjiqHupndeMSQ3Zclzki5L/niUrb1ptOIpo+mxSidSy03m+1Q5ylWlENroI1WBcQ3Q==",
+          "requires": {
+            "@turf/clone": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5",
+            "@turf/meta": "^5.1.5",
+            "@turf/rhumb-destination": "^5.1.5"
+          }
+        },
+        "@turf/triangle-grid": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/triangle-grid/-/triangle-grid-5.1.5.tgz",
+          "integrity": "sha512-jmCRcynI80xsVqd+0rv0YxP6mvZn4BAaJv8dwthg2T3WfHB9OD+rNUMohMuUY8HmI0zRT3s/Ypdy2Cdri9u/tw==",
+          "requires": {
+            "@turf/distance": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/intersect": "^5.1.5",
+            "@turf/invariant": "^5.1.5"
+          }
+        },
+        "@turf/truncate": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/truncate/-/truncate-5.1.5.tgz",
+          "integrity": "sha512-WjWGsRE6o1vUqULGb/O7O1eK6B4Eu6R/RBZWnF0rH0Os6WVel6tHktkeJdlKwz9WElIEO12wDIu6uKd54t7DDQ==",
+          "requires": {
+            "@turf/helpers": "^5.1.5",
+            "@turf/meta": "^5.1.5"
+          }
+        },
+        "@turf/turf": {
+          "version": "5.1.6",
+          "resolved": "https://registry.npmjs.org/@turf/turf/-/turf-5.1.6.tgz",
+          "integrity": "sha512-NIjkt5jAbOrom+56ELw9ERZF6qsdf1xAIHyC9/PkDMIOQAxe7FVe2HaqbQ+x88F0q5FaSX4dtpIEf08md6h5/A==",
+          "requires": {
+            "@turf/along": "5.1.x",
+            "@turf/area": "5.1.x",
+            "@turf/bbox": "5.1.x",
+            "@turf/bbox-clip": "5.1.x",
+            "@turf/bbox-polygon": "5.1.x",
+            "@turf/bearing": "5.1.x",
+            "@turf/bezier-spline": "5.1.x",
+            "@turf/boolean-clockwise": "5.1.x",
+            "@turf/boolean-contains": "5.1.x",
+            "@turf/boolean-crosses": "5.1.x",
+            "@turf/boolean-disjoint": "5.1.x",
+            "@turf/boolean-equal": "5.1.x",
+            "@turf/boolean-overlap": "5.1.x",
+            "@turf/boolean-parallel": "5.1.x",
+            "@turf/boolean-point-in-polygon": "5.1.x",
+            "@turf/boolean-point-on-line": "5.1.x",
+            "@turf/boolean-within": "5.1.x",
+            "@turf/buffer": "5.1.x",
+            "@turf/center": "5.1.x",
+            "@turf/center-mean": "5.1.x",
+            "@turf/center-median": "5.1.x",
+            "@turf/center-of-mass": "5.1.x",
+            "@turf/centroid": "5.1.x",
+            "@turf/circle": "5.1.x",
+            "@turf/clean-coords": "5.1.x",
+            "@turf/clone": "5.1.x",
+            "@turf/clusters": "5.1.x",
+            "@turf/clusters-dbscan": "5.1.x",
+            "@turf/clusters-kmeans": "5.1.x",
+            "@turf/collect": "5.1.x",
+            "@turf/combine": "5.1.x",
+            "@turf/concave": "5.1.x",
+            "@turf/convex": "5.1.x",
+            "@turf/destination": "5.1.x",
+            "@turf/difference": "5.1.x",
+            "@turf/dissolve": "5.1.x",
+            "@turf/distance": "5.1.x",
+            "@turf/ellipse": "5.1.x",
+            "@turf/envelope": "5.1.x",
+            "@turf/explode": "5.1.x",
+            "@turf/flatten": "5.1.x",
+            "@turf/flip": "5.1.x",
+            "@turf/great-circle": "5.1.x",
+            "@turf/helpers": "5.1.x",
+            "@turf/hex-grid": "5.1.x",
+            "@turf/interpolate": "5.1.x",
+            "@turf/intersect": "5.1.x",
+            "@turf/invariant": "5.1.x",
+            "@turf/isobands": "5.1.x",
+            "@turf/isolines": "5.1.x",
+            "@turf/kinks": "5.1.x",
+            "@turf/length": "5.1.x",
+            "@turf/line-arc": "5.1.x",
+            "@turf/line-chunk": "5.1.x",
+            "@turf/line-intersect": "5.1.x",
+            "@turf/line-offset": "5.1.x",
+            "@turf/line-overlap": "5.1.x",
+            "@turf/line-segment": "5.1.x",
+            "@turf/line-slice": "5.1.x",
+            "@turf/line-slice-along": "5.1.x",
+            "@turf/line-split": "5.1.x",
+            "@turf/line-to-polygon": "5.1.x",
+            "@turf/mask": "5.1.x",
+            "@turf/meta": "5.1.x",
+            "@turf/midpoint": "5.1.x",
+            "@turf/nearest-point": "5.1.x",
+            "@turf/nearest-point-on-line": "5.1.x",
+            "@turf/nearest-point-to-line": "5.1.x",
+            "@turf/planepoint": "5.1.x",
+            "@turf/point-grid": "5.1.x",
+            "@turf/point-on-feature": "5.1.x",
+            "@turf/point-to-line-distance": "5.1.x",
+            "@turf/points-within-polygon": "5.1.x",
+            "@turf/polygon-tangents": "5.1.x",
+            "@turf/polygon-to-line": "5.1.x",
+            "@turf/polygonize": "5.1.x",
+            "@turf/projection": "5.1.x",
+            "@turf/random": "5.1.x",
+            "@turf/rewind": "5.1.x",
+            "@turf/rhumb-bearing": "5.1.x",
+            "@turf/rhumb-destination": "5.1.x",
+            "@turf/rhumb-distance": "5.1.x",
+            "@turf/sample": "5.1.x",
+            "@turf/sector": "5.1.x",
+            "@turf/shortest-path": "5.1.x",
+            "@turf/simplify": "5.1.x",
+            "@turf/square": "5.1.x",
+            "@turf/square-grid": "5.1.x",
+            "@turf/standard-deviational-ellipse": "5.1.x",
+            "@turf/tag": "5.1.x",
+            "@turf/tesselate": "5.1.x",
+            "@turf/tin": "5.1.x",
+            "@turf/transform-rotate": "5.1.x",
+            "@turf/transform-scale": "5.1.x",
+            "@turf/transform-translate": "5.1.x",
+            "@turf/triangle-grid": "5.1.x",
+            "@turf/truncate": "5.1.x",
+            "@turf/union": "5.1.x",
+            "@turf/unkink-polygon": "5.1.x",
+            "@turf/voronoi": "5.1.x"
+          },
+          "dependencies": {
+            "@turf/projection": {
+              "version": "5.1.5",
+              "resolved": "https://registry.npmjs.org/@turf/projection/-/projection-5.1.5.tgz",
+              "integrity": "sha512-TWKJDFeEKQhI4Ce1+2PuOSDggn4cnMibqyUoCpIW+4KxUC1R88SE3/SYomqzwxMn00O09glHSycPkGD5JzHd8A==",
+              "requires": {
+                "@turf/clone": "^5.1.5",
+                "@turf/helpers": "^5.1.5",
+                "@turf/meta": "^5.1.5"
+              }
+            },
+            "@turf/rhumb-bearing": {
+              "version": "5.1.5",
+              "resolved": "https://registry.npmjs.org/@turf/rhumb-bearing/-/rhumb-bearing-5.1.5.tgz",
+              "integrity": "sha512-zXTl2khjwf7mx2D1uPo5vgpGgP4sM2VrKDbJNKyulPu4TO4ELt8x7FsKyCBlRTzzQf284t/xnNcZOfUbkkd70g==",
+              "requires": {
+                "@turf/helpers": "^5.1.5",
+                "@turf/invariant": "^5.1.5"
+              }
+            },
+            "@turf/rhumb-distance": {
+              "version": "5.1.5",
+              "resolved": "https://registry.npmjs.org/@turf/rhumb-distance/-/rhumb-distance-5.1.5.tgz",
+              "integrity": "sha512-AGA/ky5/BJJZtzQqafy2GvJfcUXSzCCrPFp8sDRPSKBoUN4gMBHN15ijDWYYLFoWFFj0urcauVx7chQlHZ/Qfw==",
+              "requires": {
+                "@turf/helpers": "^5.1.5",
+                "@turf/invariant": "^5.1.5"
+              }
+            }
+          }
+        },
+        "@turf/union": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/union/-/union-5.1.5.tgz",
+          "integrity": "sha512-wBy1ixxC68PpsTeEDebk/EfnbI1Za5dCyY7xFY9NMzrtVEOy0l0lQ5syOsaqY4Ire+dbsDM66p2GGxmefoyIEA==",
+          "requires": {
+            "@turf/helpers": "^5.1.5",
+            "turf-jsts": "*"
+          }
+        },
+        "@turf/unkink-polygon": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/unkink-polygon/-/unkink-polygon-5.1.5.tgz",
+          "integrity": "sha512-lzSrgsfSuyxIc4pkE2qyM2dsHxR992e6oItoZAT8G58A2Ef4qc5gRocmXPWZakGx41fQobegSo7wlo4I49wyHg==",
+          "requires": {
+            "@turf/area": "^5.1.5",
+            "@turf/boolean-point-in-polygon": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/meta": "^5.1.5",
+            "rbush": "^2.0.1"
+          }
+        },
+        "@turf/voronoi": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/voronoi/-/voronoi-5.1.5.tgz",
+          "integrity": "sha512-Ad0HZAyYjOpMIZfDGV+Q+30M9PQHIirTyn32kWyTjEI1O6uhL5NOYjzSha4Sr77xOls3hGzKOj+JET7eDtOvsg==",
+          "requires": {
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5",
+            "d3-voronoi": "1.1.2"
+          }
+        },
+        "geojson-rbush": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/geojson-rbush/-/geojson-rbush-2.1.0.tgz",
+          "integrity": "sha512-9HvLGhmAJBYkYYDdPlCrlfkKGwNW3PapiS0xPekdJLobkZE4rjtduKJXsO7+kUr97SsUlz4VtMcPuSIbjjJaQg==",
+          "requires": {
+            "@turf/helpers": "*",
+            "@turf/meta": "*",
+            "rbush": "*"
+          }
+        },
+        "jszip": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/jszip/-/jszip-2.6.1.tgz",
+          "integrity": "sha512-C4Z++nYQv+CudUkCWUdz+yKVhQiFJjuWSmRJ5Sg3d3/OzcJ6U4ooUYlmE3+rJXrVk89KWQaiJ9mPp/VLQ4D66g==",
+          "requires": {
+            "pako": "~1.0.2"
+          }
+        },
+        "lru-cache": {
+          "version": "2.7.3",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+          "integrity": "sha512-WpibWJ60c3AgAz8a2iYErDrcT2C7OmKnsWhIcHOjkUHFjkXncJhtLxNSqUmxRxRunpb5I8Vprd7aNSd2NtksJQ=="
+        },
+        "pako": {
+          "version": "1.0.11",
+          "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+          "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
+        },
+        "shpjs": {
+          "version": "3.6.3",
+          "resolved": "https://registry.npmjs.org/shpjs/-/shpjs-3.6.3.tgz",
+          "integrity": "sha512-wcR2S3WL/7RnEIm+YO+H/mZR9z9FCV46op+SZt+W5PtPs26Omb9U93f+EPI1DOpNKBuAIrWjHWh0SxlnBahJkg==",
+          "requires": {
+            "jszip": "^2.4.0",
+            "lie": "^3.0.1",
+            "lru-cache": "^2.7.0",
+            "parsedbf": "^1.1.0",
+            "proj4": "^2.1.4"
+          }
         }
       }
     },
     "geostyler-style": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/geostyler-style/-/geostyler-style-5.1.0.tgz",
-      "integrity": "sha512-AJzQBomzuTGr01uRYvu7bocJTBB6vrgBdxsIoSHDATbnNF07XnAtsrbkjXlMsKaRnbqE2MGLhQqBmBx6C2Gubg==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/geostyler-style/-/geostyler-style-4.0.3.tgz",
+      "integrity": "sha512-51esHVZz86HFoSvKRA/Kfqd2Mytek88zgHSSt8ZZg30o4dqyZuQluxwIjqkSLp5hdvmA0nwCAyqxHy6aMyJ5lQ==",
       "requires": {
         "@types/lodash": "^4.14.168",
         "lodash": "^4.17.21"

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@ag-grid-community/core": "^27.1.0",
         "@ag-grid-community/react": "^27.1.0",
         "@ant-design/icons": "^4.7.0",
+        "@camptocamp/inkmap": "^1.2.0",
         "@fortawesome/fontawesome-svg-core": "^6.1.1",
         "@fortawesome/free-brands-svg-icons": "^6.1.1",
         "@fortawesome/free-regular-svg-icons": "^6.1.1",
@@ -1978,581 +1979,16 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
-    "node_modules/@commitlint/cli": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-17.0.2.tgz",
-      "integrity": "sha512-Axe89Js0YzGGd4gxo3JLlF7yIdjOVpG1LbOorGc6PfYF+drBh14PvarSDLzyd2TNqdylUCq9wb9/A88ZjIdyhA==",
-      "dev": true,
+    "node_modules/@camptocamp/inkmap": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@camptocamp/inkmap/-/inkmap-1.2.0.tgz",
+      "integrity": "sha512-s23FoTPWV9q9CCJcu78RxbZTjBYxIMsM4Q+Rkf9VS3h2Akzsg4HbQdKzEPsJK/SmSZZPt7nAMOlzL4xp4ZIQig==",
       "dependencies": {
-        "@commitlint/format": "^17.0.0",
-        "@commitlint/lint": "^17.0.0",
-        "@commitlint/load": "^17.0.0",
-        "@commitlint/read": "^17.0.0",
-        "@commitlint/types": "^17.0.0",
-        "execa": "^5.0.0",
-        "lodash": "^4.17.19",
-        "resolve-from": "5.0.0",
-        "resolve-global": "1.0.0",
-        "yargs": "^17.0.0"
-      },
-      "bin": {
-        "commitlint": "cli.js"
-      },
-      "engines": {
-        "node": ">=v14"
-      }
-    },
-    "node_modules/@commitlint/cli/node_modules/yargs": {
-      "version": "17.5.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.5.1.tgz",
-      "integrity": "sha512-t6YAJcxDkNX7NFYiVtKvWUz8l+PaKTLiL63mJYWR2GnHq2gjEWISzsLp9wg3aY36dY1j+gfIEL3pIF+XlJJfbA==",
-      "dev": true,
-      "dependencies": {
-        "cliui": "^7.0.2",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.3",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^21.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@commitlint/cli/node_modules/yargs-parser": {
-      "version": "21.0.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.1.tgz",
-      "integrity": "sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@commitlint/config-conventional": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-17.0.2.tgz",
-      "integrity": "sha512-MfP0I/JbxKkzo+HXWB7B3WstGS4BiniotU3d3xQ9gK8cR0DbeZ4MuyGCWF65YDyrcDTS3WlrJ3ndSPA1pqhoPw==",
-      "dev": true,
-      "dependencies": {
-        "conventional-changelog-conventionalcommits": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=v14"
-      }
-    },
-    "node_modules/@commitlint/config-validator": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/config-validator/-/config-validator-17.0.0.tgz",
-      "integrity": "sha512-78IQjoZWR4kDHp/U5y17euEWzswJpPkA9TDL5F6oZZZaLIEreWzrDZD5PWtM8MsSRl/K2LDU/UrzYju2bKLMpA==",
-      "dev": true,
-      "dependencies": {
-        "@commitlint/types": "^17.0.0",
-        "ajv": "^6.12.6"
-      },
-      "engines": {
-        "node": ">=v14"
-      }
-    },
-    "node_modules/@commitlint/ensure": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-17.0.0.tgz",
-      "integrity": "sha512-M2hkJnNXvEni59S0QPOnqCKIK52G1XyXBGw51mvh7OXDudCmZ9tZiIPpU882p475Mhx48Ien1MbWjCP1zlyC0A==",
-      "dev": true,
-      "dependencies": {
-        "@commitlint/types": "^17.0.0",
-        "lodash": "^4.17.19"
-      },
-      "engines": {
-        "node": ">=v14"
-      }
-    },
-    "node_modules/@commitlint/execute-rule": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/execute-rule/-/execute-rule-17.0.0.tgz",
-      "integrity": "sha512-nVjL/w/zuqjCqSJm8UfpNaw66V9WzuJtQvEnCrK4jDw6qKTmZB+1JQ8m6BQVZbNBcwfYdDNKnhIhqI0Rk7lgpQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=v14"
-      }
-    },
-    "node_modules/@commitlint/format": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/format/-/format-17.0.0.tgz",
-      "integrity": "sha512-MZzJv7rBp/r6ZQJDEodoZvdRM0vXu1PfQvMTNWFb8jFraxnISMTnPBWMMjr2G/puoMashwaNM//fl7j8gGV5lA==",
-      "dev": true,
-      "dependencies": {
-        "@commitlint/types": "^17.0.0",
-        "chalk": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=v14"
-      }
-    },
-    "node_modules/@commitlint/format/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@commitlint/format/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/@commitlint/format/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/@commitlint/format/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
-    },
-    "node_modules/@commitlint/format/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@commitlint/format/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@commitlint/is-ignored": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-17.0.0.tgz",
-      "integrity": "sha512-UmacD0XM/wWykgdXn5CEWVS4XGuqzU+ZGvM2hwv85+SXGnIOaG88XHrt81u37ZeVt1riWW+YdOxcJW6+nd5v5w==",
-      "dev": true,
-      "dependencies": {
-        "@commitlint/types": "^17.0.0",
-        "semver": "7.3.7"
-      },
-      "engines": {
-        "node": ">=v14"
-      }
-    },
-    "node_modules/@commitlint/is-ignored/node_modules/semver": {
-      "version": "7.3.7",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@commitlint/lint": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-17.0.0.tgz",
-      "integrity": "sha512-5FL7VLvGJQby24q0pd4UdM8FNFcL+ER1T/UBf8A9KRL5+QXV1Rkl6Zhcl7+SGpGlVo6Yo0pm6aLW716LVKWLGg==",
-      "dev": true,
-      "dependencies": {
-        "@commitlint/is-ignored": "^17.0.0",
-        "@commitlint/parse": "^17.0.0",
-        "@commitlint/rules": "^17.0.0",
-        "@commitlint/types": "^17.0.0"
-      },
-      "engines": {
-        "node": ">=v14"
-      }
-    },
-    "node_modules/@commitlint/load": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-17.0.0.tgz",
-      "integrity": "sha512-XaiHF4yWQOPAI0O6wXvk+NYLtJn/Xb7jgZEeKd4C1ZWd7vR7u8z5h0PkWxSr0uLZGQsElGxv3fiZ32C5+q6M8w==",
-      "dev": true,
-      "dependencies": {
-        "@commitlint/config-validator": "^17.0.0",
-        "@commitlint/execute-rule": "^17.0.0",
-        "@commitlint/resolve-extends": "^17.0.0",
-        "@commitlint/types": "^17.0.0",
-        "@types/node": ">=12",
-        "chalk": "^4.1.0",
-        "cosmiconfig": "^7.0.0",
-        "cosmiconfig-typescript-loader": "^2.0.0",
-        "lodash": "^4.17.19",
-        "resolve-from": "^5.0.0",
-        "typescript": "^4.6.4"
-      },
-      "engines": {
-        "node": ">=v14"
-      }
-    },
-    "node_modules/@commitlint/load/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@commitlint/load/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/@commitlint/load/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/@commitlint/load/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
-    },
-    "node_modules/@commitlint/load/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@commitlint/load/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@commitlint/message": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/message/-/message-17.0.0.tgz",
-      "integrity": "sha512-LpcwYtN+lBlfZijHUdVr8aNFTVpHjuHI52BnfoV01TF7iSLnia0jttzpLkrLmI8HNQz6Vhr9UrxDWtKZiMGsBw==",
-      "dev": true,
-      "engines": {
-        "node": ">=v14"
-      }
-    },
-    "node_modules/@commitlint/parse": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-17.0.0.tgz",
-      "integrity": "sha512-cKcpfTIQYDG1ywTIr5AG0RAiLBr1gudqEsmAGCTtj8ffDChbBRxm6xXs2nv7GvmJN7msOt7vOKleLvcMmRa1+A==",
-      "dev": true,
-      "dependencies": {
-        "@commitlint/types": "^17.0.0",
-        "conventional-changelog-angular": "^5.0.11",
-        "conventional-commits-parser": "^3.2.2"
-      },
-      "engines": {
-        "node": ">=v14"
-      }
-    },
-    "node_modules/@commitlint/read": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/read/-/read-17.0.0.tgz",
-      "integrity": "sha512-zkuOdZayKX3J6F6mPnVMzohK3OBrsEdOByIqp4zQjA9VLw1hMsDEFQ18rKgUc2adkZar+4S01QrFreDCfZgbxA==",
-      "dev": true,
-      "dependencies": {
-        "@commitlint/top-level": "^17.0.0",
-        "@commitlint/types": "^17.0.0",
-        "fs-extra": "^10.0.0",
-        "git-raw-commits": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=v14"
-      }
-    },
-    "node_modules/@commitlint/read/node_modules/fs-extra": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
-      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-      "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@commitlint/resolve-extends": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-17.0.0.tgz",
-      "integrity": "sha512-wi60WiJmwaQ7lzMXK8Vbc18Hq9tE2j/6iv2AFfPUGV7fvfY6Sf1iNKuUHirSqR0fquUyufIXe4y/K9A6LVIIvw==",
-      "dev": true,
-      "dependencies": {
-        "@commitlint/config-validator": "^17.0.0",
-        "@commitlint/types": "^17.0.0",
-        "import-fresh": "^3.0.0",
-        "lodash": "^4.17.19",
-        "resolve-from": "^5.0.0",
-        "resolve-global": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=v14"
-      }
-    },
-    "node_modules/@commitlint/rules": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-17.0.0.tgz",
-      "integrity": "sha512-45nIy3dERKXWpnwX9HeBzK5SepHwlDxdGBfmedXhL30fmFCkJOdxHyOJsh0+B0RaVsLGT01NELpfzJUmtpDwdQ==",
-      "dev": true,
-      "dependencies": {
-        "@commitlint/ensure": "^17.0.0",
-        "@commitlint/message": "^17.0.0",
-        "@commitlint/to-lines": "^17.0.0",
-        "@commitlint/types": "^17.0.0",
-        "execa": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=v14"
-      }
-    },
-    "node_modules/@commitlint/to-lines": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/to-lines/-/to-lines-17.0.0.tgz",
-      "integrity": "sha512-nEi4YEz04Rf2upFbpnEorG8iymyH7o9jYIVFBG1QdzebbIFET3ir+8kQvCZuBE5pKCtViE4XBUsRZz139uFrRQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=v14"
-      }
-    },
-    "node_modules/@commitlint/top-level": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/top-level/-/top-level-17.0.0.tgz",
-      "integrity": "sha512-dZrEP1PBJvodNWYPOYiLWf6XZergdksKQaT6i1KSROLdjf5Ai0brLOv5/P+CPxBeoj3vBxK4Ax8H1Pg9t7sHIQ==",
-      "dev": true,
-      "dependencies": {
-        "find-up": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=v14"
-      }
-    },
-    "node_modules/@commitlint/top-level/node_modules/find-up": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
-      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
-      "dev": true,
-      "dependencies": {
-        "locate-path": "^6.0.0",
-        "path-exists": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@commitlint/top-level/node_modules/locate-path": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
-      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-      "dev": true,
-      "dependencies": {
-        "p-locate": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@commitlint/top-level/node_modules/p-limit": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
-      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-      "dev": true,
-      "dependencies": {
-        "yocto-queue": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@commitlint/top-level/node_modules/p-locate": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-      "dev": true,
-      "dependencies": {
-        "p-limit": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@commitlint/types": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-17.0.0.tgz",
-      "integrity": "sha512-hBAw6U+SkAT5h47zDMeOu3HSiD0SODw4Aq7rRNh1ceUmL7GyLKYhPbUvlRWqZ65XjBLPHZhFyQlRaPNz8qvUyQ==",
-      "dev": true,
-      "dependencies": {
-        "chalk": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=v14"
-      }
-    },
-    "node_modules/@commitlint/types/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@commitlint/types/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/@commitlint/types/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/@commitlint/types/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
-    },
-    "node_modules/@commitlint/types/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@commitlint/types/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@cspotcode/source-map-support": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
-      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
-      "dev": true,
-      "dependencies": {
-        "@jridgewell/trace-mapping": "0.3.9"
-      },
-      "engines": {
-        "node": ">=12"
+        "@babel/runtime": "^7.12.5",
+        "geostyler-openlayers-parser": "^2.1.0",
+        "ol": "^6.5.0",
+        "proj4": "^2.6.3",
+        "rxjs": "^6.6.3"
       }
     },
     "node_modules/@ctrl/tinycolor": {
@@ -13096,6 +12532,1411 @@
         "quickselect": "^2.0.0"
       }
     },
+    "node_modules/geostyler-openlayers-parser": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/geostyler-openlayers-parser/-/geostyler-openlayers-parser-2.5.0.tgz",
+      "integrity": "sha512-Uum/lDci8oqhBA/c0RZbD91aXP4ycjlsAp4ZoVAPDHT6Og0XyF5Tze8wg0Ux44CerE6W+m2DfWkOTAP+iaakzQ==",
+      "dependencies": {
+        "@terrestris/ol-util": "^4.0.1",
+        "geostyler-style": "^4.0.0",
+        "lodash": "^4.17.15"
+      },
+      "peerDependencies": {
+        "ol": "^6.0.0"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@terrestris/ol-util": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@terrestris/ol-util/-/ol-util-4.1.3.tgz",
+      "integrity": "sha512-vTS7rXxOcvTpXQzRGR6DVldEYcbFjADQ9/ArSKeq9yCmmY9wb3dkeGKw+rN/dltu6oZbaswjsUsBQe060kiMOQ==",
+      "dependencies": {
+        "@terrestris/base-util": "^1.0.0",
+        "@turf/turf": "^5.1.6",
+        "lodash": "^4.17.20",
+        "proj4": "^2.7.0",
+        "shpjs": "^3.6.3"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "ol": "~6.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/along": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/along/-/along-5.1.5.tgz",
+      "integrity": "sha512-N7BN1xvj6VWMe3UpjQDdVI0j0oY/EZ0bWgOgBXc4DlJ411uEsKCh6iBv0b2MSxQ3YUXEez3oc5FcgO9eVSs7iQ==",
+      "dependencies": {
+        "@turf/bearing": "^5.1.5",
+        "@turf/destination": "^5.1.5",
+        "@turf/distance": "^5.1.5",
+        "@turf/helpers": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/area": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/area/-/area-5.1.5.tgz",
+      "integrity": "sha512-lz16gqtvoz+j1jD9y3zj0Z5JnGNd3YfS0h+DQY1EcZymvi75Frm9i5YbEyth0RfxYZeOVufY7YIS3LXbJlI57g==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/bbox": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/bbox/-/bbox-5.1.5.tgz",
+      "integrity": "sha512-sYQU4fqsOYYJoD8UndC1n2hy8hV/lGIAmMLKWuzwmPUWqWOuSKWUcoRWDi9mGB0GvQQe/ow2IxZr8UaVaGz3sQ==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/bbox-clip": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/bbox-clip/-/bbox-clip-5.1.5.tgz",
+      "integrity": "sha512-KP64aoTvjcXxWHeM/Hs25vOQUBJgyJi7DlRVEoZofFJiR1kPnmDQrK7Xj+60lAk5cxuqzFnaPPxUk9Q+3v4p1Q==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "lineclip": "^1.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/bbox-polygon": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/bbox-polygon/-/bbox-polygon-5.1.5.tgz",
+      "integrity": "sha512-PKVPF5LABFWZJud8KzzfesLGm5ihiwLbVa54HJjYySe6yqU/cr5q/qcN9TWptynOFhNktG1dr0KXVG0I2FZmfw==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/bearing": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/bearing/-/bearing-5.1.5.tgz",
+      "integrity": "sha512-PrvZuJjnXGseB8hUatIjsrK3tgD3wttyRnVYXTbSfXYJZzaOfHDMplgO4lxXQp7diraZhGhCdSlbMvRRXItbUQ==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/bezier-spline": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/bezier-spline/-/bezier-spline-5.1.5.tgz",
+      "integrity": "sha512-Y9NoComaGgFFFe9TWWE/cEMg2+EnBfU1R3112ec2wlx21ygDmFGXs4boOS71WM4ySwm/dbS3wxnbVxs4j68sKw==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/boolean-clockwise": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-clockwise/-/boolean-clockwise-5.1.5.tgz",
+      "integrity": "sha512-FqbmEEOJ4rU4/2t7FKx0HUWmjFEVqR+NJrFP7ymGSjja2SQ7Q91nnBihGuT+yuHHl6ElMjQ3ttsB/eTmyCycxA==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/boolean-contains": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-contains/-/boolean-contains-5.1.5.tgz",
+      "integrity": "sha512-x2HeEieeE9vBQrTdCuj4swnAXlpKbj9ChxMdDTV479c0m2gVmfea83ocmkj3w+9cvAaS63L8WqFyNVSmkwqljQ==",
+      "dependencies": {
+        "@turf/bbox": "^5.1.5",
+        "@turf/boolean-point-in-polygon": "^5.1.5",
+        "@turf/boolean-point-on-line": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/boolean-crosses": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-crosses/-/boolean-crosses-5.1.5.tgz",
+      "integrity": "sha512-odljvS7INr9k/8yXeyXQVry7GqEaChOmXawP0+SoTfGO3hgptiik59TLU/Yjn/SLFjE2Ul54Ga1jKFSL7vvH0Q==",
+      "dependencies": {
+        "@turf/boolean-point-in-polygon": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/line-intersect": "^5.1.5",
+        "@turf/polygon-to-line": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/boolean-disjoint": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-disjoint/-/boolean-disjoint-5.1.6.tgz",
+      "integrity": "sha512-KHvUS6SBNYHBCLIJEJrg04pF5Oy+Fqn8V5G9U+9pti5vI9tyX7Ln2g7RSB7iJ1Cxsz8QAi6OukhXjEF2/8ZpGg==",
+      "dependencies": {
+        "@turf/boolean-point-in-polygon": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/line-intersect": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "@turf/polygon-to-line": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/boolean-equal": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-equal/-/boolean-equal-5.1.5.tgz",
+      "integrity": "sha512-QEMbhDPV+J8PlRkMlVg6m5oSLaYUpOx2VUhDDekQ73FlpnhFBKRIlidhvHtS6CYnEw8d+/zA3h8Z18B4W4mq9Q==",
+      "dependencies": {
+        "@turf/clean-coords": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "geojson-equality": "0.1.6"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/boolean-overlap": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-overlap/-/boolean-overlap-5.1.5.tgz",
+      "integrity": "sha512-lizojgU559KME0G705YAgWVa0B3/tsWNobMzOEWDx/1rABWTojCY4uxw2rFxpOsP++s8JJHrGWXRLh1PbdAvRQ==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/line-intersect": "^5.1.5",
+        "@turf/line-overlap": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "geojson-equality": "0.1.6"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/boolean-parallel": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-parallel/-/boolean-parallel-5.1.5.tgz",
+      "integrity": "sha512-eeuGgDhnas3nJ22A/DD8aiH0kg9dSzbQChIMAqYRPGg3pWNK41aGAbeh5z0GO5N/EVFX1+ga5a0vsPmiRgQB5g==",
+      "dependencies": {
+        "@turf/clean-coords": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/line-segment": "^5.1.5",
+        "@turf/rhumb-bearing": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/boolean-parallel/node_modules/@turf/rhumb-bearing": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/rhumb-bearing/-/rhumb-bearing-5.1.5.tgz",
+      "integrity": "sha512-zXTl2khjwf7mx2D1uPo5vgpGgP4sM2VrKDbJNKyulPu4TO4ELt8x7FsKyCBlRTzzQf284t/xnNcZOfUbkkd70g==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/boolean-point-in-polygon": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-point-in-polygon/-/boolean-point-in-polygon-5.1.5.tgz",
+      "integrity": "sha512-y+gbAhLmsAZH9uYhv+C68pu06mxsGIm3o7l0hzVkc/PXYdbkr+vKe7n7PfSN3xpVA3qoDLKLpCGOqeW8/ThaJA==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/boolean-point-on-line": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-point-on-line/-/boolean-point-on-line-5.1.5.tgz",
+      "integrity": "sha512-Zf4d28mckV2tYfLWf2iqxQ8eeLZqi2HGimM26mptf1OCEIwc1wfkKgLRRJXMu94Crvd/pJxjRAjoYGcGliP6Vg==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/boolean-within": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-within/-/boolean-within-5.1.5.tgz",
+      "integrity": "sha512-CNAtrvm4HiUwV/vhpGhvJzfhV9CN7VhPC5y4tTfQicK82fYY6ifPz0iaNpUOmshU6+TAot/fsVQVgDJ4t7HXcA==",
+      "dependencies": {
+        "@turf/bbox": "^5.1.5",
+        "@turf/boolean-point-in-polygon": "^5.1.5",
+        "@turf/boolean-point-on-line": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/buffer": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/buffer/-/buffer-5.1.5.tgz",
+      "integrity": "sha512-U3LU0HF/JNFUNabpB5ArpNG6yPla7yR5XPrZvzZRH48vvbr/N0rkSRI0tJFRWTz7ntugVm9X0OD9Y382NTJRhA==",
+      "dependencies": {
+        "@turf/bbox": "^5.1.5",
+        "@turf/center": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "@turf/projection": "^5.1.5",
+        "d3-geo": "1.7.1",
+        "turf-jsts": "*"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/buffer/node_modules/@turf/projection": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/projection/-/projection-5.1.5.tgz",
+      "integrity": "sha512-TWKJDFeEKQhI4Ce1+2PuOSDggn4cnMibqyUoCpIW+4KxUC1R88SE3/SYomqzwxMn00O09glHSycPkGD5JzHd8A==",
+      "dependencies": {
+        "@turf/clone": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/center": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/center/-/center-5.1.5.tgz",
+      "integrity": "sha512-Dy1TvAv2oHKFddZcWqlVsanxurfcZV1Mmb1E+7H7GRKI+fXZTfRjwCdbiZCbO/tPwxt8jWQHWdLHn8E9lecc3A==",
+      "dependencies": {
+        "@turf/bbox": "^5.1.5",
+        "@turf/helpers": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/center-mean": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/center-mean/-/center-mean-5.1.5.tgz",
+      "integrity": "sha512-XdkBXzFUuyCqu5EPlBwgkv8FLA8pIGBnt7xy5cxxhxKOYLMrKqwMPPHPA84TjeQpNti0gH0CVuOk2r1f/Pp8iQ==",
+      "dependencies": {
+        "@turf/bbox": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/center-median": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/center-median/-/center-median-5.1.5.tgz",
+      "integrity": "sha512-M+O6bSNsIDKZ4utk/YzSOIg6W0isjLVWud+TCLWyrDCWTSERlSJlhOaVE1y7cObhG8nYBHvmszqZyoAY6nufQw==",
+      "dependencies": {
+        "@turf/center-mean": "^5.1.5",
+        "@turf/centroid": "^5.1.5",
+        "@turf/distance": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/center-of-mass": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/center-of-mass/-/center-of-mass-5.1.5.tgz",
+      "integrity": "sha512-UvI7q6GgW3afCVIDOyTRuLT54v9Xwv65Xudxh4FIT6w7HNU4KUBtTGnx0NuhODZcgvZgWVWVakhmIcHQTMjYYA==",
+      "dependencies": {
+        "@turf/centroid": "^5.1.5",
+        "@turf/convex": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/centroid": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/centroid/-/centroid-5.1.5.tgz",
+      "integrity": "sha512-0m9ZAZJB4YXLDxF2fWGqlE/g9Y68cebeWaRNOMN+e6Bti1fz0JKQuaEqJV+J8xOmODPHSMbZZ1SqSDVRgVHP2Q==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/circle": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/circle/-/circle-5.1.5.tgz",
+      "integrity": "sha512-CNaEtvp38Q+TSFJHdzdl5iYNjBFZRluRTFikIuEcennSeMJD60nP0dMubP58TR/QQn541eNDUyED90V4KuOjyQ==",
+      "dependencies": {
+        "@turf/destination": "^5.1.5",
+        "@turf/helpers": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/clean-coords": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/clean-coords/-/clean-coords-5.1.5.tgz",
+      "integrity": "sha512-xd/iSM0McVUxbu81KCKDqirCsYkKk3EAwpDjYI8vIQ+eKf/MLSdteRcm3PB7wo2y6JcYp4dMGv2cr9IP7V+dXQ==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/clone": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/clone/-/clone-5.1.5.tgz",
+      "integrity": "sha512-//pITsQ8xUdcQ9pVb4JqXiSqG4dos5Q9N4sYFoWghX21tfOV2dhc5TGqYOhnHrQS7RiKQL1vQ48kIK34gQ5oRg==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/clusters": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/clusters/-/clusters-5.1.5.tgz",
+      "integrity": "sha512-+rQe+g66xfbIXz58tveXQCDdE9hzqRJtDVSw5xth92TvCcL4J60ZKN8mHNUSn1ZZvpUHtVPe4dYcbtk5bW8fXQ==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/clusters-dbscan": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/clusters-dbscan/-/clusters-dbscan-5.1.5.tgz",
+      "integrity": "sha512-X3qLLHJkwMuv+xdWQ08NtOc6BgeqCKKSAltyyAZ7iImE65f0C+sW024DfHSbTMsZVXBFst2Q6RQY8RVUf3QBeQ==",
+      "dependencies": {
+        "@turf/clone": "^5.1.5",
+        "@turf/distance": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "density-clustering": "1.3.0"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/clusters-kmeans": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/clusters-kmeans/-/clusters-kmeans-5.1.5.tgz",
+      "integrity": "sha512-W6raiv9+fRgmJxCvKrpSacbLXzh7beZUk0A1pjF82Fv3CFTrXAJbgAyIbdlmgXezYSXhOT5NMUugnbkUy2oBZw==",
+      "dependencies": {
+        "@turf/clone": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "skmeans": "0.9.7"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/collect": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/collect/-/collect-5.1.5.tgz",
+      "integrity": "sha512-voFWu6EGPcNuIbAp43yvGf2Ip4/q8TTeWhOSJ2yDEHgOfbAwrNUwUJCclEjcUVsnc7ypKNrFn3/8bmR9tI0NQg==",
+      "dependencies": {
+        "@turf/bbox": "^5.1.5",
+        "@turf/boolean-point-in-polygon": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "rbush": "^2.0.1"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/combine": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/combine/-/combine-5.1.5.tgz",
+      "integrity": "sha512-/RqmfCvduHquINVyNmzKOcZtZjfaEHMhghgmj8MYnzepN3ro+E2QXoaQGGrQ7nChAvGgWPAvN8EveVSc1MvzPg==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/concave": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/concave/-/concave-5.1.5.tgz",
+      "integrity": "sha512-NvR5vmAunmgjEPjNzmvjLRvPcj7C6WuqCf+vu/aqyc4h2c1B/x399bDsSM64iFT+PYesFuoS1ZhJHWivXG8Y5g==",
+      "dependencies": {
+        "@turf/clone": "^5.1.5",
+        "@turf/distance": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "@turf/tin": "^5.1.5",
+        "topojson-client": "3.x",
+        "topojson-server": "3.x"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/convex": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/convex/-/convex-5.1.5.tgz",
+      "integrity": "sha512-ZEk4kIAoYR/mjO3C8rMe2StgmwhdwmbxVvNxg3udeahe2m0ZzbfkRC4HiJAaBgfR4TLJUAEewynESReTPwASBQ==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "concaveman": "*"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/destination": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/destination/-/destination-5.1.5.tgz",
+      "integrity": "sha512-EWwZnd4wxUO9d8UWzJt88jQlFf6W/6SE1930MMzzIR9o+RfqhrS/BL1eUDrg5I5drsymf6PZsK0j/V0q6jqkFQ==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/difference": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/difference/-/difference-5.1.5.tgz",
+      "integrity": "sha512-hIjiUHS8WiDfnmADQrhh6QcXWc3zNtjIpPQ5g/2NZ3k1mjnOdmGBVObkSJG4WEUNqyj3PKlsZ8W9xnSu+lLF1Q==",
+      "dependencies": {
+        "@turf/area": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "turf-jsts": "*"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/dissolve": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/dissolve/-/dissolve-5.1.5.tgz",
+      "integrity": "sha512-YcQgyp7pvhyZHCmbqqItVH6vHs43R9N0jzP/LnAG03oMiY4wves/BO1du6VDDbnJSXeRKf1afmY9tRGKYrm9ag==",
+      "dependencies": {
+        "@turf/boolean-overlap": "^5.1.5",
+        "@turf/clone": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/line-intersect": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "@turf/union": "^5.1.5",
+        "geojson-rbush": "2.1.0",
+        "get-closest": "*"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/distance": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/distance/-/distance-5.1.5.tgz",
+      "integrity": "sha512-sYCAgYZ2MjNKMtx17EijHlK9qHwpA0MuuQWbR4P30LTCl52UlG/reBfV899wKyF3HuDL9ux78IbILwOfeQ4zgA==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/ellipse": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/ellipse/-/ellipse-5.1.5.tgz",
+      "integrity": "sha512-oVTzEyDOi3d9isgB7Ah+YiOoUKB1eHMtMDXVl1oT+vC/T+6KR2aq+HjjbF11A0cjuh3VhjSWUZaS+2TYY0pu0w==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/rhumb-destination": "^5.1.5",
+        "@turf/transform-rotate": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/envelope": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/envelope/-/envelope-5.1.5.tgz",
+      "integrity": "sha512-Mxl5A2euAxq3RZVN65/MVyaO91kzGU8MJXfegPdep6SN4bONDadEp0olwW5qSRf2U3cJ8Jppl089X6AeifD3IA==",
+      "dependencies": {
+        "@turf/bbox": "^5.1.5",
+        "@turf/bbox-polygon": "^5.1.5",
+        "@turf/helpers": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/explode": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/explode/-/explode-5.1.5.tgz",
+      "integrity": "sha512-v/hC9DB9RKRW9/ZjnKoQelIp08JNa5wew0889465s//tfgY8+JEGkSGMag2L2NnVARWmzI/vlLgMK36qwkyDIA==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/flatten": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/flatten/-/flatten-5.1.5.tgz",
+      "integrity": "sha512-aagHz5tjHmOtb8eMb5fd10+HJwdlhkhsPql1vRXQNnpv0Q9xL/4SsbvXZ6lPqkRAjiZuy087mvaz+ERml76/jg==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/flip": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/flip/-/flip-5.1.5.tgz",
+      "integrity": "sha512-7+IYM3QQAkV4co3wjEmM726/OkXqUCCHWWyIqrI9hiK+LR628qkoqP1hk6rQ4vZJrAYuvSlK+FZnr24OtgY0cw==",
+      "dependencies": {
+        "@turf/clone": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/great-circle": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/great-circle/-/great-circle-5.1.5.tgz",
+      "integrity": "sha512-k6FWwlt+YCQoD5VS1NybQjriNL7apYHO+tm2HbIFQ85blPUX4IyLppHIFevfD/k+K2bJqhFCze8JNVMBwdrzVw==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/helpers": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-5.1.5.tgz",
+      "integrity": "sha512-/lF+JR+qNDHZ8bF9d+Cp58nxtZWJ3sqFe6n3u3Vpj+/0cqkjk4nXKYBSY0azm+GIYB5mWKxUXvuP/m0ZnKj1bw=="
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/hex-grid": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/hex-grid/-/hex-grid-5.1.5.tgz",
+      "integrity": "sha512-rwDL+DlUyxDNL1aVHIKKCmrt1131ZULF3irExYIO/um6/SwRzsBw+522/RcxD/mg/Shtrpozb6bz8aJJ/3RXHA==",
+      "dependencies": {
+        "@turf/distance": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/intersect": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/interpolate": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/interpolate/-/interpolate-5.1.5.tgz",
+      "integrity": "sha512-LfmvtIUWc3NVkqPkX6j3CAIjF7y1LAZqfDd+2Ii+0fN7XOOGMWcb1uiTTAb8zDQjhTsygcUYgaz6mMYDCWYKPg==",
+      "dependencies": {
+        "@turf/bbox": "^5.1.5",
+        "@turf/centroid": "^5.1.5",
+        "@turf/clone": "^5.1.5",
+        "@turf/distance": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/hex-grid": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "@turf/point-grid": "^5.1.5",
+        "@turf/square-grid": "^5.1.5",
+        "@turf/triangle-grid": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/intersect": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/@turf/intersect/-/intersect-5.1.6.tgz",
+      "integrity": "sha512-KXyNv/GXdoGAOy03qZF53rgtXC2tNhF/4jLwTKiVRrBQH6kcEpipGStdJ+QkYIlarQPa8f7I9UlVAB19et4MfQ==",
+      "dependencies": {
+        "@turf/clean-coords": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/truncate": "^5.1.5",
+        "turf-jsts": "*"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/invariant": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-5.1.5.tgz",
+      "integrity": "sha512-4elbC8GVQ8XxrnWLWpFFXTK3qnzIYzIVtSkJrY9eefA8WNZzwcwT3WGFY3xte4BB48o5oEjihjoJharWRis78w==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/isobands": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/isobands/-/isobands-5.1.5.tgz",
+      "integrity": "sha512-0n3NPfDYQyqjOch00I4hVCCqjKn9Sm+a8qlWOKbkuhmGa9dCDzsu2bZL0ahT+LjwlS4c8/owQXqe6KE2GWqT1Q==",
+      "dependencies": {
+        "@turf/area": "^5.1.5",
+        "@turf/bbox": "^5.1.5",
+        "@turf/boolean-point-in-polygon": "^5.1.5",
+        "@turf/explode": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/isolines": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/isolines/-/isolines-5.1.5.tgz",
+      "integrity": "sha512-Ehn5pJmiq4hAn2+2jPB2rLt3iF8DDp8zciw9z2pAt5IGVRU/K+x3z4aYG5ra5vbFB/E4G3aHr/X4QPIb9LCJtA==",
+      "dependencies": {
+        "@turf/bbox": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/kinks": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/kinks/-/kinks-5.1.5.tgz",
+      "integrity": "sha512-G38sC8/+MYqQpVocT3XahhV42cqEAVJAZwUND9YOfKJZfjUn7FKmWhPURs5py95me48UuI0C0jLLAMzBkUc2nQ==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/length": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/length/-/length-5.1.5.tgz",
+      "integrity": "sha512-0ryx68h512wCoNfwyksLdabxEfwkGNTPg61/QiY+QfGFUOUNhHbP+QimViFpwF5hyX7qmroaSHVclLUqyLGRbg==",
+      "dependencies": {
+        "@turf/distance": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/line-arc": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/line-arc/-/line-arc-5.1.5.tgz",
+      "integrity": "sha512-Kz5RX/qRIHVrGNqF3BRlD3ACuuCr0G5lpaVyPjNvN+vA7Q4bEDyWIYeqm3DdTn7X2MXitpTNgr2uvX4WoUy4yA==",
+      "dependencies": {
+        "@turf/circle": "^5.1.5",
+        "@turf/destination": "^5.1.5",
+        "@turf/helpers": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/line-chunk": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/line-chunk/-/line-chunk-5.1.5.tgz",
+      "integrity": "sha512-mKvTUMahnb3EsYUMI8tQmygsliQkgQ1FZAY915zoTrm+WV246loa+84+h7i5d8W2O8gGJWuY7jQTpM7toTeL5w==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/length": "^5.1.5",
+        "@turf/line-slice-along": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/line-intersect": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/line-intersect/-/line-intersect-5.1.5.tgz",
+      "integrity": "sha512-9DajJbHhJauLI2qVMnqZ7SeFsinFroVICOSUheODk7j5teuwNABuZ2Z6WmKATzEsPkEJ1iVykqB+F9vGMVKB6g==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/line-segment": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "geojson-rbush": "2.1.0"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/line-offset": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/line-offset/-/line-offset-5.1.5.tgz",
+      "integrity": "sha512-VccGDgFfBSiCTqrHdQgxD7Rs9lnJmDOJ5gqQRculKPsCNUyRFMYIZud7l2dTs83g66evfOwkZCrTxtSoBY3Jxg==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/line-overlap": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/line-overlap/-/line-overlap-5.1.5.tgz",
+      "integrity": "sha512-hMz3XARXEbfGwLF9WXyErqQjzhZYMKvGQwlPGOoth+2o9Uga9mfWfevduJvozJAE1MKxtFttMjIXMzcShW3O8A==",
+      "dependencies": {
+        "@turf/boolean-point-on-line": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/line-segment": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "@turf/nearest-point-on-line": "^5.1.5",
+        "geojson-rbush": "2.1.0"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/line-segment": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/line-segment/-/line-segment-5.1.5.tgz",
+      "integrity": "sha512-wIrRtWuLuLXhnSkqdVG1SDayTU0/CmZf+a+BBhEf0vFIsAedJnrY3a2cbCEvtfuk6ZsAbhOi7/kYiaR/F+rEzg==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/line-slice": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/line-slice/-/line-slice-5.1.5.tgz",
+      "integrity": "sha512-Fo+CuD+fj6T702BofHO+rgiXUgzCk0iO2JqMPtttMtgzfKkVTUOQoauMNS1LNNaG/7n/TfKGh5gRCEDRNaNwYA==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/nearest-point-on-line": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/line-slice-along": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/line-slice-along/-/line-slice-along-5.1.5.tgz",
+      "integrity": "sha512-yKvSDtULztLtlPIMowm9l8pS6XLAEpCPmrARZA0sIWFX8XrcSzISBaXZbiMMzg3nxQJMXfGIgWDk10B7+J8Tqw==",
+      "dependencies": {
+        "@turf/bearing": "^5.1.5",
+        "@turf/destination": "^5.1.5",
+        "@turf/distance": "^5.1.5",
+        "@turf/helpers": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/line-split": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/line-split/-/line-split-5.1.5.tgz",
+      "integrity": "sha512-gtUUBwZL3hcSu5MpqHTl68hgAJBNHcr1APDj8E5o6iX5xFX+wvl4ohQXyMs5HOATCI8Iy83wLuggcY6maNw7LQ==",
+      "dependencies": {
+        "@turf/bbox": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/line-intersect": "^5.1.5",
+        "@turf/line-segment": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "@turf/nearest-point-on-line": "^5.1.5",
+        "@turf/square": "^5.1.5",
+        "@turf/truncate": "^5.1.5",
+        "geojson-rbush": "2.1.0"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/line-to-polygon": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/line-to-polygon/-/line-to-polygon-5.1.5.tgz",
+      "integrity": "sha512-hGiDAPd6j986kZZLDgEAkVD7O6DmIqHQliBedspoKperPJOUJJzdzSnF6OAWSsxY+j8fWtQnIo5TTqdO/KfamA==",
+      "dependencies": {
+        "@turf/bbox": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/mask": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/mask/-/mask-5.1.5.tgz",
+      "integrity": "sha512-2eOuxA3ammZAGsjlsy/H7IpeJxjl3hrgkcKM6kTKRJGft4QyKwCxqQP7RN5j0zIYvAurgs9JOLe/dpd5sE5HXQ==",
+      "dependencies": {
+        "@turf/bbox": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "@turf/union": "^5.1.5",
+        "rbush": "^2.0.1"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/meta": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-5.1.6.tgz",
+      "integrity": "sha512-lv+6LCgoc3LVitQZ4TScN/8a/fcctq8bIoxBTMJVq4aU8xoHeY1851Dq8MCU37EzbH33utkx8/jENaQP+aeElg==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/midpoint": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/midpoint/-/midpoint-5.1.5.tgz",
+      "integrity": "sha512-0pDQAKHyK/zxlvUx3XNxwvqftf4sV32QxnHfqSs4AXaODUGUbPhzAD7aXgDScBeUOVLwpAzFRQfitUvUMTGC6A==",
+      "dependencies": {
+        "@turf/bearing": "^5.1.5",
+        "@turf/destination": "^5.1.5",
+        "@turf/distance": "^5.1.5",
+        "@turf/helpers": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/nearest-point": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/nearest-point/-/nearest-point-5.1.5.tgz",
+      "integrity": "sha512-tZQXI7OE7keNKK4OvYOJ5gervCEuu2pJ6psu59QW9yhe2Di3Gl+HAdLvVa6RZ8s5Fndr3u0JWKsmxve3fCxc9g==",
+      "dependencies": {
+        "@turf/clone": "^5.1.5",
+        "@turf/distance": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/nearest-point-on-line": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/nearest-point-on-line/-/nearest-point-on-line-5.1.5.tgz",
+      "integrity": "sha512-qT7BLTwToo8cq0oNoz921oLlRPJamyRg/rZgll+kNBadyDPmJI4W66riHcpM9RQcAJ6TPvDveIIBeGJH7iG88w==",
+      "dependencies": {
+        "@turf/bearing": "^5.1.5",
+        "@turf/destination": "^5.1.5",
+        "@turf/distance": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/line-intersect": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/nearest-point-to-line": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/@turf/nearest-point-to-line/-/nearest-point-to-line-5.1.6.tgz",
+      "integrity": "sha512-ZSvDIEiHhifn/vNwLXZI/E8xmEz5yBPqfUR7BVHRZrB1cP7jLhKZvkbidjG//uW8Fr1Ulc+PFOXczLspIcx/lw==",
+      "dependencies": {
+        "@turf/helpers": "6.x",
+        "@turf/invariant": "6.x",
+        "@turf/meta": "6.x",
+        "@turf/point-to-line-distance": "^5.1.5",
+        "object-assign": "*"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/nearest-point-to-line/node_modules/@turf/helpers": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.5.0.tgz",
+      "integrity": "sha512-VbI1dV5bLFzohYYdgqwikdMVpe7pJ9X3E+dlr425wa2/sMJqYDhTO++ec38/pcPvPE6oD9WEEeU3Xu3gza+VPw==",
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/nearest-point-to-line/node_modules/@turf/invariant": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-6.5.0.tgz",
+      "integrity": "sha512-Wv8PRNCtPD31UVbdJE/KVAWKe7l6US+lJItRR/HOEW3eh+U/JwRCSUl/KZ7bmjM/C+zLNoreM2TU6OoLACs4eg==",
+      "dependencies": {
+        "@turf/helpers": "^6.5.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/nearest-point-to-line/node_modules/@turf/meta": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-6.5.0.tgz",
+      "integrity": "sha512-RrArvtsV0vdsCBegoBtOalgdSOfkBrTJ07VkpiCnq/491W67hnMWmDu7e6Ztw0C3WldRYTXkg3SumfdzZxLBHA==",
+      "dependencies": {
+        "@turf/helpers": "^6.5.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/planepoint": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/planepoint/-/planepoint-5.1.5.tgz",
+      "integrity": "sha512-+Tp+SQ0Db2tqwLbxfXJPysT9IxcOHSMIin2dJb/j3Qn5+g0LRus6rczZl6dWNAIjqBPMawj/V/dZhMu6Q9O9wA==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/point-grid": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/point-grid/-/point-grid-5.1.5.tgz",
+      "integrity": "sha512-4ibozguP9YJ297Q7i9e8/ypGSycvt1re2jrPXTxeuZ4/L/NE5B1nOBLG+tw121nMjD+S+v2RWOtqD+FZ3Ga+ew==",
+      "dependencies": {
+        "@turf/boolean-within": "^5.1.5",
+        "@turf/distance": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/point-on-feature": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/point-on-feature/-/point-on-feature-5.1.5.tgz",
+      "integrity": "sha512-NTcpe5xZjybRh0aTL+7td1cm0s49GGbAt5u8Cdec4W9ix2PsehRcLUbmQIQsODN2kiVyUSpnhECIpsyN5MjX7A==",
+      "dependencies": {
+        "@turf/boolean-point-in-polygon": "^5.1.5",
+        "@turf/center": "^5.1.5",
+        "@turf/explode": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/nearest-point": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/point-to-line-distance": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/@turf/point-to-line-distance/-/point-to-line-distance-5.1.6.tgz",
+      "integrity": "sha512-PE3hiTeeDEi4ZLPtI8XAzFYW9nHo1EVsZGm/4ZVV8jo39d3X1oLVHxY3e1PkCmWwRapXy4QLqvnTQ7nU4wspNw==",
+      "dependencies": {
+        "@turf/bearing": "6.x",
+        "@turf/distance": "6.x",
+        "@turf/helpers": "6.x",
+        "@turf/invariant": "6.x",
+        "@turf/meta": "6.x",
+        "@turf/projection": "6.x",
+        "@turf/rhumb-bearing": "6.x",
+        "@turf/rhumb-distance": "6.x"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/point-to-line-distance/node_modules/@turf/bearing": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/bearing/-/bearing-6.5.0.tgz",
+      "integrity": "sha512-dxINYhIEMzgDOztyMZc20I7ssYVNEpSv04VbMo5YPQsqa80KO3TFvbuCahMsCAW5z8Tncc8dwBlEFrmRjJG33A==",
+      "dependencies": {
+        "@turf/helpers": "^6.5.0",
+        "@turf/invariant": "^6.5.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/point-to-line-distance/node_modules/@turf/distance": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/distance/-/distance-6.5.0.tgz",
+      "integrity": "sha512-xzykSLfoURec5qvQJcfifw/1mJa+5UwByZZ5TZ8iaqjGYN0vomhV9aiSLeYdUGtYRESZ+DYC/OzY+4RclZYgMg==",
+      "dependencies": {
+        "@turf/helpers": "^6.5.0",
+        "@turf/invariant": "^6.5.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/point-to-line-distance/node_modules/@turf/helpers": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.5.0.tgz",
+      "integrity": "sha512-VbI1dV5bLFzohYYdgqwikdMVpe7pJ9X3E+dlr425wa2/sMJqYDhTO++ec38/pcPvPE6oD9WEEeU3Xu3gza+VPw==",
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/point-to-line-distance/node_modules/@turf/invariant": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-6.5.0.tgz",
+      "integrity": "sha512-Wv8PRNCtPD31UVbdJE/KVAWKe7l6US+lJItRR/HOEW3eh+U/JwRCSUl/KZ7bmjM/C+zLNoreM2TU6OoLACs4eg==",
+      "dependencies": {
+        "@turf/helpers": "^6.5.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/point-to-line-distance/node_modules/@turf/meta": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-6.5.0.tgz",
+      "integrity": "sha512-RrArvtsV0vdsCBegoBtOalgdSOfkBrTJ07VkpiCnq/491W67hnMWmDu7e6Ztw0C3WldRYTXkg3SumfdzZxLBHA==",
+      "dependencies": {
+        "@turf/helpers": "^6.5.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/points-within-polygon": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/points-within-polygon/-/points-within-polygon-5.1.5.tgz",
+      "integrity": "sha512-nexe2AHVOY8wEBvs+CYSOp10NyOCkyZ1gkhIfsx0mzU8LPYBxD9ctjlKveheKh4AAldLcFupd/gSCBTKF1JS7A==",
+      "dependencies": {
+        "@turf/boolean-point-in-polygon": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/polygon-tangents": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/polygon-tangents/-/polygon-tangents-5.1.5.tgz",
+      "integrity": "sha512-uoZfKvFhl6rf0+CDWucru9fZ4mJB5Nsg37TS/7emrzjoVxXyOdxc/s1HFCjcKflMue7MjU/gT6AitJyrvdztDg==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/polygon-to-line": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/polygon-to-line/-/polygon-to-line-5.1.5.tgz",
+      "integrity": "sha512-kVo0owPqyccy5+qZGvaxGvMsYkgueKE2OOgX2UV/HyrXF3uI3TomK1txjApqeFsLvwuSANxesvVbYLrYiIwvGw==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/polygonize": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/polygonize/-/polygonize-5.1.5.tgz",
+      "integrity": "sha512-qzhtuzoOhldqZHm+ZPsWAs9nDpnkcDfsr+I0twmBF+wjAmo0HKiy9++sRQ4kEePpdwbMpF07D/NdZqYdmOJkGQ==",
+      "dependencies": {
+        "@turf/boolean-point-in-polygon": "^5.1.5",
+        "@turf/envelope": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/random": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/random/-/random-5.1.5.tgz",
+      "integrity": "sha512-oitpBwEb6YXqoUkIAOVMK+vrTPxUi2rqITmtTa/FBHr6J8TDwMWq6bufE3Gmgjxsss50O2ITJunOksxrouWGDQ==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/rewind": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/rewind/-/rewind-5.1.5.tgz",
+      "integrity": "sha512-Gdem7JXNu+G4hMllQHXRFRihJl3+pNl7qY+l4qhQFxq+hiU1cQoVFnyoleIqWKIrdK/i2YubaSwc3SCM7N5mMw==",
+      "dependencies": {
+        "@turf/boolean-clockwise": "^5.1.5",
+        "@turf/clone": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/rhumb-destination": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/rhumb-destination/-/rhumb-destination-5.1.5.tgz",
+      "integrity": "sha512-FdDUCSRfRAfsRmUaWjc76Wk32QYFJ6ckmSt6Ls6nEczO6eg/RgH1atF8CIYwR5ifl0Sk1rQzKiOSbpCyvVwQtw==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/sample": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/sample/-/sample-5.1.5.tgz",
+      "integrity": "sha512-EJE8yx+5x7rXejTzwBdOKpvT4tOCS0jwYJfycyTVDuLUSh2rETeYdjy7EeJbofnxm9CRPXqWQMPWIBKWxNTjow==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/sector": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/sector/-/sector-5.1.5.tgz",
+      "integrity": "sha512-dnWVifL3xWTqPPs8mfbbV9muDimNJtxRk4ogrkOLEDQ9ZZ1ALQMtQdYrg7kI3iC+L+LscV37tl+E8bayWyX8YA==",
+      "dependencies": {
+        "@turf/circle": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/line-arc": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/shortest-path": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/shortest-path/-/shortest-path-5.1.5.tgz",
+      "integrity": "sha512-ZGC8kSBj02GKWiI56Z5FNdrZ+fS0xyeOUNrPJWzudAlrv9wKGaRuWoIVRLGBu0j0OuO1HCwggic2c6WV/AhP0A==",
+      "dependencies": {
+        "@turf/bbox": "^5.1.5",
+        "@turf/bbox-polygon": "^5.1.5",
+        "@turf/boolean-point-in-polygon": "^5.1.5",
+        "@turf/clean-coords": "^5.1.5",
+        "@turf/distance": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "@turf/transform-scale": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/simplify": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/simplify/-/simplify-5.1.5.tgz",
+      "integrity": "sha512-IuBXEYdGSxbDOK3v949ajaPvs6NhjhTCTbKA6mSGuVbwGS7gzAuRiPSG4K/MvCVuQy3PKpkPcUGD+Uvt2Ov2PQ==",
+      "dependencies": {
+        "@turf/clean-coords": "^5.1.5",
+        "@turf/clone": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/square": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/square/-/square-5.1.5.tgz",
+      "integrity": "sha512-GgP2le9ksoW6vsVef5wFkjmWQiLPTJvcjGXqmoGWT4oMwDpvTJVQ91RBLs8qQbI4KACCQevz94N69klk3ah30Q==",
+      "dependencies": {
+        "@turf/distance": "^5.1.5",
+        "@turf/helpers": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/square-grid": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/square-grid/-/square-grid-5.1.5.tgz",
+      "integrity": "sha512-/pusEL4FmOwNWLcZfIXUyqUe0fOdkfaLO4wLhDlg/ZL1jWr/wZjhVlMU0tQ27kVN6dJTvlzNc9e0JWNw6yt2eQ==",
+      "dependencies": {
+        "@turf/boolean-contains": "^5.1.5",
+        "@turf/boolean-overlap": "^5.1.5",
+        "@turf/distance": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/intersect": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/standard-deviational-ellipse": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/standard-deviational-ellipse/-/standard-deviational-ellipse-5.1.5.tgz",
+      "integrity": "sha512-GOaxGKeeJAXV1H3Zz2fjQ5XeSbMKz1OkFRlTDBUipiAawe/9qTCF55L87I2ZPnO80B5BaaIT+AN2n0lMcAklzA==",
+      "dependencies": {
+        "@turf/center-mean": "^5.1.5",
+        "@turf/ellipse": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "@turf/points-within-polygon": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/tag": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/tag/-/tag-5.1.5.tgz",
+      "integrity": "sha512-XI3QFpva6tEsRnzFe1tJGdAAWlzjnXZPfJ9EKShTxEW8ZgPzm92b2odjiSAt2KuQusK82ltNfdw5Frlna5xGYQ==",
+      "dependencies": {
+        "@turf/boolean-point-in-polygon": "^5.1.5",
+        "@turf/clone": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/tesselate": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/tesselate/-/tesselate-5.1.5.tgz",
+      "integrity": "sha512-Rs/jAij26bcU4OzvFXkWDase1G3kSwyuuKZPFU0t7OmJu7eQJOR12WOZLGcVxd5oBlklo4xPE4EBQUqpQUsQgg==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "earcut": "^2.0.0"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/tin": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/tin/-/tin-5.1.5.tgz",
+      "integrity": "sha512-lDyCTYKoThBIKmkBxBMupqEpFbvTDAYuZIs8qrWnmux2vntSb8OFGi7ZbGPC6apS2hdVwZZae3YB88Tp+Fg+xw==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/transform-rotate": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/transform-rotate/-/transform-rotate-5.1.5.tgz",
+      "integrity": "sha512-3QKckeHKPXu5O5vEuT+nkszGDI6aknDD06ePb00+6H2oA7MZj7nj+fVQIJLs41MRb76IyKr4n5NvuKZU6idESA==",
+      "dependencies": {
+        "@turf/centroid": "^5.1.5",
+        "@turf/clone": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "@turf/rhumb-bearing": "^5.1.5",
+        "@turf/rhumb-destination": "^5.1.5",
+        "@turf/rhumb-distance": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/transform-rotate/node_modules/@turf/rhumb-bearing": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/rhumb-bearing/-/rhumb-bearing-5.1.5.tgz",
+      "integrity": "sha512-zXTl2khjwf7mx2D1uPo5vgpGgP4sM2VrKDbJNKyulPu4TO4ELt8x7FsKyCBlRTzzQf284t/xnNcZOfUbkkd70g==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/transform-rotate/node_modules/@turf/rhumb-distance": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/rhumb-distance/-/rhumb-distance-5.1.5.tgz",
+      "integrity": "sha512-AGA/ky5/BJJZtzQqafy2GvJfcUXSzCCrPFp8sDRPSKBoUN4gMBHN15ijDWYYLFoWFFj0urcauVx7chQlHZ/Qfw==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/transform-scale": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/transform-scale/-/transform-scale-5.1.5.tgz",
+      "integrity": "sha512-t1fCZX29ONA7DJiqCKA4YZy0+hCzhppWNOZhglBUv9vKHsWCFYZDUKfFInciaypUInsZyvm8eKxxixBVPdPGsw==",
+      "dependencies": {
+        "@turf/bbox": "^5.1.5",
+        "@turf/center": "^5.1.5",
+        "@turf/centroid": "^5.1.5",
+        "@turf/clone": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "@turf/rhumb-bearing": "^5.1.5",
+        "@turf/rhumb-destination": "^5.1.5",
+        "@turf/rhumb-distance": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/transform-scale/node_modules/@turf/rhumb-bearing": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/rhumb-bearing/-/rhumb-bearing-5.1.5.tgz",
+      "integrity": "sha512-zXTl2khjwf7mx2D1uPo5vgpGgP4sM2VrKDbJNKyulPu4TO4ELt8x7FsKyCBlRTzzQf284t/xnNcZOfUbkkd70g==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/transform-scale/node_modules/@turf/rhumb-distance": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/rhumb-distance/-/rhumb-distance-5.1.5.tgz",
+      "integrity": "sha512-AGA/ky5/BJJZtzQqafy2GvJfcUXSzCCrPFp8sDRPSKBoUN4gMBHN15ijDWYYLFoWFFj0urcauVx7chQlHZ/Qfw==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/transform-translate": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/transform-translate/-/transform-translate-5.1.5.tgz",
+      "integrity": "sha512-GdLFp7I7198oRQt311B8EjiqHupndeMSQ3Zclzki5L/niUrb1ptOIpo+mxSidSy03m+1Q5ylWlENroI1WBcQ3Q==",
+      "dependencies": {
+        "@turf/clone": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "@turf/rhumb-destination": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/triangle-grid": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/triangle-grid/-/triangle-grid-5.1.5.tgz",
+      "integrity": "sha512-jmCRcynI80xsVqd+0rv0YxP6mvZn4BAaJv8dwthg2T3WfHB9OD+rNUMohMuUY8HmI0zRT3s/Ypdy2Cdri9u/tw==",
+      "dependencies": {
+        "@turf/distance": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/intersect": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/truncate": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/truncate/-/truncate-5.1.5.tgz",
+      "integrity": "sha512-WjWGsRE6o1vUqULGb/O7O1eK6B4Eu6R/RBZWnF0rH0Os6WVel6tHktkeJdlKwz9WElIEO12wDIu6uKd54t7DDQ==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/turf": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/@turf/turf/-/turf-5.1.6.tgz",
+      "integrity": "sha512-NIjkt5jAbOrom+56ELw9ERZF6qsdf1xAIHyC9/PkDMIOQAxe7FVe2HaqbQ+x88F0q5FaSX4dtpIEf08md6h5/A==",
+      "dependencies": {
+        "@turf/along": "5.1.x",
+        "@turf/area": "5.1.x",
+        "@turf/bbox": "5.1.x",
+        "@turf/bbox-clip": "5.1.x",
+        "@turf/bbox-polygon": "5.1.x",
+        "@turf/bearing": "5.1.x",
+        "@turf/bezier-spline": "5.1.x",
+        "@turf/boolean-clockwise": "5.1.x",
+        "@turf/boolean-contains": "5.1.x",
+        "@turf/boolean-crosses": "5.1.x",
+        "@turf/boolean-disjoint": "5.1.x",
+        "@turf/boolean-equal": "5.1.x",
+        "@turf/boolean-overlap": "5.1.x",
+        "@turf/boolean-parallel": "5.1.x",
+        "@turf/boolean-point-in-polygon": "5.1.x",
+        "@turf/boolean-point-on-line": "5.1.x",
+        "@turf/boolean-within": "5.1.x",
+        "@turf/buffer": "5.1.x",
+        "@turf/center": "5.1.x",
+        "@turf/center-mean": "5.1.x",
+        "@turf/center-median": "5.1.x",
+        "@turf/center-of-mass": "5.1.x",
+        "@turf/centroid": "5.1.x",
+        "@turf/circle": "5.1.x",
+        "@turf/clean-coords": "5.1.x",
+        "@turf/clone": "5.1.x",
+        "@turf/clusters": "5.1.x",
+        "@turf/clusters-dbscan": "5.1.x",
+        "@turf/clusters-kmeans": "5.1.x",
+        "@turf/collect": "5.1.x",
+        "@turf/combine": "5.1.x",
+        "@turf/concave": "5.1.x",
+        "@turf/convex": "5.1.x",
+        "@turf/destination": "5.1.x",
+        "@turf/difference": "5.1.x",
+        "@turf/dissolve": "5.1.x",
+        "@turf/distance": "5.1.x",
+        "@turf/ellipse": "5.1.x",
+        "@turf/envelope": "5.1.x",
+        "@turf/explode": "5.1.x",
+        "@turf/flatten": "5.1.x",
+        "@turf/flip": "5.1.x",
+        "@turf/great-circle": "5.1.x",
+        "@turf/helpers": "5.1.x",
+        "@turf/hex-grid": "5.1.x",
+        "@turf/interpolate": "5.1.x",
+        "@turf/intersect": "5.1.x",
+        "@turf/invariant": "5.1.x",
+        "@turf/isobands": "5.1.x",
+        "@turf/isolines": "5.1.x",
+        "@turf/kinks": "5.1.x",
+        "@turf/length": "5.1.x",
+        "@turf/line-arc": "5.1.x",
+        "@turf/line-chunk": "5.1.x",
+        "@turf/line-intersect": "5.1.x",
+        "@turf/line-offset": "5.1.x",
+        "@turf/line-overlap": "5.1.x",
+        "@turf/line-segment": "5.1.x",
+        "@turf/line-slice": "5.1.x",
+        "@turf/line-slice-along": "5.1.x",
+        "@turf/line-split": "5.1.x",
+        "@turf/line-to-polygon": "5.1.x",
+        "@turf/mask": "5.1.x",
+        "@turf/meta": "5.1.x",
+        "@turf/midpoint": "5.1.x",
+        "@turf/nearest-point": "5.1.x",
+        "@turf/nearest-point-on-line": "5.1.x",
+        "@turf/nearest-point-to-line": "5.1.x",
+        "@turf/planepoint": "5.1.x",
+        "@turf/point-grid": "5.1.x",
+        "@turf/point-on-feature": "5.1.x",
+        "@turf/point-to-line-distance": "5.1.x",
+        "@turf/points-within-polygon": "5.1.x",
+        "@turf/polygon-tangents": "5.1.x",
+        "@turf/polygon-to-line": "5.1.x",
+        "@turf/polygonize": "5.1.x",
+        "@turf/projection": "5.1.x",
+        "@turf/random": "5.1.x",
+        "@turf/rewind": "5.1.x",
+        "@turf/rhumb-bearing": "5.1.x",
+        "@turf/rhumb-destination": "5.1.x",
+        "@turf/rhumb-distance": "5.1.x",
+        "@turf/sample": "5.1.x",
+        "@turf/sector": "5.1.x",
+        "@turf/shortest-path": "5.1.x",
+        "@turf/simplify": "5.1.x",
+        "@turf/square": "5.1.x",
+        "@turf/square-grid": "5.1.x",
+        "@turf/standard-deviational-ellipse": "5.1.x",
+        "@turf/tag": "5.1.x",
+        "@turf/tesselate": "5.1.x",
+        "@turf/tin": "5.1.x",
+        "@turf/transform-rotate": "5.1.x",
+        "@turf/transform-scale": "5.1.x",
+        "@turf/transform-translate": "5.1.x",
+        "@turf/triangle-grid": "5.1.x",
+        "@turf/truncate": "5.1.x",
+        "@turf/union": "5.1.x",
+        "@turf/unkink-polygon": "5.1.x",
+        "@turf/voronoi": "5.1.x"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/turf/node_modules/@turf/projection": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/projection/-/projection-5.1.5.tgz",
+      "integrity": "sha512-TWKJDFeEKQhI4Ce1+2PuOSDggn4cnMibqyUoCpIW+4KxUC1R88SE3/SYomqzwxMn00O09glHSycPkGD5JzHd8A==",
+      "dependencies": {
+        "@turf/clone": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/turf/node_modules/@turf/rhumb-bearing": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/rhumb-bearing/-/rhumb-bearing-5.1.5.tgz",
+      "integrity": "sha512-zXTl2khjwf7mx2D1uPo5vgpGgP4sM2VrKDbJNKyulPu4TO4ELt8x7FsKyCBlRTzzQf284t/xnNcZOfUbkkd70g==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/turf/node_modules/@turf/rhumb-distance": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/rhumb-distance/-/rhumb-distance-5.1.5.tgz",
+      "integrity": "sha512-AGA/ky5/BJJZtzQqafy2GvJfcUXSzCCrPFp8sDRPSKBoUN4gMBHN15ijDWYYLFoWFFj0urcauVx7chQlHZ/Qfw==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/union": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/union/-/union-5.1.5.tgz",
+      "integrity": "sha512-wBy1ixxC68PpsTeEDebk/EfnbI1Za5dCyY7xFY9NMzrtVEOy0l0lQ5syOsaqY4Ire+dbsDM66p2GGxmefoyIEA==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "turf-jsts": "*"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/unkink-polygon": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/unkink-polygon/-/unkink-polygon-5.1.5.tgz",
+      "integrity": "sha512-lzSrgsfSuyxIc4pkE2qyM2dsHxR992e6oItoZAT8G58A2Ef4qc5gRocmXPWZakGx41fQobegSo7wlo4I49wyHg==",
+      "dependencies": {
+        "@turf/area": "^5.1.5",
+        "@turf/boolean-point-in-polygon": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "rbush": "^2.0.1"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/@turf/voronoi": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/voronoi/-/voronoi-5.1.5.tgz",
+      "integrity": "sha512-Ad0HZAyYjOpMIZfDGV+Q+30M9PQHIirTyn32kWyTjEI1O6uhL5NOYjzSha4Sr77xOls3hGzKOj+JET7eDtOvsg==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "d3-voronoi": "1.1.2"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/geojson-rbush": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/geojson-rbush/-/geojson-rbush-2.1.0.tgz",
+      "integrity": "sha512-9HvLGhmAJBYkYYDdPlCrlfkKGwNW3PapiS0xPekdJLobkZE4rjtduKJXsO7+kUr97SsUlz4VtMcPuSIbjjJaQg==",
+      "dependencies": {
+        "@turf/helpers": "*",
+        "@turf/meta": "*",
+        "rbush": "*"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/jszip": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-2.6.1.tgz",
+      "integrity": "sha512-C4Z++nYQv+CudUkCWUdz+yKVhQiFJjuWSmRJ5Sg3d3/OzcJ6U4ooUYlmE3+rJXrVk89KWQaiJ9mPp/VLQ4D66g==",
+      "dependencies": {
+        "pako": "~1.0.2"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/lru-cache": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+      "integrity": "sha512-WpibWJ60c3AgAz8a2iYErDrcT2C7OmKnsWhIcHOjkUHFjkXncJhtLxNSqUmxRxRunpb5I8Vprd7aNSd2NtksJQ=="
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/shpjs": {
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/shpjs/-/shpjs-3.6.3.tgz",
+      "integrity": "sha512-wcR2S3WL/7RnEIm+YO+H/mZR9z9FCV46op+SZt+W5PtPs26Omb9U93f+EPI1DOpNKBuAIrWjHWh0SxlnBahJkg==",
+      "dependencies": {
+        "jszip": "^2.4.0",
+        "lie": "^3.0.1",
+        "lru-cache": "^2.7.0",
+        "parsedbf": "^1.1.0",
+        "proj4": "^2.1.4"
+      }
+    },
+    "node_modules/geostyler-style": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/geostyler-style/-/geostyler-style-4.0.3.tgz",
+      "integrity": "sha512-51esHVZz86HFoSvKRA/Kfqd2Mytek88zgHSSt8ZZg30o4dqyZuQluxwIjqkSLp5hdvmA0nwCAyqxHy6aMyJ5lQ==",
+      "dependencies": {
+        "@types/lodash": "^4.14.168",
+        "lodash": "^4.17.21"
+      }
+    },
     "node_modules/geotiff": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/geotiff/-/geotiff-2.0.5.tgz",
@@ -13132,6 +13973,11 @@
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
       }
+    },
+    "node_modules/get-closest": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/get-closest/-/get-closest-0.0.4.tgz",
+      "integrity": "sha512-oMgZYUtnPMZB6XieXiUADpRIc5kfD+RPfpiYe9aIlEYGIcOx2mTGgKmUkctlLof/ANleypqOJRhQypbrh33DkA=="
     },
     "node_modules/get-intrinsic": {
       "version": "1.1.1",
@@ -18072,6 +18918,11 @@
       "dependencies": {
         "immediate": "~3.0.5"
       }
+    },
+    "node_modules/lineclip": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/lineclip/-/lineclip-1.1.5.tgz",
+      "integrity": "sha512-KlA/wRSjpKl7tS9iRUdlG72oQ7qZ1IlVbVgHwoO10TBR/4gQ86uhKow6nlzMAJJhjCWKto8OeoAzzIzKSmN25A=="
     },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
@@ -26506,7 +27357,6 @@
       "version": "6.6.7",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
       "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
-      "dev": true,
       "dependencies": {
         "tslib": "^1.9.0"
       },
@@ -26517,8 +27367,7 @@
     "node_modules/rxjs/node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/safe-buffer": {
       "version": "5.1.2",
@@ -32261,436 +33110,16 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
-    "@commitlint/cli": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-17.0.2.tgz",
-      "integrity": "sha512-Axe89Js0YzGGd4gxo3JLlF7yIdjOVpG1LbOorGc6PfYF+drBh14PvarSDLzyd2TNqdylUCq9wb9/A88ZjIdyhA==",
-      "dev": true,
+    "@camptocamp/inkmap": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@camptocamp/inkmap/-/inkmap-1.2.0.tgz",
+      "integrity": "sha512-s23FoTPWV9q9CCJcu78RxbZTjBYxIMsM4Q+Rkf9VS3h2Akzsg4HbQdKzEPsJK/SmSZZPt7nAMOlzL4xp4ZIQig==",
       "requires": {
-        "@commitlint/format": "^17.0.0",
-        "@commitlint/lint": "^17.0.0",
-        "@commitlint/load": "^17.0.0",
-        "@commitlint/read": "^17.0.0",
-        "@commitlint/types": "^17.0.0",
-        "execa": "^5.0.0",
-        "lodash": "^4.17.19",
-        "resolve-from": "5.0.0",
-        "resolve-global": "1.0.0",
-        "yargs": "^17.0.0"
-      },
-      "dependencies": {
-        "yargs": {
-          "version": "17.5.1",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.5.1.tgz",
-          "integrity": "sha512-t6YAJcxDkNX7NFYiVtKvWUz8l+PaKTLiL63mJYWR2GnHq2gjEWISzsLp9wg3aY36dY1j+gfIEL3pIF+XlJJfbA==",
-          "dev": true,
-          "requires": {
-            "cliui": "^7.0.2",
-            "escalade": "^3.1.1",
-            "get-caller-file": "^2.0.5",
-            "require-directory": "^2.1.1",
-            "string-width": "^4.2.3",
-            "y18n": "^5.0.5",
-            "yargs-parser": "^21.0.0"
-          }
-        },
-        "yargs-parser": {
-          "version": "21.0.1",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.1.tgz",
-          "integrity": "sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg==",
-          "dev": true
-        }
-      }
-    },
-    "@commitlint/config-conventional": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-17.0.2.tgz",
-      "integrity": "sha512-MfP0I/JbxKkzo+HXWB7B3WstGS4BiniotU3d3xQ9gK8cR0DbeZ4MuyGCWF65YDyrcDTS3WlrJ3ndSPA1pqhoPw==",
-      "dev": true,
-      "requires": {
-        "conventional-changelog-conventionalcommits": "^5.0.0"
-      }
-    },
-    "@commitlint/config-validator": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/config-validator/-/config-validator-17.0.0.tgz",
-      "integrity": "sha512-78IQjoZWR4kDHp/U5y17euEWzswJpPkA9TDL5F6oZZZaLIEreWzrDZD5PWtM8MsSRl/K2LDU/UrzYju2bKLMpA==",
-      "dev": true,
-      "requires": {
-        "@commitlint/types": "^17.0.0",
-        "ajv": "^6.12.6"
-      }
-    },
-    "@commitlint/ensure": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-17.0.0.tgz",
-      "integrity": "sha512-M2hkJnNXvEni59S0QPOnqCKIK52G1XyXBGw51mvh7OXDudCmZ9tZiIPpU882p475Mhx48Ien1MbWjCP1zlyC0A==",
-      "dev": true,
-      "requires": {
-        "@commitlint/types": "^17.0.0",
-        "lodash": "^4.17.19"
-      }
-    },
-    "@commitlint/execute-rule": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/execute-rule/-/execute-rule-17.0.0.tgz",
-      "integrity": "sha512-nVjL/w/zuqjCqSJm8UfpNaw66V9WzuJtQvEnCrK4jDw6qKTmZB+1JQ8m6BQVZbNBcwfYdDNKnhIhqI0Rk7lgpQ==",
-      "dev": true
-    },
-    "@commitlint/format": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/format/-/format-17.0.0.tgz",
-      "integrity": "sha512-MZzJv7rBp/r6ZQJDEodoZvdRM0vXu1PfQvMTNWFb8jFraxnISMTnPBWMMjr2G/puoMashwaNM//fl7j8gGV5lA==",
-      "dev": true,
-      "requires": {
-        "@commitlint/types": "^17.0.0",
-        "chalk": "^4.1.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "chalk": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        }
-      }
-    },
-    "@commitlint/is-ignored": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-17.0.0.tgz",
-      "integrity": "sha512-UmacD0XM/wWykgdXn5CEWVS4XGuqzU+ZGvM2hwv85+SXGnIOaG88XHrt81u37ZeVt1riWW+YdOxcJW6+nd5v5w==",
-      "dev": true,
-      "requires": {
-        "@commitlint/types": "^17.0.0",
-        "semver": "7.3.7"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "7.3.7",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-          "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        }
-      }
-    },
-    "@commitlint/lint": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-17.0.0.tgz",
-      "integrity": "sha512-5FL7VLvGJQby24q0pd4UdM8FNFcL+ER1T/UBf8A9KRL5+QXV1Rkl6Zhcl7+SGpGlVo6Yo0pm6aLW716LVKWLGg==",
-      "dev": true,
-      "requires": {
-        "@commitlint/is-ignored": "^17.0.0",
-        "@commitlint/parse": "^17.0.0",
-        "@commitlint/rules": "^17.0.0",
-        "@commitlint/types": "^17.0.0"
-      }
-    },
-    "@commitlint/load": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-17.0.0.tgz",
-      "integrity": "sha512-XaiHF4yWQOPAI0O6wXvk+NYLtJn/Xb7jgZEeKd4C1ZWd7vR7u8z5h0PkWxSr0uLZGQsElGxv3fiZ32C5+q6M8w==",
-      "dev": true,
-      "requires": {
-        "@commitlint/config-validator": "^17.0.0",
-        "@commitlint/execute-rule": "^17.0.0",
-        "@commitlint/resolve-extends": "^17.0.0",
-        "@commitlint/types": "^17.0.0",
-        "@types/node": ">=12",
-        "chalk": "^4.1.0",
-        "cosmiconfig": "^7.0.0",
-        "cosmiconfig-typescript-loader": "^2.0.0",
-        "lodash": "^4.17.19",
-        "resolve-from": "^5.0.0",
-        "typescript": "^4.6.4"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "chalk": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        }
-      }
-    },
-    "@commitlint/message": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/message/-/message-17.0.0.tgz",
-      "integrity": "sha512-LpcwYtN+lBlfZijHUdVr8aNFTVpHjuHI52BnfoV01TF7iSLnia0jttzpLkrLmI8HNQz6Vhr9UrxDWtKZiMGsBw==",
-      "dev": true
-    },
-    "@commitlint/parse": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-17.0.0.tgz",
-      "integrity": "sha512-cKcpfTIQYDG1ywTIr5AG0RAiLBr1gudqEsmAGCTtj8ffDChbBRxm6xXs2nv7GvmJN7msOt7vOKleLvcMmRa1+A==",
-      "dev": true,
-      "requires": {
-        "@commitlint/types": "^17.0.0",
-        "conventional-changelog-angular": "^5.0.11",
-        "conventional-commits-parser": "^3.2.2"
-      }
-    },
-    "@commitlint/read": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/read/-/read-17.0.0.tgz",
-      "integrity": "sha512-zkuOdZayKX3J6F6mPnVMzohK3OBrsEdOByIqp4zQjA9VLw1hMsDEFQ18rKgUc2adkZar+4S01QrFreDCfZgbxA==",
-      "dev": true,
-      "requires": {
-        "@commitlint/top-level": "^17.0.0",
-        "@commitlint/types": "^17.0.0",
-        "fs-extra": "^10.0.0",
-        "git-raw-commits": "^2.0.0"
-      },
-      "dependencies": {
-        "fs-extra": {
-          "version": "10.1.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
-          "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^6.0.1",
-            "universalify": "^2.0.0"
-          }
-        }
-      }
-    },
-    "@commitlint/resolve-extends": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-17.0.0.tgz",
-      "integrity": "sha512-wi60WiJmwaQ7lzMXK8Vbc18Hq9tE2j/6iv2AFfPUGV7fvfY6Sf1iNKuUHirSqR0fquUyufIXe4y/K9A6LVIIvw==",
-      "dev": true,
-      "requires": {
-        "@commitlint/config-validator": "^17.0.0",
-        "@commitlint/types": "^17.0.0",
-        "import-fresh": "^3.0.0",
-        "lodash": "^4.17.19",
-        "resolve-from": "^5.0.0",
-        "resolve-global": "^1.0.0"
-      }
-    },
-    "@commitlint/rules": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-17.0.0.tgz",
-      "integrity": "sha512-45nIy3dERKXWpnwX9HeBzK5SepHwlDxdGBfmedXhL30fmFCkJOdxHyOJsh0+B0RaVsLGT01NELpfzJUmtpDwdQ==",
-      "dev": true,
-      "requires": {
-        "@commitlint/ensure": "^17.0.0",
-        "@commitlint/message": "^17.0.0",
-        "@commitlint/to-lines": "^17.0.0",
-        "@commitlint/types": "^17.0.0",
-        "execa": "^5.0.0"
-      }
-    },
-    "@commitlint/to-lines": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/to-lines/-/to-lines-17.0.0.tgz",
-      "integrity": "sha512-nEi4YEz04Rf2upFbpnEorG8iymyH7o9jYIVFBG1QdzebbIFET3ir+8kQvCZuBE5pKCtViE4XBUsRZz139uFrRQ==",
-      "dev": true
-    },
-    "@commitlint/top-level": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/top-level/-/top-level-17.0.0.tgz",
-      "integrity": "sha512-dZrEP1PBJvodNWYPOYiLWf6XZergdksKQaT6i1KSROLdjf5Ai0brLOv5/P+CPxBeoj3vBxK4Ax8H1Pg9t7sHIQ==",
-      "dev": true,
-      "requires": {
-        "find-up": "^5.0.0"
-      },
-      "dependencies": {
-        "find-up": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
-          "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
-          "dev": true,
-          "requires": {
-            "locate-path": "^6.0.0",
-            "path-exists": "^4.0.0"
-          }
-        },
-        "locate-path": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
-          "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-          "dev": true,
-          "requires": {
-            "p-locate": "^5.0.0"
-          }
-        },
-        "p-limit": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
-          "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-          "dev": true,
-          "requires": {
-            "yocto-queue": "^0.1.0"
-          }
-        },
-        "p-locate": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-          "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-          "dev": true,
-          "requires": {
-            "p-limit": "^3.0.2"
-          }
-        }
-      }
-    },
-    "@commitlint/types": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-17.0.0.tgz",
-      "integrity": "sha512-hBAw6U+SkAT5h47zDMeOu3HSiD0SODw4Aq7rRNh1ceUmL7GyLKYhPbUvlRWqZ65XjBLPHZhFyQlRaPNz8qvUyQ==",
-      "dev": true,
-      "requires": {
-        "chalk": "^4.1.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "chalk": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        }
-      }
-    },
-    "@cspotcode/source-map-support": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
-      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
-      "dev": true,
-      "requires": {
-        "@jridgewell/trace-mapping": "0.3.9"
+        "@babel/runtime": "^7.12.5",
+        "geostyler-openlayers-parser": "^2.1.0",
+        "ol": "^6.5.0",
+        "proj4": "^2.6.3",
+        "rxjs": "^6.6.3"
       }
     },
     "@ctrl/tinycolor": {
@@ -40876,6 +41305,1394 @@
         }
       }
     },
+    "geostyler-openlayers-parser": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/geostyler-openlayers-parser/-/geostyler-openlayers-parser-2.5.0.tgz",
+      "integrity": "sha512-Uum/lDci8oqhBA/c0RZbD91aXP4ycjlsAp4ZoVAPDHT6Og0XyF5Tze8wg0Ux44CerE6W+m2DfWkOTAP+iaakzQ==",
+      "requires": {
+        "@terrestris/ol-util": "^4.0.1",
+        "geostyler-style": "^4.0.0",
+        "lodash": "^4.17.15"
+      },
+      "dependencies": {
+        "@terrestris/ol-util": {
+          "version": "4.1.3",
+          "resolved": "https://registry.npmjs.org/@terrestris/ol-util/-/ol-util-4.1.3.tgz",
+          "integrity": "sha512-vTS7rXxOcvTpXQzRGR6DVldEYcbFjADQ9/ArSKeq9yCmmY9wb3dkeGKw+rN/dltu6oZbaswjsUsBQe060kiMOQ==",
+          "requires": {
+            "@terrestris/base-util": "^1.0.0",
+            "@turf/turf": "^5.1.6",
+            "lodash": "^4.17.20",
+            "proj4": "^2.7.0",
+            "shpjs": "^3.6.3"
+          }
+        },
+        "@turf/along": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/along/-/along-5.1.5.tgz",
+          "integrity": "sha512-N7BN1xvj6VWMe3UpjQDdVI0j0oY/EZ0bWgOgBXc4DlJ411uEsKCh6iBv0b2MSxQ3YUXEez3oc5FcgO9eVSs7iQ==",
+          "requires": {
+            "@turf/bearing": "^5.1.5",
+            "@turf/destination": "^5.1.5",
+            "@turf/distance": "^5.1.5",
+            "@turf/helpers": "^5.1.5"
+          }
+        },
+        "@turf/area": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/area/-/area-5.1.5.tgz",
+          "integrity": "sha512-lz16gqtvoz+j1jD9y3zj0Z5JnGNd3YfS0h+DQY1EcZymvi75Frm9i5YbEyth0RfxYZeOVufY7YIS3LXbJlI57g==",
+          "requires": {
+            "@turf/helpers": "^5.1.5",
+            "@turf/meta": "^5.1.5"
+          }
+        },
+        "@turf/bbox": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/bbox/-/bbox-5.1.5.tgz",
+          "integrity": "sha512-sYQU4fqsOYYJoD8UndC1n2hy8hV/lGIAmMLKWuzwmPUWqWOuSKWUcoRWDi9mGB0GvQQe/ow2IxZr8UaVaGz3sQ==",
+          "requires": {
+            "@turf/helpers": "^5.1.5",
+            "@turf/meta": "^5.1.5"
+          }
+        },
+        "@turf/bbox-clip": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/bbox-clip/-/bbox-clip-5.1.5.tgz",
+          "integrity": "sha512-KP64aoTvjcXxWHeM/Hs25vOQUBJgyJi7DlRVEoZofFJiR1kPnmDQrK7Xj+60lAk5cxuqzFnaPPxUk9Q+3v4p1Q==",
+          "requires": {
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5",
+            "lineclip": "^1.1.5"
+          }
+        },
+        "@turf/bbox-polygon": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/bbox-polygon/-/bbox-polygon-5.1.5.tgz",
+          "integrity": "sha512-PKVPF5LABFWZJud8KzzfesLGm5ihiwLbVa54HJjYySe6yqU/cr5q/qcN9TWptynOFhNktG1dr0KXVG0I2FZmfw==",
+          "requires": {
+            "@turf/helpers": "^5.1.5"
+          }
+        },
+        "@turf/bearing": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/bearing/-/bearing-5.1.5.tgz",
+          "integrity": "sha512-PrvZuJjnXGseB8hUatIjsrK3tgD3wttyRnVYXTbSfXYJZzaOfHDMplgO4lxXQp7diraZhGhCdSlbMvRRXItbUQ==",
+          "requires": {
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5"
+          }
+        },
+        "@turf/bezier-spline": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/bezier-spline/-/bezier-spline-5.1.5.tgz",
+          "integrity": "sha512-Y9NoComaGgFFFe9TWWE/cEMg2+EnBfU1R3112ec2wlx21ygDmFGXs4boOS71WM4ySwm/dbS3wxnbVxs4j68sKw==",
+          "requires": {
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5"
+          }
+        },
+        "@turf/boolean-clockwise": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/boolean-clockwise/-/boolean-clockwise-5.1.5.tgz",
+          "integrity": "sha512-FqbmEEOJ4rU4/2t7FKx0HUWmjFEVqR+NJrFP7ymGSjja2SQ7Q91nnBihGuT+yuHHl6ElMjQ3ttsB/eTmyCycxA==",
+          "requires": {
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5"
+          }
+        },
+        "@turf/boolean-contains": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/boolean-contains/-/boolean-contains-5.1.5.tgz",
+          "integrity": "sha512-x2HeEieeE9vBQrTdCuj4swnAXlpKbj9ChxMdDTV479c0m2gVmfea83ocmkj3w+9cvAaS63L8WqFyNVSmkwqljQ==",
+          "requires": {
+            "@turf/bbox": "^5.1.5",
+            "@turf/boolean-point-in-polygon": "^5.1.5",
+            "@turf/boolean-point-on-line": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5"
+          }
+        },
+        "@turf/boolean-crosses": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/boolean-crosses/-/boolean-crosses-5.1.5.tgz",
+          "integrity": "sha512-odljvS7INr9k/8yXeyXQVry7GqEaChOmXawP0+SoTfGO3hgptiik59TLU/Yjn/SLFjE2Ul54Ga1jKFSL7vvH0Q==",
+          "requires": {
+            "@turf/boolean-point-in-polygon": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5",
+            "@turf/line-intersect": "^5.1.5",
+            "@turf/polygon-to-line": "^5.1.5"
+          }
+        },
+        "@turf/boolean-disjoint": {
+          "version": "5.1.6",
+          "resolved": "https://registry.npmjs.org/@turf/boolean-disjoint/-/boolean-disjoint-5.1.6.tgz",
+          "integrity": "sha512-KHvUS6SBNYHBCLIJEJrg04pF5Oy+Fqn8V5G9U+9pti5vI9tyX7Ln2g7RSB7iJ1Cxsz8QAi6OukhXjEF2/8ZpGg==",
+          "requires": {
+            "@turf/boolean-point-in-polygon": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/line-intersect": "^5.1.5",
+            "@turf/meta": "^5.1.5",
+            "@turf/polygon-to-line": "^5.1.5"
+          }
+        },
+        "@turf/boolean-equal": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/boolean-equal/-/boolean-equal-5.1.5.tgz",
+          "integrity": "sha512-QEMbhDPV+J8PlRkMlVg6m5oSLaYUpOx2VUhDDekQ73FlpnhFBKRIlidhvHtS6CYnEw8d+/zA3h8Z18B4W4mq9Q==",
+          "requires": {
+            "@turf/clean-coords": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5",
+            "geojson-equality": "0.1.6"
+          }
+        },
+        "@turf/boolean-overlap": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/boolean-overlap/-/boolean-overlap-5.1.5.tgz",
+          "integrity": "sha512-lizojgU559KME0G705YAgWVa0B3/tsWNobMzOEWDx/1rABWTojCY4uxw2rFxpOsP++s8JJHrGWXRLh1PbdAvRQ==",
+          "requires": {
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5",
+            "@turf/line-intersect": "^5.1.5",
+            "@turf/line-overlap": "^5.1.5",
+            "@turf/meta": "^5.1.5",
+            "geojson-equality": "0.1.6"
+          }
+        },
+        "@turf/boolean-parallel": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/boolean-parallel/-/boolean-parallel-5.1.5.tgz",
+          "integrity": "sha512-eeuGgDhnas3nJ22A/DD8aiH0kg9dSzbQChIMAqYRPGg3pWNK41aGAbeh5z0GO5N/EVFX1+ga5a0vsPmiRgQB5g==",
+          "requires": {
+            "@turf/clean-coords": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/line-segment": "^5.1.5",
+            "@turf/rhumb-bearing": "^5.1.5"
+          },
+          "dependencies": {
+            "@turf/rhumb-bearing": {
+              "version": "5.1.5",
+              "resolved": "https://registry.npmjs.org/@turf/rhumb-bearing/-/rhumb-bearing-5.1.5.tgz",
+              "integrity": "sha512-zXTl2khjwf7mx2D1uPo5vgpGgP4sM2VrKDbJNKyulPu4TO4ELt8x7FsKyCBlRTzzQf284t/xnNcZOfUbkkd70g==",
+              "requires": {
+                "@turf/helpers": "^5.1.5",
+                "@turf/invariant": "^5.1.5"
+              }
+            }
+          }
+        },
+        "@turf/boolean-point-in-polygon": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/boolean-point-in-polygon/-/boolean-point-in-polygon-5.1.5.tgz",
+          "integrity": "sha512-y+gbAhLmsAZH9uYhv+C68pu06mxsGIm3o7l0hzVkc/PXYdbkr+vKe7n7PfSN3xpVA3qoDLKLpCGOqeW8/ThaJA==",
+          "requires": {
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5"
+          }
+        },
+        "@turf/boolean-point-on-line": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/boolean-point-on-line/-/boolean-point-on-line-5.1.5.tgz",
+          "integrity": "sha512-Zf4d28mckV2tYfLWf2iqxQ8eeLZqi2HGimM26mptf1OCEIwc1wfkKgLRRJXMu94Crvd/pJxjRAjoYGcGliP6Vg==",
+          "requires": {
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5"
+          }
+        },
+        "@turf/boolean-within": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/boolean-within/-/boolean-within-5.1.5.tgz",
+          "integrity": "sha512-CNAtrvm4HiUwV/vhpGhvJzfhV9CN7VhPC5y4tTfQicK82fYY6ifPz0iaNpUOmshU6+TAot/fsVQVgDJ4t7HXcA==",
+          "requires": {
+            "@turf/bbox": "^5.1.5",
+            "@turf/boolean-point-in-polygon": "^5.1.5",
+            "@turf/boolean-point-on-line": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5"
+          }
+        },
+        "@turf/buffer": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/buffer/-/buffer-5.1.5.tgz",
+          "integrity": "sha512-U3LU0HF/JNFUNabpB5ArpNG6yPla7yR5XPrZvzZRH48vvbr/N0rkSRI0tJFRWTz7ntugVm9X0OD9Y382NTJRhA==",
+          "requires": {
+            "@turf/bbox": "^5.1.5",
+            "@turf/center": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/meta": "^5.1.5",
+            "@turf/projection": "^5.1.5",
+            "d3-geo": "1.7.1",
+            "turf-jsts": "*"
+          },
+          "dependencies": {
+            "@turf/projection": {
+              "version": "5.1.5",
+              "resolved": "https://registry.npmjs.org/@turf/projection/-/projection-5.1.5.tgz",
+              "integrity": "sha512-TWKJDFeEKQhI4Ce1+2PuOSDggn4cnMibqyUoCpIW+4KxUC1R88SE3/SYomqzwxMn00O09glHSycPkGD5JzHd8A==",
+              "requires": {
+                "@turf/clone": "^5.1.5",
+                "@turf/helpers": "^5.1.5",
+                "@turf/meta": "^5.1.5"
+              }
+            }
+          }
+        },
+        "@turf/center": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/center/-/center-5.1.5.tgz",
+          "integrity": "sha512-Dy1TvAv2oHKFddZcWqlVsanxurfcZV1Mmb1E+7H7GRKI+fXZTfRjwCdbiZCbO/tPwxt8jWQHWdLHn8E9lecc3A==",
+          "requires": {
+            "@turf/bbox": "^5.1.5",
+            "@turf/helpers": "^5.1.5"
+          }
+        },
+        "@turf/center-mean": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/center-mean/-/center-mean-5.1.5.tgz",
+          "integrity": "sha512-XdkBXzFUuyCqu5EPlBwgkv8FLA8pIGBnt7xy5cxxhxKOYLMrKqwMPPHPA84TjeQpNti0gH0CVuOk2r1f/Pp8iQ==",
+          "requires": {
+            "@turf/bbox": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/meta": "^5.1.5"
+          }
+        },
+        "@turf/center-median": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/center-median/-/center-median-5.1.5.tgz",
+          "integrity": "sha512-M+O6bSNsIDKZ4utk/YzSOIg6W0isjLVWud+TCLWyrDCWTSERlSJlhOaVE1y7cObhG8nYBHvmszqZyoAY6nufQw==",
+          "requires": {
+            "@turf/center-mean": "^5.1.5",
+            "@turf/centroid": "^5.1.5",
+            "@turf/distance": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/meta": "^5.1.5"
+          }
+        },
+        "@turf/center-of-mass": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/center-of-mass/-/center-of-mass-5.1.5.tgz",
+          "integrity": "sha512-UvI7q6GgW3afCVIDOyTRuLT54v9Xwv65Xudxh4FIT6w7HNU4KUBtTGnx0NuhODZcgvZgWVWVakhmIcHQTMjYYA==",
+          "requires": {
+            "@turf/centroid": "^5.1.5",
+            "@turf/convex": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5",
+            "@turf/meta": "^5.1.5"
+          }
+        },
+        "@turf/centroid": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/centroid/-/centroid-5.1.5.tgz",
+          "integrity": "sha512-0m9ZAZJB4YXLDxF2fWGqlE/g9Y68cebeWaRNOMN+e6Bti1fz0JKQuaEqJV+J8xOmODPHSMbZZ1SqSDVRgVHP2Q==",
+          "requires": {
+            "@turf/helpers": "^5.1.5",
+            "@turf/meta": "^5.1.5"
+          }
+        },
+        "@turf/circle": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/circle/-/circle-5.1.5.tgz",
+          "integrity": "sha512-CNaEtvp38Q+TSFJHdzdl5iYNjBFZRluRTFikIuEcennSeMJD60nP0dMubP58TR/QQn541eNDUyED90V4KuOjyQ==",
+          "requires": {
+            "@turf/destination": "^5.1.5",
+            "@turf/helpers": "^5.1.5"
+          }
+        },
+        "@turf/clean-coords": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/clean-coords/-/clean-coords-5.1.5.tgz",
+          "integrity": "sha512-xd/iSM0McVUxbu81KCKDqirCsYkKk3EAwpDjYI8vIQ+eKf/MLSdteRcm3PB7wo2y6JcYp4dMGv2cr9IP7V+dXQ==",
+          "requires": {
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5"
+          }
+        },
+        "@turf/clone": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/clone/-/clone-5.1.5.tgz",
+          "integrity": "sha512-//pITsQ8xUdcQ9pVb4JqXiSqG4dos5Q9N4sYFoWghX21tfOV2dhc5TGqYOhnHrQS7RiKQL1vQ48kIK34gQ5oRg==",
+          "requires": {
+            "@turf/helpers": "^5.1.5"
+          }
+        },
+        "@turf/clusters": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/clusters/-/clusters-5.1.5.tgz",
+          "integrity": "sha512-+rQe+g66xfbIXz58tveXQCDdE9hzqRJtDVSw5xth92TvCcL4J60ZKN8mHNUSn1ZZvpUHtVPe4dYcbtk5bW8fXQ==",
+          "requires": {
+            "@turf/helpers": "^5.1.5",
+            "@turf/meta": "^5.1.5"
+          }
+        },
+        "@turf/clusters-dbscan": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/clusters-dbscan/-/clusters-dbscan-5.1.5.tgz",
+          "integrity": "sha512-X3qLLHJkwMuv+xdWQ08NtOc6BgeqCKKSAltyyAZ7iImE65f0C+sW024DfHSbTMsZVXBFst2Q6RQY8RVUf3QBeQ==",
+          "requires": {
+            "@turf/clone": "^5.1.5",
+            "@turf/distance": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5",
+            "@turf/meta": "^5.1.5",
+            "density-clustering": "1.3.0"
+          }
+        },
+        "@turf/clusters-kmeans": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/clusters-kmeans/-/clusters-kmeans-5.1.5.tgz",
+          "integrity": "sha512-W6raiv9+fRgmJxCvKrpSacbLXzh7beZUk0A1pjF82Fv3CFTrXAJbgAyIbdlmgXezYSXhOT5NMUugnbkUy2oBZw==",
+          "requires": {
+            "@turf/clone": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5",
+            "@turf/meta": "^5.1.5",
+            "skmeans": "0.9.7"
+          }
+        },
+        "@turf/collect": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/collect/-/collect-5.1.5.tgz",
+          "integrity": "sha512-voFWu6EGPcNuIbAp43yvGf2Ip4/q8TTeWhOSJ2yDEHgOfbAwrNUwUJCclEjcUVsnc7ypKNrFn3/8bmR9tI0NQg==",
+          "requires": {
+            "@turf/bbox": "^5.1.5",
+            "@turf/boolean-point-in-polygon": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "rbush": "^2.0.1"
+          }
+        },
+        "@turf/combine": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/combine/-/combine-5.1.5.tgz",
+          "integrity": "sha512-/RqmfCvduHquINVyNmzKOcZtZjfaEHMhghgmj8MYnzepN3ro+E2QXoaQGGrQ7nChAvGgWPAvN8EveVSc1MvzPg==",
+          "requires": {
+            "@turf/helpers": "^5.1.5",
+            "@turf/meta": "^5.1.5"
+          }
+        },
+        "@turf/concave": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/concave/-/concave-5.1.5.tgz",
+          "integrity": "sha512-NvR5vmAunmgjEPjNzmvjLRvPcj7C6WuqCf+vu/aqyc4h2c1B/x399bDsSM64iFT+PYesFuoS1ZhJHWivXG8Y5g==",
+          "requires": {
+            "@turf/clone": "^5.1.5",
+            "@turf/distance": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5",
+            "@turf/meta": "^5.1.5",
+            "@turf/tin": "^5.1.5",
+            "topojson-client": "3.x",
+            "topojson-server": "3.x"
+          }
+        },
+        "@turf/convex": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/convex/-/convex-5.1.5.tgz",
+          "integrity": "sha512-ZEk4kIAoYR/mjO3C8rMe2StgmwhdwmbxVvNxg3udeahe2m0ZzbfkRC4HiJAaBgfR4TLJUAEewynESReTPwASBQ==",
+          "requires": {
+            "@turf/helpers": "^5.1.5",
+            "@turf/meta": "^5.1.5",
+            "concaveman": "*"
+          }
+        },
+        "@turf/destination": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/destination/-/destination-5.1.5.tgz",
+          "integrity": "sha512-EWwZnd4wxUO9d8UWzJt88jQlFf6W/6SE1930MMzzIR9o+RfqhrS/BL1eUDrg5I5drsymf6PZsK0j/V0q6jqkFQ==",
+          "requires": {
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5"
+          }
+        },
+        "@turf/difference": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/difference/-/difference-5.1.5.tgz",
+          "integrity": "sha512-hIjiUHS8WiDfnmADQrhh6QcXWc3zNtjIpPQ5g/2NZ3k1mjnOdmGBVObkSJG4WEUNqyj3PKlsZ8W9xnSu+lLF1Q==",
+          "requires": {
+            "@turf/area": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5",
+            "@turf/meta": "^5.1.5",
+            "turf-jsts": "*"
+          }
+        },
+        "@turf/dissolve": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/dissolve/-/dissolve-5.1.5.tgz",
+          "integrity": "sha512-YcQgyp7pvhyZHCmbqqItVH6vHs43R9N0jzP/LnAG03oMiY4wves/BO1du6VDDbnJSXeRKf1afmY9tRGKYrm9ag==",
+          "requires": {
+            "@turf/boolean-overlap": "^5.1.5",
+            "@turf/clone": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5",
+            "@turf/line-intersect": "^5.1.5",
+            "@turf/meta": "^5.1.5",
+            "@turf/union": "^5.1.5",
+            "geojson-rbush": "2.1.0",
+            "get-closest": "*"
+          }
+        },
+        "@turf/distance": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/distance/-/distance-5.1.5.tgz",
+          "integrity": "sha512-sYCAgYZ2MjNKMtx17EijHlK9qHwpA0MuuQWbR4P30LTCl52UlG/reBfV899wKyF3HuDL9ux78IbILwOfeQ4zgA==",
+          "requires": {
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5"
+          }
+        },
+        "@turf/ellipse": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/ellipse/-/ellipse-5.1.5.tgz",
+          "integrity": "sha512-oVTzEyDOi3d9isgB7Ah+YiOoUKB1eHMtMDXVl1oT+vC/T+6KR2aq+HjjbF11A0cjuh3VhjSWUZaS+2TYY0pu0w==",
+          "requires": {
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5",
+            "@turf/rhumb-destination": "^5.1.5",
+            "@turf/transform-rotate": "^5.1.5"
+          }
+        },
+        "@turf/envelope": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/envelope/-/envelope-5.1.5.tgz",
+          "integrity": "sha512-Mxl5A2euAxq3RZVN65/MVyaO91kzGU8MJXfegPdep6SN4bONDadEp0olwW5qSRf2U3cJ8Jppl089X6AeifD3IA==",
+          "requires": {
+            "@turf/bbox": "^5.1.5",
+            "@turf/bbox-polygon": "^5.1.5",
+            "@turf/helpers": "^5.1.5"
+          }
+        },
+        "@turf/explode": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/explode/-/explode-5.1.5.tgz",
+          "integrity": "sha512-v/hC9DB9RKRW9/ZjnKoQelIp08JNa5wew0889465s//tfgY8+JEGkSGMag2L2NnVARWmzI/vlLgMK36qwkyDIA==",
+          "requires": {
+            "@turf/helpers": "^5.1.5",
+            "@turf/meta": "^5.1.5"
+          }
+        },
+        "@turf/flatten": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/flatten/-/flatten-5.1.5.tgz",
+          "integrity": "sha512-aagHz5tjHmOtb8eMb5fd10+HJwdlhkhsPql1vRXQNnpv0Q9xL/4SsbvXZ6lPqkRAjiZuy087mvaz+ERml76/jg==",
+          "requires": {
+            "@turf/helpers": "^5.1.5",
+            "@turf/meta": "^5.1.5"
+          }
+        },
+        "@turf/flip": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/flip/-/flip-5.1.5.tgz",
+          "integrity": "sha512-7+IYM3QQAkV4co3wjEmM726/OkXqUCCHWWyIqrI9hiK+LR628qkoqP1hk6rQ4vZJrAYuvSlK+FZnr24OtgY0cw==",
+          "requires": {
+            "@turf/clone": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/meta": "^5.1.5"
+          }
+        },
+        "@turf/great-circle": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/great-circle/-/great-circle-5.1.5.tgz",
+          "integrity": "sha512-k6FWwlt+YCQoD5VS1NybQjriNL7apYHO+tm2HbIFQ85blPUX4IyLppHIFevfD/k+K2bJqhFCze8JNVMBwdrzVw==",
+          "requires": {
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5"
+          }
+        },
+        "@turf/helpers": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-5.1.5.tgz",
+          "integrity": "sha512-/lF+JR+qNDHZ8bF9d+Cp58nxtZWJ3sqFe6n3u3Vpj+/0cqkjk4nXKYBSY0azm+GIYB5mWKxUXvuP/m0ZnKj1bw=="
+        },
+        "@turf/hex-grid": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/hex-grid/-/hex-grid-5.1.5.tgz",
+          "integrity": "sha512-rwDL+DlUyxDNL1aVHIKKCmrt1131ZULF3irExYIO/um6/SwRzsBw+522/RcxD/mg/Shtrpozb6bz8aJJ/3RXHA==",
+          "requires": {
+            "@turf/distance": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/intersect": "^5.1.5",
+            "@turf/invariant": "^5.1.5"
+          }
+        },
+        "@turf/interpolate": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/interpolate/-/interpolate-5.1.5.tgz",
+          "integrity": "sha512-LfmvtIUWc3NVkqPkX6j3CAIjF7y1LAZqfDd+2Ii+0fN7XOOGMWcb1uiTTAb8zDQjhTsygcUYgaz6mMYDCWYKPg==",
+          "requires": {
+            "@turf/bbox": "^5.1.5",
+            "@turf/centroid": "^5.1.5",
+            "@turf/clone": "^5.1.5",
+            "@turf/distance": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/hex-grid": "^5.1.5",
+            "@turf/invariant": "^5.1.5",
+            "@turf/meta": "^5.1.5",
+            "@turf/point-grid": "^5.1.5",
+            "@turf/square-grid": "^5.1.5",
+            "@turf/triangle-grid": "^5.1.5"
+          }
+        },
+        "@turf/intersect": {
+          "version": "5.1.6",
+          "resolved": "https://registry.npmjs.org/@turf/intersect/-/intersect-5.1.6.tgz",
+          "integrity": "sha512-KXyNv/GXdoGAOy03qZF53rgtXC2tNhF/4jLwTKiVRrBQH6kcEpipGStdJ+QkYIlarQPa8f7I9UlVAB19et4MfQ==",
+          "requires": {
+            "@turf/clean-coords": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5",
+            "@turf/truncate": "^5.1.5",
+            "turf-jsts": "*"
+          }
+        },
+        "@turf/invariant": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-5.1.5.tgz",
+          "integrity": "sha512-4elbC8GVQ8XxrnWLWpFFXTK3qnzIYzIVtSkJrY9eefA8WNZzwcwT3WGFY3xte4BB48o5oEjihjoJharWRis78w==",
+          "requires": {
+            "@turf/helpers": "^5.1.5"
+          }
+        },
+        "@turf/isobands": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/isobands/-/isobands-5.1.5.tgz",
+          "integrity": "sha512-0n3NPfDYQyqjOch00I4hVCCqjKn9Sm+a8qlWOKbkuhmGa9dCDzsu2bZL0ahT+LjwlS4c8/owQXqe6KE2GWqT1Q==",
+          "requires": {
+            "@turf/area": "^5.1.5",
+            "@turf/bbox": "^5.1.5",
+            "@turf/boolean-point-in-polygon": "^5.1.5",
+            "@turf/explode": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5",
+            "@turf/meta": "^5.1.5"
+          }
+        },
+        "@turf/isolines": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/isolines/-/isolines-5.1.5.tgz",
+          "integrity": "sha512-Ehn5pJmiq4hAn2+2jPB2rLt3iF8DDp8zciw9z2pAt5IGVRU/K+x3z4aYG5ra5vbFB/E4G3aHr/X4QPIb9LCJtA==",
+          "requires": {
+            "@turf/bbox": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5",
+            "@turf/meta": "^5.1.5"
+          }
+        },
+        "@turf/kinks": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/kinks/-/kinks-5.1.5.tgz",
+          "integrity": "sha512-G38sC8/+MYqQpVocT3XahhV42cqEAVJAZwUND9YOfKJZfjUn7FKmWhPURs5py95me48UuI0C0jLLAMzBkUc2nQ==",
+          "requires": {
+            "@turf/helpers": "^5.1.5"
+          }
+        },
+        "@turf/length": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/length/-/length-5.1.5.tgz",
+          "integrity": "sha512-0ryx68h512wCoNfwyksLdabxEfwkGNTPg61/QiY+QfGFUOUNhHbP+QimViFpwF5hyX7qmroaSHVclLUqyLGRbg==",
+          "requires": {
+            "@turf/distance": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/meta": "^5.1.5"
+          }
+        },
+        "@turf/line-arc": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/line-arc/-/line-arc-5.1.5.tgz",
+          "integrity": "sha512-Kz5RX/qRIHVrGNqF3BRlD3ACuuCr0G5lpaVyPjNvN+vA7Q4bEDyWIYeqm3DdTn7X2MXitpTNgr2uvX4WoUy4yA==",
+          "requires": {
+            "@turf/circle": "^5.1.5",
+            "@turf/destination": "^5.1.5",
+            "@turf/helpers": "^5.1.5"
+          }
+        },
+        "@turf/line-chunk": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/line-chunk/-/line-chunk-5.1.5.tgz",
+          "integrity": "sha512-mKvTUMahnb3EsYUMI8tQmygsliQkgQ1FZAY915zoTrm+WV246loa+84+h7i5d8W2O8gGJWuY7jQTpM7toTeL5w==",
+          "requires": {
+            "@turf/helpers": "^5.1.5",
+            "@turf/length": "^5.1.5",
+            "@turf/line-slice-along": "^5.1.5",
+            "@turf/meta": "^5.1.5"
+          }
+        },
+        "@turf/line-intersect": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/line-intersect/-/line-intersect-5.1.5.tgz",
+          "integrity": "sha512-9DajJbHhJauLI2qVMnqZ7SeFsinFroVICOSUheODk7j5teuwNABuZ2Z6WmKATzEsPkEJ1iVykqB+F9vGMVKB6g==",
+          "requires": {
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5",
+            "@turf/line-segment": "^5.1.5",
+            "@turf/meta": "^5.1.5",
+            "geojson-rbush": "2.1.0"
+          }
+        },
+        "@turf/line-offset": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/line-offset/-/line-offset-5.1.5.tgz",
+          "integrity": "sha512-VccGDgFfBSiCTqrHdQgxD7Rs9lnJmDOJ5gqQRculKPsCNUyRFMYIZud7l2dTs83g66evfOwkZCrTxtSoBY3Jxg==",
+          "requires": {
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5",
+            "@turf/meta": "^5.1.5"
+          }
+        },
+        "@turf/line-overlap": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/line-overlap/-/line-overlap-5.1.5.tgz",
+          "integrity": "sha512-hMz3XARXEbfGwLF9WXyErqQjzhZYMKvGQwlPGOoth+2o9Uga9mfWfevduJvozJAE1MKxtFttMjIXMzcShW3O8A==",
+          "requires": {
+            "@turf/boolean-point-on-line": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5",
+            "@turf/line-segment": "^5.1.5",
+            "@turf/meta": "^5.1.5",
+            "@turf/nearest-point-on-line": "^5.1.5",
+            "geojson-rbush": "2.1.0"
+          }
+        },
+        "@turf/line-segment": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/line-segment/-/line-segment-5.1.5.tgz",
+          "integrity": "sha512-wIrRtWuLuLXhnSkqdVG1SDayTU0/CmZf+a+BBhEf0vFIsAedJnrY3a2cbCEvtfuk6ZsAbhOi7/kYiaR/F+rEzg==",
+          "requires": {
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5",
+            "@turf/meta": "^5.1.5"
+          }
+        },
+        "@turf/line-slice": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/line-slice/-/line-slice-5.1.5.tgz",
+          "integrity": "sha512-Fo+CuD+fj6T702BofHO+rgiXUgzCk0iO2JqMPtttMtgzfKkVTUOQoauMNS1LNNaG/7n/TfKGh5gRCEDRNaNwYA==",
+          "requires": {
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5",
+            "@turf/nearest-point-on-line": "^5.1.5"
+          }
+        },
+        "@turf/line-slice-along": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/line-slice-along/-/line-slice-along-5.1.5.tgz",
+          "integrity": "sha512-yKvSDtULztLtlPIMowm9l8pS6XLAEpCPmrARZA0sIWFX8XrcSzISBaXZbiMMzg3nxQJMXfGIgWDk10B7+J8Tqw==",
+          "requires": {
+            "@turf/bearing": "^5.1.5",
+            "@turf/destination": "^5.1.5",
+            "@turf/distance": "^5.1.5",
+            "@turf/helpers": "^5.1.5"
+          }
+        },
+        "@turf/line-split": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/line-split/-/line-split-5.1.5.tgz",
+          "integrity": "sha512-gtUUBwZL3hcSu5MpqHTl68hgAJBNHcr1APDj8E5o6iX5xFX+wvl4ohQXyMs5HOATCI8Iy83wLuggcY6maNw7LQ==",
+          "requires": {
+            "@turf/bbox": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5",
+            "@turf/line-intersect": "^5.1.5",
+            "@turf/line-segment": "^5.1.5",
+            "@turf/meta": "^5.1.5",
+            "@turf/nearest-point-on-line": "^5.1.5",
+            "@turf/square": "^5.1.5",
+            "@turf/truncate": "^5.1.5",
+            "geojson-rbush": "2.1.0"
+          }
+        },
+        "@turf/line-to-polygon": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/line-to-polygon/-/line-to-polygon-5.1.5.tgz",
+          "integrity": "sha512-hGiDAPd6j986kZZLDgEAkVD7O6DmIqHQliBedspoKperPJOUJJzdzSnF6OAWSsxY+j8fWtQnIo5TTqdO/KfamA==",
+          "requires": {
+            "@turf/bbox": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5"
+          }
+        },
+        "@turf/mask": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/mask/-/mask-5.1.5.tgz",
+          "integrity": "sha512-2eOuxA3ammZAGsjlsy/H7IpeJxjl3hrgkcKM6kTKRJGft4QyKwCxqQP7RN5j0zIYvAurgs9JOLe/dpd5sE5HXQ==",
+          "requires": {
+            "@turf/bbox": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/meta": "^5.1.5",
+            "@turf/union": "^5.1.5",
+            "rbush": "^2.0.1"
+          }
+        },
+        "@turf/meta": {
+          "version": "5.1.6",
+          "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-5.1.6.tgz",
+          "integrity": "sha512-lv+6LCgoc3LVitQZ4TScN/8a/fcctq8bIoxBTMJVq4aU8xoHeY1851Dq8MCU37EzbH33utkx8/jENaQP+aeElg==",
+          "requires": {
+            "@turf/helpers": "^5.1.5"
+          }
+        },
+        "@turf/midpoint": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/midpoint/-/midpoint-5.1.5.tgz",
+          "integrity": "sha512-0pDQAKHyK/zxlvUx3XNxwvqftf4sV32QxnHfqSs4AXaODUGUbPhzAD7aXgDScBeUOVLwpAzFRQfitUvUMTGC6A==",
+          "requires": {
+            "@turf/bearing": "^5.1.5",
+            "@turf/destination": "^5.1.5",
+            "@turf/distance": "^5.1.5",
+            "@turf/helpers": "^5.1.5"
+          }
+        },
+        "@turf/nearest-point": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/nearest-point/-/nearest-point-5.1.5.tgz",
+          "integrity": "sha512-tZQXI7OE7keNKK4OvYOJ5gervCEuu2pJ6psu59QW9yhe2Di3Gl+HAdLvVa6RZ8s5Fndr3u0JWKsmxve3fCxc9g==",
+          "requires": {
+            "@turf/clone": "^5.1.5",
+            "@turf/distance": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/meta": "^5.1.5"
+          }
+        },
+        "@turf/nearest-point-on-line": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/nearest-point-on-line/-/nearest-point-on-line-5.1.5.tgz",
+          "integrity": "sha512-qT7BLTwToo8cq0oNoz921oLlRPJamyRg/rZgll+kNBadyDPmJI4W66riHcpM9RQcAJ6TPvDveIIBeGJH7iG88w==",
+          "requires": {
+            "@turf/bearing": "^5.1.5",
+            "@turf/destination": "^5.1.5",
+            "@turf/distance": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5",
+            "@turf/line-intersect": "^5.1.5",
+            "@turf/meta": "^5.1.5"
+          }
+        },
+        "@turf/nearest-point-to-line": {
+          "version": "5.1.6",
+          "resolved": "https://registry.npmjs.org/@turf/nearest-point-to-line/-/nearest-point-to-line-5.1.6.tgz",
+          "integrity": "sha512-ZSvDIEiHhifn/vNwLXZI/E8xmEz5yBPqfUR7BVHRZrB1cP7jLhKZvkbidjG//uW8Fr1Ulc+PFOXczLspIcx/lw==",
+          "requires": {
+            "@turf/helpers": "6.x",
+            "@turf/invariant": "6.x",
+            "@turf/meta": "6.x",
+            "@turf/point-to-line-distance": "^5.1.5",
+            "object-assign": "*"
+          },
+          "dependencies": {
+            "@turf/helpers": {
+              "version": "6.5.0",
+              "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.5.0.tgz",
+              "integrity": "sha512-VbI1dV5bLFzohYYdgqwikdMVpe7pJ9X3E+dlr425wa2/sMJqYDhTO++ec38/pcPvPE6oD9WEEeU3Xu3gza+VPw=="
+            },
+            "@turf/invariant": {
+              "version": "6.5.0",
+              "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-6.5.0.tgz",
+              "integrity": "sha512-Wv8PRNCtPD31UVbdJE/KVAWKe7l6US+lJItRR/HOEW3eh+U/JwRCSUl/KZ7bmjM/C+zLNoreM2TU6OoLACs4eg==",
+              "requires": {
+                "@turf/helpers": "^6.5.0"
+              }
+            },
+            "@turf/meta": {
+              "version": "6.5.0",
+              "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-6.5.0.tgz",
+              "integrity": "sha512-RrArvtsV0vdsCBegoBtOalgdSOfkBrTJ07VkpiCnq/491W67hnMWmDu7e6Ztw0C3WldRYTXkg3SumfdzZxLBHA==",
+              "requires": {
+                "@turf/helpers": "^6.5.0"
+              }
+            }
+          }
+        },
+        "@turf/planepoint": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/planepoint/-/planepoint-5.1.5.tgz",
+          "integrity": "sha512-+Tp+SQ0Db2tqwLbxfXJPysT9IxcOHSMIin2dJb/j3Qn5+g0LRus6rczZl6dWNAIjqBPMawj/V/dZhMu6Q9O9wA==",
+          "requires": {
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5"
+          }
+        },
+        "@turf/point-grid": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/point-grid/-/point-grid-5.1.5.tgz",
+          "integrity": "sha512-4ibozguP9YJ297Q7i9e8/ypGSycvt1re2jrPXTxeuZ4/L/NE5B1nOBLG+tw121nMjD+S+v2RWOtqD+FZ3Ga+ew==",
+          "requires": {
+            "@turf/boolean-within": "^5.1.5",
+            "@turf/distance": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5"
+          }
+        },
+        "@turf/point-on-feature": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/point-on-feature/-/point-on-feature-5.1.5.tgz",
+          "integrity": "sha512-NTcpe5xZjybRh0aTL+7td1cm0s49GGbAt5u8Cdec4W9ix2PsehRcLUbmQIQsODN2kiVyUSpnhECIpsyN5MjX7A==",
+          "requires": {
+            "@turf/boolean-point-in-polygon": "^5.1.5",
+            "@turf/center": "^5.1.5",
+            "@turf/explode": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/nearest-point": "^5.1.5"
+          }
+        },
+        "@turf/point-to-line-distance": {
+          "version": "5.1.6",
+          "resolved": "https://registry.npmjs.org/@turf/point-to-line-distance/-/point-to-line-distance-5.1.6.tgz",
+          "integrity": "sha512-PE3hiTeeDEi4ZLPtI8XAzFYW9nHo1EVsZGm/4ZVV8jo39d3X1oLVHxY3e1PkCmWwRapXy4QLqvnTQ7nU4wspNw==",
+          "requires": {
+            "@turf/bearing": "6.x",
+            "@turf/distance": "6.x",
+            "@turf/helpers": "6.x",
+            "@turf/invariant": "6.x",
+            "@turf/meta": "6.x",
+            "@turf/projection": "6.x",
+            "@turf/rhumb-bearing": "6.x",
+            "@turf/rhumb-distance": "6.x"
+          },
+          "dependencies": {
+            "@turf/bearing": {
+              "version": "6.5.0",
+              "resolved": "https://registry.npmjs.org/@turf/bearing/-/bearing-6.5.0.tgz",
+              "integrity": "sha512-dxINYhIEMzgDOztyMZc20I7ssYVNEpSv04VbMo5YPQsqa80KO3TFvbuCahMsCAW5z8Tncc8dwBlEFrmRjJG33A==",
+              "requires": {
+                "@turf/helpers": "^6.5.0",
+                "@turf/invariant": "^6.5.0"
+              }
+            },
+            "@turf/distance": {
+              "version": "6.5.0",
+              "resolved": "https://registry.npmjs.org/@turf/distance/-/distance-6.5.0.tgz",
+              "integrity": "sha512-xzykSLfoURec5qvQJcfifw/1mJa+5UwByZZ5TZ8iaqjGYN0vomhV9aiSLeYdUGtYRESZ+DYC/OzY+4RclZYgMg==",
+              "requires": {
+                "@turf/helpers": "^6.5.0",
+                "@turf/invariant": "^6.5.0"
+              }
+            },
+            "@turf/helpers": {
+              "version": "6.5.0",
+              "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.5.0.tgz",
+              "integrity": "sha512-VbI1dV5bLFzohYYdgqwikdMVpe7pJ9X3E+dlr425wa2/sMJqYDhTO++ec38/pcPvPE6oD9WEEeU3Xu3gza+VPw=="
+            },
+            "@turf/invariant": {
+              "version": "6.5.0",
+              "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-6.5.0.tgz",
+              "integrity": "sha512-Wv8PRNCtPD31UVbdJE/KVAWKe7l6US+lJItRR/HOEW3eh+U/JwRCSUl/KZ7bmjM/C+zLNoreM2TU6OoLACs4eg==",
+              "requires": {
+                "@turf/helpers": "^6.5.0"
+              }
+            },
+            "@turf/meta": {
+              "version": "6.5.0",
+              "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-6.5.0.tgz",
+              "integrity": "sha512-RrArvtsV0vdsCBegoBtOalgdSOfkBrTJ07VkpiCnq/491W67hnMWmDu7e6Ztw0C3WldRYTXkg3SumfdzZxLBHA==",
+              "requires": {
+                "@turf/helpers": "^6.5.0"
+              }
+            }
+          }
+        },
+        "@turf/points-within-polygon": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/points-within-polygon/-/points-within-polygon-5.1.5.tgz",
+          "integrity": "sha512-nexe2AHVOY8wEBvs+CYSOp10NyOCkyZ1gkhIfsx0mzU8LPYBxD9ctjlKveheKh4AAldLcFupd/gSCBTKF1JS7A==",
+          "requires": {
+            "@turf/boolean-point-in-polygon": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/meta": "^5.1.5"
+          }
+        },
+        "@turf/polygon-tangents": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/polygon-tangents/-/polygon-tangents-5.1.5.tgz",
+          "integrity": "sha512-uoZfKvFhl6rf0+CDWucru9fZ4mJB5Nsg37TS/7emrzjoVxXyOdxc/s1HFCjcKflMue7MjU/gT6AitJyrvdztDg==",
+          "requires": {
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5"
+          }
+        },
+        "@turf/polygon-to-line": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/polygon-to-line/-/polygon-to-line-5.1.5.tgz",
+          "integrity": "sha512-kVo0owPqyccy5+qZGvaxGvMsYkgueKE2OOgX2UV/HyrXF3uI3TomK1txjApqeFsLvwuSANxesvVbYLrYiIwvGw==",
+          "requires": {
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5"
+          }
+        },
+        "@turf/polygonize": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/polygonize/-/polygonize-5.1.5.tgz",
+          "integrity": "sha512-qzhtuzoOhldqZHm+ZPsWAs9nDpnkcDfsr+I0twmBF+wjAmo0HKiy9++sRQ4kEePpdwbMpF07D/NdZqYdmOJkGQ==",
+          "requires": {
+            "@turf/boolean-point-in-polygon": "^5.1.5",
+            "@turf/envelope": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5",
+            "@turf/meta": "^5.1.5"
+          }
+        },
+        "@turf/random": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/random/-/random-5.1.5.tgz",
+          "integrity": "sha512-oitpBwEb6YXqoUkIAOVMK+vrTPxUi2rqITmtTa/FBHr6J8TDwMWq6bufE3Gmgjxsss50O2ITJunOksxrouWGDQ==",
+          "requires": {
+            "@turf/helpers": "^5.1.5"
+          }
+        },
+        "@turf/rewind": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/rewind/-/rewind-5.1.5.tgz",
+          "integrity": "sha512-Gdem7JXNu+G4hMllQHXRFRihJl3+pNl7qY+l4qhQFxq+hiU1cQoVFnyoleIqWKIrdK/i2YubaSwc3SCM7N5mMw==",
+          "requires": {
+            "@turf/boolean-clockwise": "^5.1.5",
+            "@turf/clone": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5",
+            "@turf/meta": "^5.1.5"
+          }
+        },
+        "@turf/rhumb-destination": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/rhumb-destination/-/rhumb-destination-5.1.5.tgz",
+          "integrity": "sha512-FdDUCSRfRAfsRmUaWjc76Wk32QYFJ6ckmSt6Ls6nEczO6eg/RgH1atF8CIYwR5ifl0Sk1rQzKiOSbpCyvVwQtw==",
+          "requires": {
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5"
+          }
+        },
+        "@turf/sample": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/sample/-/sample-5.1.5.tgz",
+          "integrity": "sha512-EJE8yx+5x7rXejTzwBdOKpvT4tOCS0jwYJfycyTVDuLUSh2rETeYdjy7EeJbofnxm9CRPXqWQMPWIBKWxNTjow==",
+          "requires": {
+            "@turf/helpers": "^5.1.5"
+          }
+        },
+        "@turf/sector": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/sector/-/sector-5.1.5.tgz",
+          "integrity": "sha512-dnWVifL3xWTqPPs8mfbbV9muDimNJtxRk4ogrkOLEDQ9ZZ1ALQMtQdYrg7kI3iC+L+LscV37tl+E8bayWyX8YA==",
+          "requires": {
+            "@turf/circle": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5",
+            "@turf/line-arc": "^5.1.5",
+            "@turf/meta": "^5.1.5"
+          }
+        },
+        "@turf/shortest-path": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/shortest-path/-/shortest-path-5.1.5.tgz",
+          "integrity": "sha512-ZGC8kSBj02GKWiI56Z5FNdrZ+fS0xyeOUNrPJWzudAlrv9wKGaRuWoIVRLGBu0j0OuO1HCwggic2c6WV/AhP0A==",
+          "requires": {
+            "@turf/bbox": "^5.1.5",
+            "@turf/bbox-polygon": "^5.1.5",
+            "@turf/boolean-point-in-polygon": "^5.1.5",
+            "@turf/clean-coords": "^5.1.5",
+            "@turf/distance": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5",
+            "@turf/meta": "^5.1.5",
+            "@turf/transform-scale": "^5.1.5"
+          }
+        },
+        "@turf/simplify": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/simplify/-/simplify-5.1.5.tgz",
+          "integrity": "sha512-IuBXEYdGSxbDOK3v949ajaPvs6NhjhTCTbKA6mSGuVbwGS7gzAuRiPSG4K/MvCVuQy3PKpkPcUGD+Uvt2Ov2PQ==",
+          "requires": {
+            "@turf/clean-coords": "^5.1.5",
+            "@turf/clone": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/meta": "^5.1.5"
+          }
+        },
+        "@turf/square": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/square/-/square-5.1.5.tgz",
+          "integrity": "sha512-GgP2le9ksoW6vsVef5wFkjmWQiLPTJvcjGXqmoGWT4oMwDpvTJVQ91RBLs8qQbI4KACCQevz94N69klk3ah30Q==",
+          "requires": {
+            "@turf/distance": "^5.1.5",
+            "@turf/helpers": "^5.1.5"
+          }
+        },
+        "@turf/square-grid": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/square-grid/-/square-grid-5.1.5.tgz",
+          "integrity": "sha512-/pusEL4FmOwNWLcZfIXUyqUe0fOdkfaLO4wLhDlg/ZL1jWr/wZjhVlMU0tQ27kVN6dJTvlzNc9e0JWNw6yt2eQ==",
+          "requires": {
+            "@turf/boolean-contains": "^5.1.5",
+            "@turf/boolean-overlap": "^5.1.5",
+            "@turf/distance": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/intersect": "^5.1.5",
+            "@turf/invariant": "^5.1.5"
+          }
+        },
+        "@turf/standard-deviational-ellipse": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/standard-deviational-ellipse/-/standard-deviational-ellipse-5.1.5.tgz",
+          "integrity": "sha512-GOaxGKeeJAXV1H3Zz2fjQ5XeSbMKz1OkFRlTDBUipiAawe/9qTCF55L87I2ZPnO80B5BaaIT+AN2n0lMcAklzA==",
+          "requires": {
+            "@turf/center-mean": "^5.1.5",
+            "@turf/ellipse": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5",
+            "@turf/meta": "^5.1.5",
+            "@turf/points-within-polygon": "^5.1.5"
+          }
+        },
+        "@turf/tag": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/tag/-/tag-5.1.5.tgz",
+          "integrity": "sha512-XI3QFpva6tEsRnzFe1tJGdAAWlzjnXZPfJ9EKShTxEW8ZgPzm92b2odjiSAt2KuQusK82ltNfdw5Frlna5xGYQ==",
+          "requires": {
+            "@turf/boolean-point-in-polygon": "^5.1.5",
+            "@turf/clone": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/meta": "^5.1.5"
+          }
+        },
+        "@turf/tesselate": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/tesselate/-/tesselate-5.1.5.tgz",
+          "integrity": "sha512-Rs/jAij26bcU4OzvFXkWDase1G3kSwyuuKZPFU0t7OmJu7eQJOR12WOZLGcVxd5oBlklo4xPE4EBQUqpQUsQgg==",
+          "requires": {
+            "@turf/helpers": "^5.1.5",
+            "earcut": "^2.0.0"
+          }
+        },
+        "@turf/tin": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/tin/-/tin-5.1.5.tgz",
+          "integrity": "sha512-lDyCTYKoThBIKmkBxBMupqEpFbvTDAYuZIs8qrWnmux2vntSb8OFGi7ZbGPC6apS2hdVwZZae3YB88Tp+Fg+xw==",
+          "requires": {
+            "@turf/helpers": "^5.1.5"
+          }
+        },
+        "@turf/transform-rotate": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/transform-rotate/-/transform-rotate-5.1.5.tgz",
+          "integrity": "sha512-3QKckeHKPXu5O5vEuT+nkszGDI6aknDD06ePb00+6H2oA7MZj7nj+fVQIJLs41MRb76IyKr4n5NvuKZU6idESA==",
+          "requires": {
+            "@turf/centroid": "^5.1.5",
+            "@turf/clone": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5",
+            "@turf/meta": "^5.1.5",
+            "@turf/rhumb-bearing": "^5.1.5",
+            "@turf/rhumb-destination": "^5.1.5",
+            "@turf/rhumb-distance": "^5.1.5"
+          },
+          "dependencies": {
+            "@turf/rhumb-bearing": {
+              "version": "5.1.5",
+              "resolved": "https://registry.npmjs.org/@turf/rhumb-bearing/-/rhumb-bearing-5.1.5.tgz",
+              "integrity": "sha512-zXTl2khjwf7mx2D1uPo5vgpGgP4sM2VrKDbJNKyulPu4TO4ELt8x7FsKyCBlRTzzQf284t/xnNcZOfUbkkd70g==",
+              "requires": {
+                "@turf/helpers": "^5.1.5",
+                "@turf/invariant": "^5.1.5"
+              }
+            },
+            "@turf/rhumb-distance": {
+              "version": "5.1.5",
+              "resolved": "https://registry.npmjs.org/@turf/rhumb-distance/-/rhumb-distance-5.1.5.tgz",
+              "integrity": "sha512-AGA/ky5/BJJZtzQqafy2GvJfcUXSzCCrPFp8sDRPSKBoUN4gMBHN15ijDWYYLFoWFFj0urcauVx7chQlHZ/Qfw==",
+              "requires": {
+                "@turf/helpers": "^5.1.5",
+                "@turf/invariant": "^5.1.5"
+              }
+            }
+          }
+        },
+        "@turf/transform-scale": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/transform-scale/-/transform-scale-5.1.5.tgz",
+          "integrity": "sha512-t1fCZX29ONA7DJiqCKA4YZy0+hCzhppWNOZhglBUv9vKHsWCFYZDUKfFInciaypUInsZyvm8eKxxixBVPdPGsw==",
+          "requires": {
+            "@turf/bbox": "^5.1.5",
+            "@turf/center": "^5.1.5",
+            "@turf/centroid": "^5.1.5",
+            "@turf/clone": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5",
+            "@turf/meta": "^5.1.5",
+            "@turf/rhumb-bearing": "^5.1.5",
+            "@turf/rhumb-destination": "^5.1.5",
+            "@turf/rhumb-distance": "^5.1.5"
+          },
+          "dependencies": {
+            "@turf/rhumb-bearing": {
+              "version": "5.1.5",
+              "resolved": "https://registry.npmjs.org/@turf/rhumb-bearing/-/rhumb-bearing-5.1.5.tgz",
+              "integrity": "sha512-zXTl2khjwf7mx2D1uPo5vgpGgP4sM2VrKDbJNKyulPu4TO4ELt8x7FsKyCBlRTzzQf284t/xnNcZOfUbkkd70g==",
+              "requires": {
+                "@turf/helpers": "^5.1.5",
+                "@turf/invariant": "^5.1.5"
+              }
+            },
+            "@turf/rhumb-distance": {
+              "version": "5.1.5",
+              "resolved": "https://registry.npmjs.org/@turf/rhumb-distance/-/rhumb-distance-5.1.5.tgz",
+              "integrity": "sha512-AGA/ky5/BJJZtzQqafy2GvJfcUXSzCCrPFp8sDRPSKBoUN4gMBHN15ijDWYYLFoWFFj0urcauVx7chQlHZ/Qfw==",
+              "requires": {
+                "@turf/helpers": "^5.1.5",
+                "@turf/invariant": "^5.1.5"
+              }
+            }
+          }
+        },
+        "@turf/transform-translate": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/transform-translate/-/transform-translate-5.1.5.tgz",
+          "integrity": "sha512-GdLFp7I7198oRQt311B8EjiqHupndeMSQ3Zclzki5L/niUrb1ptOIpo+mxSidSy03m+1Q5ylWlENroI1WBcQ3Q==",
+          "requires": {
+            "@turf/clone": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5",
+            "@turf/meta": "^5.1.5",
+            "@turf/rhumb-destination": "^5.1.5"
+          }
+        },
+        "@turf/triangle-grid": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/triangle-grid/-/triangle-grid-5.1.5.tgz",
+          "integrity": "sha512-jmCRcynI80xsVqd+0rv0YxP6mvZn4BAaJv8dwthg2T3WfHB9OD+rNUMohMuUY8HmI0zRT3s/Ypdy2Cdri9u/tw==",
+          "requires": {
+            "@turf/distance": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/intersect": "^5.1.5",
+            "@turf/invariant": "^5.1.5"
+          }
+        },
+        "@turf/truncate": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/truncate/-/truncate-5.1.5.tgz",
+          "integrity": "sha512-WjWGsRE6o1vUqULGb/O7O1eK6B4Eu6R/RBZWnF0rH0Os6WVel6tHktkeJdlKwz9WElIEO12wDIu6uKd54t7DDQ==",
+          "requires": {
+            "@turf/helpers": "^5.1.5",
+            "@turf/meta": "^5.1.5"
+          }
+        },
+        "@turf/turf": {
+          "version": "5.1.6",
+          "resolved": "https://registry.npmjs.org/@turf/turf/-/turf-5.1.6.tgz",
+          "integrity": "sha512-NIjkt5jAbOrom+56ELw9ERZF6qsdf1xAIHyC9/PkDMIOQAxe7FVe2HaqbQ+x88F0q5FaSX4dtpIEf08md6h5/A==",
+          "requires": {
+            "@turf/along": "5.1.x",
+            "@turf/area": "5.1.x",
+            "@turf/bbox": "5.1.x",
+            "@turf/bbox-clip": "5.1.x",
+            "@turf/bbox-polygon": "5.1.x",
+            "@turf/bearing": "5.1.x",
+            "@turf/bezier-spline": "5.1.x",
+            "@turf/boolean-clockwise": "5.1.x",
+            "@turf/boolean-contains": "5.1.x",
+            "@turf/boolean-crosses": "5.1.x",
+            "@turf/boolean-disjoint": "5.1.x",
+            "@turf/boolean-equal": "5.1.x",
+            "@turf/boolean-overlap": "5.1.x",
+            "@turf/boolean-parallel": "5.1.x",
+            "@turf/boolean-point-in-polygon": "5.1.x",
+            "@turf/boolean-point-on-line": "5.1.x",
+            "@turf/boolean-within": "5.1.x",
+            "@turf/buffer": "5.1.x",
+            "@turf/center": "5.1.x",
+            "@turf/center-mean": "5.1.x",
+            "@turf/center-median": "5.1.x",
+            "@turf/center-of-mass": "5.1.x",
+            "@turf/centroid": "5.1.x",
+            "@turf/circle": "5.1.x",
+            "@turf/clean-coords": "5.1.x",
+            "@turf/clone": "5.1.x",
+            "@turf/clusters": "5.1.x",
+            "@turf/clusters-dbscan": "5.1.x",
+            "@turf/clusters-kmeans": "5.1.x",
+            "@turf/collect": "5.1.x",
+            "@turf/combine": "5.1.x",
+            "@turf/concave": "5.1.x",
+            "@turf/convex": "5.1.x",
+            "@turf/destination": "5.1.x",
+            "@turf/difference": "5.1.x",
+            "@turf/dissolve": "5.1.x",
+            "@turf/distance": "5.1.x",
+            "@turf/ellipse": "5.1.x",
+            "@turf/envelope": "5.1.x",
+            "@turf/explode": "5.1.x",
+            "@turf/flatten": "5.1.x",
+            "@turf/flip": "5.1.x",
+            "@turf/great-circle": "5.1.x",
+            "@turf/helpers": "5.1.x",
+            "@turf/hex-grid": "5.1.x",
+            "@turf/interpolate": "5.1.x",
+            "@turf/intersect": "5.1.x",
+            "@turf/invariant": "5.1.x",
+            "@turf/isobands": "5.1.x",
+            "@turf/isolines": "5.1.x",
+            "@turf/kinks": "5.1.x",
+            "@turf/length": "5.1.x",
+            "@turf/line-arc": "5.1.x",
+            "@turf/line-chunk": "5.1.x",
+            "@turf/line-intersect": "5.1.x",
+            "@turf/line-offset": "5.1.x",
+            "@turf/line-overlap": "5.1.x",
+            "@turf/line-segment": "5.1.x",
+            "@turf/line-slice": "5.1.x",
+            "@turf/line-slice-along": "5.1.x",
+            "@turf/line-split": "5.1.x",
+            "@turf/line-to-polygon": "5.1.x",
+            "@turf/mask": "5.1.x",
+            "@turf/meta": "5.1.x",
+            "@turf/midpoint": "5.1.x",
+            "@turf/nearest-point": "5.1.x",
+            "@turf/nearest-point-on-line": "5.1.x",
+            "@turf/nearest-point-to-line": "5.1.x",
+            "@turf/planepoint": "5.1.x",
+            "@turf/point-grid": "5.1.x",
+            "@turf/point-on-feature": "5.1.x",
+            "@turf/point-to-line-distance": "5.1.x",
+            "@turf/points-within-polygon": "5.1.x",
+            "@turf/polygon-tangents": "5.1.x",
+            "@turf/polygon-to-line": "5.1.x",
+            "@turf/polygonize": "5.1.x",
+            "@turf/projection": "5.1.x",
+            "@turf/random": "5.1.x",
+            "@turf/rewind": "5.1.x",
+            "@turf/rhumb-bearing": "5.1.x",
+            "@turf/rhumb-destination": "5.1.x",
+            "@turf/rhumb-distance": "5.1.x",
+            "@turf/sample": "5.1.x",
+            "@turf/sector": "5.1.x",
+            "@turf/shortest-path": "5.1.x",
+            "@turf/simplify": "5.1.x",
+            "@turf/square": "5.1.x",
+            "@turf/square-grid": "5.1.x",
+            "@turf/standard-deviational-ellipse": "5.1.x",
+            "@turf/tag": "5.1.x",
+            "@turf/tesselate": "5.1.x",
+            "@turf/tin": "5.1.x",
+            "@turf/transform-rotate": "5.1.x",
+            "@turf/transform-scale": "5.1.x",
+            "@turf/transform-translate": "5.1.x",
+            "@turf/triangle-grid": "5.1.x",
+            "@turf/truncate": "5.1.x",
+            "@turf/union": "5.1.x",
+            "@turf/unkink-polygon": "5.1.x",
+            "@turf/voronoi": "5.1.x"
+          },
+          "dependencies": {
+            "@turf/projection": {
+              "version": "5.1.5",
+              "resolved": "https://registry.npmjs.org/@turf/projection/-/projection-5.1.5.tgz",
+              "integrity": "sha512-TWKJDFeEKQhI4Ce1+2PuOSDggn4cnMibqyUoCpIW+4KxUC1R88SE3/SYomqzwxMn00O09glHSycPkGD5JzHd8A==",
+              "requires": {
+                "@turf/clone": "^5.1.5",
+                "@turf/helpers": "^5.1.5",
+                "@turf/meta": "^5.1.5"
+              }
+            },
+            "@turf/rhumb-bearing": {
+              "version": "5.1.5",
+              "resolved": "https://registry.npmjs.org/@turf/rhumb-bearing/-/rhumb-bearing-5.1.5.tgz",
+              "integrity": "sha512-zXTl2khjwf7mx2D1uPo5vgpGgP4sM2VrKDbJNKyulPu4TO4ELt8x7FsKyCBlRTzzQf284t/xnNcZOfUbkkd70g==",
+              "requires": {
+                "@turf/helpers": "^5.1.5",
+                "@turf/invariant": "^5.1.5"
+              }
+            },
+            "@turf/rhumb-distance": {
+              "version": "5.1.5",
+              "resolved": "https://registry.npmjs.org/@turf/rhumb-distance/-/rhumb-distance-5.1.5.tgz",
+              "integrity": "sha512-AGA/ky5/BJJZtzQqafy2GvJfcUXSzCCrPFp8sDRPSKBoUN4gMBHN15ijDWYYLFoWFFj0urcauVx7chQlHZ/Qfw==",
+              "requires": {
+                "@turf/helpers": "^5.1.5",
+                "@turf/invariant": "^5.1.5"
+              }
+            }
+          }
+        },
+        "@turf/union": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/union/-/union-5.1.5.tgz",
+          "integrity": "sha512-wBy1ixxC68PpsTeEDebk/EfnbI1Za5dCyY7xFY9NMzrtVEOy0l0lQ5syOsaqY4Ire+dbsDM66p2GGxmefoyIEA==",
+          "requires": {
+            "@turf/helpers": "^5.1.5",
+            "turf-jsts": "*"
+          }
+        },
+        "@turf/unkink-polygon": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/unkink-polygon/-/unkink-polygon-5.1.5.tgz",
+          "integrity": "sha512-lzSrgsfSuyxIc4pkE2qyM2dsHxR992e6oItoZAT8G58A2Ef4qc5gRocmXPWZakGx41fQobegSo7wlo4I49wyHg==",
+          "requires": {
+            "@turf/area": "^5.1.5",
+            "@turf/boolean-point-in-polygon": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/meta": "^5.1.5",
+            "rbush": "^2.0.1"
+          }
+        },
+        "@turf/voronoi": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/voronoi/-/voronoi-5.1.5.tgz",
+          "integrity": "sha512-Ad0HZAyYjOpMIZfDGV+Q+30M9PQHIirTyn32kWyTjEI1O6uhL5NOYjzSha4Sr77xOls3hGzKOj+JET7eDtOvsg==",
+          "requires": {
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5",
+            "d3-voronoi": "1.1.2"
+          }
+        },
+        "geojson-rbush": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/geojson-rbush/-/geojson-rbush-2.1.0.tgz",
+          "integrity": "sha512-9HvLGhmAJBYkYYDdPlCrlfkKGwNW3PapiS0xPekdJLobkZE4rjtduKJXsO7+kUr97SsUlz4VtMcPuSIbjjJaQg==",
+          "requires": {
+            "@turf/helpers": "*",
+            "@turf/meta": "*",
+            "rbush": "*"
+          }
+        },
+        "jszip": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/jszip/-/jszip-2.6.1.tgz",
+          "integrity": "sha512-C4Z++nYQv+CudUkCWUdz+yKVhQiFJjuWSmRJ5Sg3d3/OzcJ6U4ooUYlmE3+rJXrVk89KWQaiJ9mPp/VLQ4D66g==",
+          "requires": {
+            "pako": "~1.0.2"
+          }
+        },
+        "lru-cache": {
+          "version": "2.7.3",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+          "integrity": "sha512-WpibWJ60c3AgAz8a2iYErDrcT2C7OmKnsWhIcHOjkUHFjkXncJhtLxNSqUmxRxRunpb5I8Vprd7aNSd2NtksJQ=="
+        },
+        "pako": {
+          "version": "1.0.11",
+          "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+          "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
+        },
+        "shpjs": {
+          "version": "3.6.3",
+          "resolved": "https://registry.npmjs.org/shpjs/-/shpjs-3.6.3.tgz",
+          "integrity": "sha512-wcR2S3WL/7RnEIm+YO+H/mZR9z9FCV46op+SZt+W5PtPs26Omb9U93f+EPI1DOpNKBuAIrWjHWh0SxlnBahJkg==",
+          "requires": {
+            "jszip": "^2.4.0",
+            "lie": "^3.0.1",
+            "lru-cache": "^2.7.0",
+            "parsedbf": "^1.1.0",
+            "proj4": "^2.1.4"
+          }
+        }
+      }
+    },
+    "geostyler-style": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/geostyler-style/-/geostyler-style-4.0.3.tgz",
+      "integrity": "sha512-51esHVZz86HFoSvKRA/Kfqd2Mytek88zgHSSt8ZZg30o4dqyZuQluxwIjqkSLp5hdvmA0nwCAyqxHy6aMyJ5lQ==",
+      "requires": {
+        "@types/lodash": "^4.14.168",
+        "lodash": "^4.17.21"
+      }
+    },
     "geotiff": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/geotiff/-/geotiff-2.0.5.tgz",
@@ -40902,6 +42719,11 @@
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "dev": true
+    },
+    "get-closest": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/get-closest/-/get-closest-0.0.4.tgz",
+      "integrity": "sha512-oMgZYUtnPMZB6XieXiUADpRIc5kfD+RPfpiYe9aIlEYGIcOx2mTGgKmUkctlLof/ANleypqOJRhQypbrh33DkA=="
     },
     "get-intrinsic": {
       "version": "1.1.1",
@@ -44638,6 +46460,11 @@
       "requires": {
         "immediate": "~3.0.5"
       }
+    },
+    "lineclip": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/lineclip/-/lineclip-1.1.5.tgz",
+      "integrity": "sha512-KlA/wRSjpKl7tS9iRUdlG72oQ7qZ1IlVbVgHwoO10TBR/4gQ86uhKow6nlzMAJJhjCWKto8OeoAzzIzKSmN25A=="
     },
     "lines-and-columns": {
       "version": "1.2.4",
@@ -50855,7 +52682,6 @@
       "version": "6.6.7",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
       "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
-      "dev": true,
       "requires": {
         "tslib": "^1.9.0"
       },
@@ -50863,8 +52689,7 @@
         "tslib": {
           "version": "1.14.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-          "dev": true
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -69,6 +69,7 @@
         "canvas": "^2.9.0",
         "chokidar": "^3.5.3",
         "copy-to-clipboard": "^3.3.1",
+        "copy-webpack-plugin": "^11.0.0",
         "coveralls": "^3.1.1",
         "css-loader": "^6.6.0",
         "enzyme": "^3.11.0",
@@ -6673,6 +6674,45 @@
         "ajv": ">=5.0.0"
       }
     },
+    "node_modules/ajv-formats": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+      "dev": true,
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-formats/node_modules/ajv": {
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+      "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true
+    },
     "node_modules/ajv-keywords": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
@@ -9398,65 +9438,132 @@
       }
     },
     "node_modules/copy-webpack-plugin": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-6.4.1.tgz",
-      "integrity": "sha512-MXyPCjdPVx5iiWyl40Va3JGh27bKzOTNY3NjUTrosD2q7dR/cLD0013uqJ3BpFbUjyONINjb6qI7nDIJujrMbA==",
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-11.0.0.tgz",
+      "integrity": "sha512-fX2MWpamkW0hZxMEg0+mYnA40LTosOSa5TqZ9GYIBzyJa9C3QUaMPSE2xAi/buNr8u89SfD9wHSQVBzrRa/SOQ==",
       "dev": true,
       "dependencies": {
-        "cacache": "^15.0.5",
-        "fast-glob": "^3.2.4",
-        "find-cache-dir": "^3.3.1",
-        "glob-parent": "^5.1.1",
-        "globby": "^11.0.1",
-        "loader-utils": "^2.0.0",
+        "fast-glob": "^3.2.11",
+        "glob-parent": "^6.0.1",
+        "globby": "^13.1.1",
         "normalize-path": "^3.0.0",
-        "p-limit": "^3.0.2",
-        "schema-utils": "^3.0.0",
-        "serialize-javascript": "^5.0.1",
-        "webpack-sources": "^1.4.3"
+        "schema-utils": "^4.0.0",
+        "serialize-javascript": "^6.0.0"
       },
       "engines": {
-        "node": ">= 10.13.0"
+        "node": ">= 14.15.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       },
       "peerDependencies": {
-        "webpack": "^4.37.0 || ^5.0.0"
+        "webpack": "^5.1.0"
       }
     },
-    "node_modules/copy-webpack-plugin/node_modules/p-limit": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
-      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+    "node_modules/copy-webpack-plugin/node_modules/ajv": {
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+      "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
       "dev": true,
       "dependencies": {
-        "yocto-queue": "^0.1.0"
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/copy-webpack-plugin/node_modules/ajv-keywords": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
+      "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3"
+      },
+      "peerDependencies": {
+        "ajv": "^8.8.2"
+      }
+    },
+    "node_modules/copy-webpack-plugin/node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "dependencies": {
+        "is-glob": "^4.0.3"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/copy-webpack-plugin/node_modules/globby": {
+      "version": "13.1.2",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-13.1.2.tgz",
+      "integrity": "sha512-LKSDZXToac40u8Q1PQtZihbNdTYSNMuWe+K5l+oa6KgDzSvVrHXlJy40hUP522RjAIoNLJYBJi7ow+rbFpIhHQ==",
+      "dev": true,
+      "dependencies": {
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.11",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/copy-webpack-plugin/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true
+    },
     "node_modules/copy-webpack-plugin/node_modules/schema-utils": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
-      "integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.0.0.tgz",
+      "integrity": "sha512-1edyXKgh6XnJsJSQ8mKWXnN/BVaIbFMLpouRUrXgVq7WYne5kw3MW7UPhO44uRXQSIpTSXoJbmrR2X0w9kUTyg==",
       "dev": true,
       "dependencies": {
-        "@types/json-schema": "^7.0.8",
-        "ajv": "^6.12.5",
-        "ajv-keywords": "^3.5.2"
+        "@types/json-schema": "^7.0.9",
+        "ajv": "^8.8.0",
+        "ajv-formats": "^2.1.1",
+        "ajv-keywords": "^5.0.0"
       },
       "engines": {
-        "node": ">= 10.13.0"
+        "node": ">= 12.13.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/copy-webpack-plugin/node_modules/serialize-javascript": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
+      "integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
+      "dev": true,
+      "dependencies": {
+        "randombytes": "^2.1.0"
+      }
+    },
+    "node_modules/copy-webpack-plugin/node_modules/slash": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
+      "integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/core-js": {
@@ -26551,6 +26658,35 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/react-styleguidist/node_modules/copy-webpack-plugin": {
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-6.4.1.tgz",
+      "integrity": "sha512-MXyPCjdPVx5iiWyl40Va3JGh27bKzOTNY3NjUTrosD2q7dR/cLD0013uqJ3BpFbUjyONINjb6qI7nDIJujrMbA==",
+      "dev": true,
+      "dependencies": {
+        "cacache": "^15.0.5",
+        "fast-glob": "^3.2.4",
+        "find-cache-dir": "^3.3.1",
+        "glob-parent": "^5.1.1",
+        "globby": "^11.0.1",
+        "loader-utils": "^2.0.0",
+        "normalize-path": "^3.0.0",
+        "p-limit": "^3.0.2",
+        "schema-utils": "^3.0.0",
+        "serialize-javascript": "^5.0.1",
+        "webpack-sources": "^1.4.3"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^4.37.0 || ^5.0.0"
+      }
+    },
     "node_modules/react-styleguidist/node_modules/escodegen": {
       "version": "1.14.3",
       "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.3.tgz",
@@ -26612,6 +26748,21 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/react-styleguidist/node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/react-styleguidist/node_modules/prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
@@ -26629,6 +26780,24 @@
       "peerDependencies": {
         "react": "^16.0.0",
         "react-dom": "^16.0.0"
+      }
+    },
+    "node_modules/react-styleguidist/node_modules/schema-utils": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
+      "integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
+      "dev": true,
+      "dependencies": {
+        "@types/json-schema": "^7.0.8",
+        "ajv": "^6.12.5",
+        "ajv-keywords": "^3.5.2"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/react-styleguidist/node_modules/source-map": {
@@ -27119,6 +27288,15 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -36839,6 +37017,35 @@
       "dev": true,
       "requires": {}
     },
+    "ajv-formats": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+      "dev": true,
+      "requires": {
+        "ajv": "^8.0.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "8.11.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+          "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "json-schema-traverse": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+          "dev": true
+        }
+      }
+    },
     "ajv-keywords": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
@@ -38898,43 +39105,94 @@
       }
     },
     "copy-webpack-plugin": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-6.4.1.tgz",
-      "integrity": "sha512-MXyPCjdPVx5iiWyl40Va3JGh27bKzOTNY3NjUTrosD2q7dR/cLD0013uqJ3BpFbUjyONINjb6qI7nDIJujrMbA==",
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-11.0.0.tgz",
+      "integrity": "sha512-fX2MWpamkW0hZxMEg0+mYnA40LTosOSa5TqZ9GYIBzyJa9C3QUaMPSE2xAi/buNr8u89SfD9wHSQVBzrRa/SOQ==",
       "dev": true,
       "requires": {
-        "cacache": "^15.0.5",
-        "fast-glob": "^3.2.4",
-        "find-cache-dir": "^3.3.1",
-        "glob-parent": "^5.1.1",
-        "globby": "^11.0.1",
-        "loader-utils": "^2.0.0",
+        "fast-glob": "^3.2.11",
+        "glob-parent": "^6.0.1",
+        "globby": "^13.1.1",
         "normalize-path": "^3.0.0",
-        "p-limit": "^3.0.2",
-        "schema-utils": "^3.0.0",
-        "serialize-javascript": "^5.0.1",
-        "webpack-sources": "^1.4.3"
+        "schema-utils": "^4.0.0",
+        "serialize-javascript": "^6.0.0"
       },
       "dependencies": {
-        "p-limit": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
-          "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+        "ajv": {
+          "version": "8.11.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+          "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
           "dev": true,
           "requires": {
-            "yocto-queue": "^0.1.0"
+            "fast-deep-equal": "^3.1.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2",
+            "uri-js": "^4.2.2"
           }
         },
-        "schema-utils": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
-          "integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
+        "ajv-keywords": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
+          "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
           "dev": true,
           "requires": {
-            "@types/json-schema": "^7.0.8",
-            "ajv": "^6.12.5",
-            "ajv-keywords": "^3.5.2"
+            "fast-deep-equal": "^3.1.3"
           }
+        },
+        "glob-parent": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+          "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+          "dev": true,
+          "requires": {
+            "is-glob": "^4.0.3"
+          }
+        },
+        "globby": {
+          "version": "13.1.2",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-13.1.2.tgz",
+          "integrity": "sha512-LKSDZXToac40u8Q1PQtZihbNdTYSNMuWe+K5l+oa6KgDzSvVrHXlJy40hUP522RjAIoNLJYBJi7ow+rbFpIhHQ==",
+          "dev": true,
+          "requires": {
+            "dir-glob": "^3.0.1",
+            "fast-glob": "^3.2.11",
+            "ignore": "^5.2.0",
+            "merge2": "^1.4.1",
+            "slash": "^4.0.0"
+          }
+        },
+        "json-schema-traverse": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+          "dev": true
+        },
+        "schema-utils": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.0.0.tgz",
+          "integrity": "sha512-1edyXKgh6XnJsJSQ8mKWXnN/BVaIbFMLpouRUrXgVq7WYne5kw3MW7UPhO44uRXQSIpTSXoJbmrR2X0w9kUTyg==",
+          "dev": true,
+          "requires": {
+            "@types/json-schema": "^7.0.9",
+            "ajv": "^8.8.0",
+            "ajv-formats": "^2.1.1",
+            "ajv-keywords": "^5.0.0"
+          }
+        },
+        "serialize-javascript": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
+          "integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
+          "dev": true,
+          "requires": {
+            "randombytes": "^2.1.0"
+          }
+        },
+        "slash": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
+          "integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==",
+          "dev": true
         }
       }
     },
@@ -52060,6 +52318,25 @@
           "integrity": "sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ==",
           "dev": true
         },
+        "copy-webpack-plugin": {
+          "version": "6.4.1",
+          "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-6.4.1.tgz",
+          "integrity": "sha512-MXyPCjdPVx5iiWyl40Va3JGh27bKzOTNY3NjUTrosD2q7dR/cLD0013uqJ3BpFbUjyONINjb6qI7nDIJujrMbA==",
+          "dev": true,
+          "requires": {
+            "cacache": "^15.0.5",
+            "fast-glob": "^3.2.4",
+            "find-cache-dir": "^3.3.1",
+            "glob-parent": "^5.1.1",
+            "globby": "^11.0.1",
+            "loader-utils": "^2.0.0",
+            "normalize-path": "^3.0.0",
+            "p-limit": "^3.0.2",
+            "schema-utils": "^3.0.0",
+            "serialize-javascript": "^5.0.1",
+            "webpack-sources": "^1.4.3"
+          }
+        },
         "escodegen": {
           "version": "1.14.3",
           "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.3.tgz",
@@ -52103,6 +52380,15 @@
             "word-wrap": "~1.2.3"
           }
         },
+        "p-limit": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+          "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+          "dev": true,
+          "requires": {
+            "yocto-queue": "^0.1.0"
+          }
+        },
         "prelude-ls": {
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
@@ -52115,6 +52401,17 @@
           "integrity": "sha512-bL5W5mAxSW6+cLwqqVWY47Silqgy2DKDTR4hDBrLrUqC5BXc29YVx17l2IZk5v36VcDEq1Bszu2oHm1qBwKqBA==",
           "dev": true,
           "requires": {}
+        },
+        "schema-utils": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
+          "integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
+          "dev": true,
+          "requires": {
+            "@types/json-schema": "^7.0.8",
+            "ajv": "^6.12.5",
+            "ajv-keywords": "^3.5.2"
+          }
         },
         "source-map": {
           "version": "0.6.1",
@@ -52506,6 +52803,12 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "dev": true
+    },
+    "require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "dev": true
     },
     "require-main-filename": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "@fortawesome/free-solid-svg-icons": "^6.1.1",
         "@fortawesome/react-fontawesome": "^0.1.18",
         "@terrestris/base-util": "^1.0.1",
-        "@terrestris/ol-util": "^6.0.1",
+        "@terrestris/ol-util": "^7.0.0",
         "@types/geojson": "^7946.0.8",
         "@types/lodash": "^4.14.179",
         "@types/moment": "^2.13.0",
@@ -29,7 +29,6 @@
         "@types/react": "^17.0",
         "@types/react-dom": "^18.0.2",
         "@types/react-rnd": "^8.0.0",
-        "geostyler-openlayers-parser": "^3.0.2",
         "lodash": "^4.17.21",
         "moment": "^2.29.2",
         "proj4": "^2.7.5",
@@ -5114,14 +5113,16 @@
       }
     },
     "node_modules/@terrestris/ol-util": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@terrestris/ol-util/-/ol-util-6.0.1.tgz",
-      "integrity": "sha512-8AH+1IX2Mmg5wckKjaxgRFayq3RhJ6L15pVRd4qlF9nKPwnDj2ysPJY3aJA9BwsJ5I6cue/TTyPqjU3u2nGyRA==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@terrestris/ol-util/-/ol-util-7.0.0.tgz",
+      "integrity": "sha512-YVD38nZesK5fXVqaV8rAaRzufL7mVWwlUmr0lrvn45LZIKP0A1f85aW9TuGwEr9/qOOR9ZtsEBBkDvngisM2eg==",
       "dependencies": {
         "@terrestris/base-util": "^1.0.1",
         "@turf/turf": "^6.5.0",
+        "@types/geojson": "^7946.0.8",
+        "geostyler-openlayers-parser": "^3.1.0",
         "lodash": "^4.17.21",
-        "polygon-splitter": "^0.0.7",
+        "polygon-splitter": "^0.0.8",
         "proj4": "^2.7.5",
         "shpjs": "^4.0.2",
         "typescript": "^4.5.5"
@@ -14123,16 +14124,22 @@
       }
     },
     "node_modules/geostyler-openlayers-parser": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/geostyler-openlayers-parser/-/geostyler-openlayers-parser-3.0.2.tgz",
-      "integrity": "sha512-HiEjaobWR/UU/1NoSyobV85OIdoX7gxQaaTVQaFIyo7+8zN+RWRMf99chmY9PSasX8b5khN1LJfVL1ySUKwcsQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/geostyler-openlayers-parser/-/geostyler-openlayers-parser-3.1.0.tgz",
+      "integrity": "sha512-TidTBmvlM/yVUWuarjO5mb9uiBmRDeWxCkdnvktuUrezWUWsVZWUXk9faA9s9D8o3IQMKJtI5UzIcSGuCB6H0Q==",
       "dependencies": {
+        "color-name": "^1.1.4",
         "geostyler-style": "^5.0.2",
         "lodash": "^4.17.21"
       },
       "peerDependencies": {
         "ol": "^6.0.0"
       }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "node_modules/geostyler-style": {
       "version": "5.1.0",
@@ -24996,9 +25003,9 @@
       }
     },
     "node_modules/polygon-splitter": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/polygon-splitter/-/polygon-splitter-0.0.7.tgz",
-      "integrity": "sha512-YSXN/PAfrD3+KPfqIY1J2QgA7FJLycRI7f7t21IdkfJ8taQU1fFmORzb0ZuAWfHRf/u4r66po0rWNpNjZUw+Yw==",
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/polygon-splitter/-/polygon-splitter-0.0.8.tgz",
+      "integrity": "sha512-/eKAKNXG61VE+VRK49VrPBh+y7hWUFC3Qem8RgPsqvu4Oc1UFsNgSBEYVTOdvbJj0d/fODJ6Zr9zU4sPl7WK1Q==",
       "dependencies": {
         "robust-predicates": "^2.0.4"
       }
@@ -36121,14 +36128,16 @@
       }
     },
     "@terrestris/ol-util": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@terrestris/ol-util/-/ol-util-6.0.1.tgz",
-      "integrity": "sha512-8AH+1IX2Mmg5wckKjaxgRFayq3RhJ6L15pVRd4qlF9nKPwnDj2ysPJY3aJA9BwsJ5I6cue/TTyPqjU3u2nGyRA==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@terrestris/ol-util/-/ol-util-7.0.0.tgz",
+      "integrity": "sha512-YVD38nZesK5fXVqaV8rAaRzufL7mVWwlUmr0lrvn45LZIKP0A1f85aW9TuGwEr9/qOOR9ZtsEBBkDvngisM2eg==",
       "requires": {
         "@terrestris/base-util": "^1.0.1",
         "@turf/turf": "^6.5.0",
+        "@types/geojson": "^7946.0.8",
+        "geostyler-openlayers-parser": "^3.1.0",
         "lodash": "^4.17.21",
-        "polygon-splitter": "^0.0.7",
+        "polygon-splitter": "^0.0.8",
         "proj4": "^2.7.5",
         "shpjs": "^4.0.2",
         "typescript": "^4.5.5"
@@ -43112,12 +43121,20 @@
       }
     },
     "geostyler-openlayers-parser": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/geostyler-openlayers-parser/-/geostyler-openlayers-parser-3.0.2.tgz",
-      "integrity": "sha512-HiEjaobWR/UU/1NoSyobV85OIdoX7gxQaaTVQaFIyo7+8zN+RWRMf99chmY9PSasX8b5khN1LJfVL1ySUKwcsQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/geostyler-openlayers-parser/-/geostyler-openlayers-parser-3.1.0.tgz",
+      "integrity": "sha512-TidTBmvlM/yVUWuarjO5mb9uiBmRDeWxCkdnvktuUrezWUWsVZWUXk9faA9s9D8o3IQMKJtI5UzIcSGuCB6H0Q==",
       "requires": {
+        "color-name": "^1.1.4",
         "geostyler-style": "^5.0.2",
         "lodash": "^4.17.21"
+      },
+      "dependencies": {
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        }
       }
     },
     "geostyler-style": {
@@ -51211,9 +51228,9 @@
       }
     },
     "polygon-splitter": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/polygon-splitter/-/polygon-splitter-0.0.7.tgz",
-      "integrity": "sha512-YSXN/PAfrD3+KPfqIY1J2QgA7FJLycRI7f7t21IdkfJ8taQU1fFmORzb0ZuAWfHRf/u4r66po0rWNpNjZUw+Yw==",
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/polygon-splitter/-/polygon-splitter-0.0.8.tgz",
+      "integrity": "sha512-/eKAKNXG61VE+VRK49VrPBh+y7hWUFC3Qem8RgPsqvu4Oc1UFsNgSBEYVTOdvbJj0d/fODJ6Zr9zU4sPl7WK1Q==",
       "requires": {
         "robust-predicates": "^2.0.4"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "@types/react": "^17.0",
         "@types/react-dom": "^18.0.2",
         "@types/react-rnd": "^8.0.0",
+        "geostyler-openlayers-parser": "^3.0.2",
         "lodash": "^4.17.21",
         "moment": "^2.29.2",
         "proj4": "^2.7.5",
@@ -1992,6 +1993,1448 @@
         "rxjs": "^6.6.3"
       }
     },
+    "node_modules/@camptocamp/inkmap/node_modules/@terrestris/ol-util": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@terrestris/ol-util/-/ol-util-4.1.3.tgz",
+      "integrity": "sha512-vTS7rXxOcvTpXQzRGR6DVldEYcbFjADQ9/ArSKeq9yCmmY9wb3dkeGKw+rN/dltu6oZbaswjsUsBQe060kiMOQ==",
+      "dependencies": {
+        "@terrestris/base-util": "^1.0.0",
+        "@turf/turf": "^5.1.6",
+        "lodash": "^4.17.20",
+        "proj4": "^2.7.0",
+        "shpjs": "^3.6.3"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "ol": "~6.5"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/@turf/along": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/along/-/along-5.1.5.tgz",
+      "integrity": "sha512-N7BN1xvj6VWMe3UpjQDdVI0j0oY/EZ0bWgOgBXc4DlJ411uEsKCh6iBv0b2MSxQ3YUXEez3oc5FcgO9eVSs7iQ==",
+      "dependencies": {
+        "@turf/bearing": "^5.1.5",
+        "@turf/destination": "^5.1.5",
+        "@turf/distance": "^5.1.5",
+        "@turf/helpers": "^5.1.5"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/@turf/area": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/area/-/area-5.1.5.tgz",
+      "integrity": "sha512-lz16gqtvoz+j1jD9y3zj0Z5JnGNd3YfS0h+DQY1EcZymvi75Frm9i5YbEyth0RfxYZeOVufY7YIS3LXbJlI57g==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/@turf/bbox": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/bbox/-/bbox-5.1.5.tgz",
+      "integrity": "sha512-sYQU4fqsOYYJoD8UndC1n2hy8hV/lGIAmMLKWuzwmPUWqWOuSKWUcoRWDi9mGB0GvQQe/ow2IxZr8UaVaGz3sQ==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/@turf/bbox-clip": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/bbox-clip/-/bbox-clip-5.1.5.tgz",
+      "integrity": "sha512-KP64aoTvjcXxWHeM/Hs25vOQUBJgyJi7DlRVEoZofFJiR1kPnmDQrK7Xj+60lAk5cxuqzFnaPPxUk9Q+3v4p1Q==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "lineclip": "^1.1.5"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/@turf/bbox-polygon": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/bbox-polygon/-/bbox-polygon-5.1.5.tgz",
+      "integrity": "sha512-PKVPF5LABFWZJud8KzzfesLGm5ihiwLbVa54HJjYySe6yqU/cr5q/qcN9TWptynOFhNktG1dr0KXVG0I2FZmfw==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/@turf/bearing": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/bearing/-/bearing-5.1.5.tgz",
+      "integrity": "sha512-PrvZuJjnXGseB8hUatIjsrK3tgD3wttyRnVYXTbSfXYJZzaOfHDMplgO4lxXQp7diraZhGhCdSlbMvRRXItbUQ==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/@turf/bezier-spline": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/bezier-spline/-/bezier-spline-5.1.5.tgz",
+      "integrity": "sha512-Y9NoComaGgFFFe9TWWE/cEMg2+EnBfU1R3112ec2wlx21ygDmFGXs4boOS71WM4ySwm/dbS3wxnbVxs4j68sKw==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/@turf/boolean-clockwise": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-clockwise/-/boolean-clockwise-5.1.5.tgz",
+      "integrity": "sha512-FqbmEEOJ4rU4/2t7FKx0HUWmjFEVqR+NJrFP7ymGSjja2SQ7Q91nnBihGuT+yuHHl6ElMjQ3ttsB/eTmyCycxA==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/@turf/boolean-contains": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-contains/-/boolean-contains-5.1.5.tgz",
+      "integrity": "sha512-x2HeEieeE9vBQrTdCuj4swnAXlpKbj9ChxMdDTV479c0m2gVmfea83ocmkj3w+9cvAaS63L8WqFyNVSmkwqljQ==",
+      "dependencies": {
+        "@turf/bbox": "^5.1.5",
+        "@turf/boolean-point-in-polygon": "^5.1.5",
+        "@turf/boolean-point-on-line": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/@turf/boolean-crosses": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-crosses/-/boolean-crosses-5.1.5.tgz",
+      "integrity": "sha512-odljvS7INr9k/8yXeyXQVry7GqEaChOmXawP0+SoTfGO3hgptiik59TLU/Yjn/SLFjE2Ul54Ga1jKFSL7vvH0Q==",
+      "dependencies": {
+        "@turf/boolean-point-in-polygon": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/line-intersect": "^5.1.5",
+        "@turf/polygon-to-line": "^5.1.5"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/@turf/boolean-disjoint": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-disjoint/-/boolean-disjoint-5.1.6.tgz",
+      "integrity": "sha512-KHvUS6SBNYHBCLIJEJrg04pF5Oy+Fqn8V5G9U+9pti5vI9tyX7Ln2g7RSB7iJ1Cxsz8QAi6OukhXjEF2/8ZpGg==",
+      "dependencies": {
+        "@turf/boolean-point-in-polygon": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/line-intersect": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "@turf/polygon-to-line": "^5.1.5"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/@turf/boolean-equal": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-equal/-/boolean-equal-5.1.5.tgz",
+      "integrity": "sha512-QEMbhDPV+J8PlRkMlVg6m5oSLaYUpOx2VUhDDekQ73FlpnhFBKRIlidhvHtS6CYnEw8d+/zA3h8Z18B4W4mq9Q==",
+      "dependencies": {
+        "@turf/clean-coords": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "geojson-equality": "0.1.6"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/@turf/boolean-overlap": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-overlap/-/boolean-overlap-5.1.5.tgz",
+      "integrity": "sha512-lizojgU559KME0G705YAgWVa0B3/tsWNobMzOEWDx/1rABWTojCY4uxw2rFxpOsP++s8JJHrGWXRLh1PbdAvRQ==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/line-intersect": "^5.1.5",
+        "@turf/line-overlap": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "geojson-equality": "0.1.6"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/@turf/boolean-parallel": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-parallel/-/boolean-parallel-5.1.5.tgz",
+      "integrity": "sha512-eeuGgDhnas3nJ22A/DD8aiH0kg9dSzbQChIMAqYRPGg3pWNK41aGAbeh5z0GO5N/EVFX1+ga5a0vsPmiRgQB5g==",
+      "dependencies": {
+        "@turf/clean-coords": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/line-segment": "^5.1.5",
+        "@turf/rhumb-bearing": "^5.1.5"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/@turf/boolean-parallel/node_modules/@turf/rhumb-bearing": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/rhumb-bearing/-/rhumb-bearing-5.1.5.tgz",
+      "integrity": "sha512-zXTl2khjwf7mx2D1uPo5vgpGgP4sM2VrKDbJNKyulPu4TO4ELt8x7FsKyCBlRTzzQf284t/xnNcZOfUbkkd70g==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/@turf/boolean-point-in-polygon": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-point-in-polygon/-/boolean-point-in-polygon-5.1.5.tgz",
+      "integrity": "sha512-y+gbAhLmsAZH9uYhv+C68pu06mxsGIm3o7l0hzVkc/PXYdbkr+vKe7n7PfSN3xpVA3qoDLKLpCGOqeW8/ThaJA==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/@turf/boolean-point-on-line": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-point-on-line/-/boolean-point-on-line-5.1.5.tgz",
+      "integrity": "sha512-Zf4d28mckV2tYfLWf2iqxQ8eeLZqi2HGimM26mptf1OCEIwc1wfkKgLRRJXMu94Crvd/pJxjRAjoYGcGliP6Vg==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/@turf/boolean-within": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-within/-/boolean-within-5.1.5.tgz",
+      "integrity": "sha512-CNAtrvm4HiUwV/vhpGhvJzfhV9CN7VhPC5y4tTfQicK82fYY6ifPz0iaNpUOmshU6+TAot/fsVQVgDJ4t7HXcA==",
+      "dependencies": {
+        "@turf/bbox": "^5.1.5",
+        "@turf/boolean-point-in-polygon": "^5.1.5",
+        "@turf/boolean-point-on-line": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/@turf/buffer": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/buffer/-/buffer-5.1.5.tgz",
+      "integrity": "sha512-U3LU0HF/JNFUNabpB5ArpNG6yPla7yR5XPrZvzZRH48vvbr/N0rkSRI0tJFRWTz7ntugVm9X0OD9Y382NTJRhA==",
+      "dependencies": {
+        "@turf/bbox": "^5.1.5",
+        "@turf/center": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "@turf/projection": "^5.1.5",
+        "d3-geo": "1.7.1",
+        "turf-jsts": "*"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/@turf/buffer/node_modules/@turf/projection": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/projection/-/projection-5.1.5.tgz",
+      "integrity": "sha512-TWKJDFeEKQhI4Ce1+2PuOSDggn4cnMibqyUoCpIW+4KxUC1R88SE3/SYomqzwxMn00O09glHSycPkGD5JzHd8A==",
+      "dependencies": {
+        "@turf/clone": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/@turf/center": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/center/-/center-5.1.5.tgz",
+      "integrity": "sha512-Dy1TvAv2oHKFddZcWqlVsanxurfcZV1Mmb1E+7H7GRKI+fXZTfRjwCdbiZCbO/tPwxt8jWQHWdLHn8E9lecc3A==",
+      "dependencies": {
+        "@turf/bbox": "^5.1.5",
+        "@turf/helpers": "^5.1.5"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/@turf/center-mean": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/center-mean/-/center-mean-5.1.5.tgz",
+      "integrity": "sha512-XdkBXzFUuyCqu5EPlBwgkv8FLA8pIGBnt7xy5cxxhxKOYLMrKqwMPPHPA84TjeQpNti0gH0CVuOk2r1f/Pp8iQ==",
+      "dependencies": {
+        "@turf/bbox": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/@turf/center-median": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/center-median/-/center-median-5.1.5.tgz",
+      "integrity": "sha512-M+O6bSNsIDKZ4utk/YzSOIg6W0isjLVWud+TCLWyrDCWTSERlSJlhOaVE1y7cObhG8nYBHvmszqZyoAY6nufQw==",
+      "dependencies": {
+        "@turf/center-mean": "^5.1.5",
+        "@turf/centroid": "^5.1.5",
+        "@turf/distance": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/@turf/center-of-mass": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/center-of-mass/-/center-of-mass-5.1.5.tgz",
+      "integrity": "sha512-UvI7q6GgW3afCVIDOyTRuLT54v9Xwv65Xudxh4FIT6w7HNU4KUBtTGnx0NuhODZcgvZgWVWVakhmIcHQTMjYYA==",
+      "dependencies": {
+        "@turf/centroid": "^5.1.5",
+        "@turf/convex": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/@turf/centroid": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/centroid/-/centroid-5.1.5.tgz",
+      "integrity": "sha512-0m9ZAZJB4YXLDxF2fWGqlE/g9Y68cebeWaRNOMN+e6Bti1fz0JKQuaEqJV+J8xOmODPHSMbZZ1SqSDVRgVHP2Q==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/@turf/circle": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/circle/-/circle-5.1.5.tgz",
+      "integrity": "sha512-CNaEtvp38Q+TSFJHdzdl5iYNjBFZRluRTFikIuEcennSeMJD60nP0dMubP58TR/QQn541eNDUyED90V4KuOjyQ==",
+      "dependencies": {
+        "@turf/destination": "^5.1.5",
+        "@turf/helpers": "^5.1.5"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/@turf/clean-coords": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/clean-coords/-/clean-coords-5.1.5.tgz",
+      "integrity": "sha512-xd/iSM0McVUxbu81KCKDqirCsYkKk3EAwpDjYI8vIQ+eKf/MLSdteRcm3PB7wo2y6JcYp4dMGv2cr9IP7V+dXQ==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/@turf/clone": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/clone/-/clone-5.1.5.tgz",
+      "integrity": "sha512-//pITsQ8xUdcQ9pVb4JqXiSqG4dos5Q9N4sYFoWghX21tfOV2dhc5TGqYOhnHrQS7RiKQL1vQ48kIK34gQ5oRg==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/@turf/clusters": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/clusters/-/clusters-5.1.5.tgz",
+      "integrity": "sha512-+rQe+g66xfbIXz58tveXQCDdE9hzqRJtDVSw5xth92TvCcL4J60ZKN8mHNUSn1ZZvpUHtVPe4dYcbtk5bW8fXQ==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/@turf/clusters-dbscan": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/clusters-dbscan/-/clusters-dbscan-5.1.5.tgz",
+      "integrity": "sha512-X3qLLHJkwMuv+xdWQ08NtOc6BgeqCKKSAltyyAZ7iImE65f0C+sW024DfHSbTMsZVXBFst2Q6RQY8RVUf3QBeQ==",
+      "dependencies": {
+        "@turf/clone": "^5.1.5",
+        "@turf/distance": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "density-clustering": "1.3.0"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/@turf/clusters-kmeans": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/clusters-kmeans/-/clusters-kmeans-5.1.5.tgz",
+      "integrity": "sha512-W6raiv9+fRgmJxCvKrpSacbLXzh7beZUk0A1pjF82Fv3CFTrXAJbgAyIbdlmgXezYSXhOT5NMUugnbkUy2oBZw==",
+      "dependencies": {
+        "@turf/clone": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "skmeans": "0.9.7"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/@turf/collect": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/collect/-/collect-5.1.5.tgz",
+      "integrity": "sha512-voFWu6EGPcNuIbAp43yvGf2Ip4/q8TTeWhOSJ2yDEHgOfbAwrNUwUJCclEjcUVsnc7ypKNrFn3/8bmR9tI0NQg==",
+      "dependencies": {
+        "@turf/bbox": "^5.1.5",
+        "@turf/boolean-point-in-polygon": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "rbush": "^2.0.1"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/@turf/combine": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/combine/-/combine-5.1.5.tgz",
+      "integrity": "sha512-/RqmfCvduHquINVyNmzKOcZtZjfaEHMhghgmj8MYnzepN3ro+E2QXoaQGGrQ7nChAvGgWPAvN8EveVSc1MvzPg==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/@turf/concave": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/concave/-/concave-5.1.5.tgz",
+      "integrity": "sha512-NvR5vmAunmgjEPjNzmvjLRvPcj7C6WuqCf+vu/aqyc4h2c1B/x399bDsSM64iFT+PYesFuoS1ZhJHWivXG8Y5g==",
+      "dependencies": {
+        "@turf/clone": "^5.1.5",
+        "@turf/distance": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "@turf/tin": "^5.1.5",
+        "topojson-client": "3.x",
+        "topojson-server": "3.x"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/@turf/convex": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/convex/-/convex-5.1.5.tgz",
+      "integrity": "sha512-ZEk4kIAoYR/mjO3C8rMe2StgmwhdwmbxVvNxg3udeahe2m0ZzbfkRC4HiJAaBgfR4TLJUAEewynESReTPwASBQ==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "concaveman": "*"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/@turf/destination": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/destination/-/destination-5.1.5.tgz",
+      "integrity": "sha512-EWwZnd4wxUO9d8UWzJt88jQlFf6W/6SE1930MMzzIR9o+RfqhrS/BL1eUDrg5I5drsymf6PZsK0j/V0q6jqkFQ==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/@turf/difference": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/difference/-/difference-5.1.5.tgz",
+      "integrity": "sha512-hIjiUHS8WiDfnmADQrhh6QcXWc3zNtjIpPQ5g/2NZ3k1mjnOdmGBVObkSJG4WEUNqyj3PKlsZ8W9xnSu+lLF1Q==",
+      "dependencies": {
+        "@turf/area": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "turf-jsts": "*"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/@turf/dissolve": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/dissolve/-/dissolve-5.1.5.tgz",
+      "integrity": "sha512-YcQgyp7pvhyZHCmbqqItVH6vHs43R9N0jzP/LnAG03oMiY4wves/BO1du6VDDbnJSXeRKf1afmY9tRGKYrm9ag==",
+      "dependencies": {
+        "@turf/boolean-overlap": "^5.1.5",
+        "@turf/clone": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/line-intersect": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "@turf/union": "^5.1.5",
+        "geojson-rbush": "2.1.0",
+        "get-closest": "*"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/@turf/distance": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/distance/-/distance-5.1.5.tgz",
+      "integrity": "sha512-sYCAgYZ2MjNKMtx17EijHlK9qHwpA0MuuQWbR4P30LTCl52UlG/reBfV899wKyF3HuDL9ux78IbILwOfeQ4zgA==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/@turf/ellipse": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/ellipse/-/ellipse-5.1.5.tgz",
+      "integrity": "sha512-oVTzEyDOi3d9isgB7Ah+YiOoUKB1eHMtMDXVl1oT+vC/T+6KR2aq+HjjbF11A0cjuh3VhjSWUZaS+2TYY0pu0w==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/rhumb-destination": "^5.1.5",
+        "@turf/transform-rotate": "^5.1.5"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/@turf/envelope": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/envelope/-/envelope-5.1.5.tgz",
+      "integrity": "sha512-Mxl5A2euAxq3RZVN65/MVyaO91kzGU8MJXfegPdep6SN4bONDadEp0olwW5qSRf2U3cJ8Jppl089X6AeifD3IA==",
+      "dependencies": {
+        "@turf/bbox": "^5.1.5",
+        "@turf/bbox-polygon": "^5.1.5",
+        "@turf/helpers": "^5.1.5"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/@turf/explode": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/explode/-/explode-5.1.5.tgz",
+      "integrity": "sha512-v/hC9DB9RKRW9/ZjnKoQelIp08JNa5wew0889465s//tfgY8+JEGkSGMag2L2NnVARWmzI/vlLgMK36qwkyDIA==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/@turf/flatten": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/flatten/-/flatten-5.1.5.tgz",
+      "integrity": "sha512-aagHz5tjHmOtb8eMb5fd10+HJwdlhkhsPql1vRXQNnpv0Q9xL/4SsbvXZ6lPqkRAjiZuy087mvaz+ERml76/jg==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/@turf/flip": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/flip/-/flip-5.1.5.tgz",
+      "integrity": "sha512-7+IYM3QQAkV4co3wjEmM726/OkXqUCCHWWyIqrI9hiK+LR628qkoqP1hk6rQ4vZJrAYuvSlK+FZnr24OtgY0cw==",
+      "dependencies": {
+        "@turf/clone": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/@turf/great-circle": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/great-circle/-/great-circle-5.1.5.tgz",
+      "integrity": "sha512-k6FWwlt+YCQoD5VS1NybQjriNL7apYHO+tm2HbIFQ85blPUX4IyLppHIFevfD/k+K2bJqhFCze8JNVMBwdrzVw==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/@turf/helpers": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-5.1.5.tgz",
+      "integrity": "sha512-/lF+JR+qNDHZ8bF9d+Cp58nxtZWJ3sqFe6n3u3Vpj+/0cqkjk4nXKYBSY0azm+GIYB5mWKxUXvuP/m0ZnKj1bw=="
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/@turf/hex-grid": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/hex-grid/-/hex-grid-5.1.5.tgz",
+      "integrity": "sha512-rwDL+DlUyxDNL1aVHIKKCmrt1131ZULF3irExYIO/um6/SwRzsBw+522/RcxD/mg/Shtrpozb6bz8aJJ/3RXHA==",
+      "dependencies": {
+        "@turf/distance": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/intersect": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/@turf/interpolate": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/interpolate/-/interpolate-5.1.5.tgz",
+      "integrity": "sha512-LfmvtIUWc3NVkqPkX6j3CAIjF7y1LAZqfDd+2Ii+0fN7XOOGMWcb1uiTTAb8zDQjhTsygcUYgaz6mMYDCWYKPg==",
+      "dependencies": {
+        "@turf/bbox": "^5.1.5",
+        "@turf/centroid": "^5.1.5",
+        "@turf/clone": "^5.1.5",
+        "@turf/distance": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/hex-grid": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "@turf/point-grid": "^5.1.5",
+        "@turf/square-grid": "^5.1.5",
+        "@turf/triangle-grid": "^5.1.5"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/@turf/intersect": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/@turf/intersect/-/intersect-5.1.6.tgz",
+      "integrity": "sha512-KXyNv/GXdoGAOy03qZF53rgtXC2tNhF/4jLwTKiVRrBQH6kcEpipGStdJ+QkYIlarQPa8f7I9UlVAB19et4MfQ==",
+      "dependencies": {
+        "@turf/clean-coords": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/truncate": "^5.1.5",
+        "turf-jsts": "*"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/@turf/invariant": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-5.1.5.tgz",
+      "integrity": "sha512-4elbC8GVQ8XxrnWLWpFFXTK3qnzIYzIVtSkJrY9eefA8WNZzwcwT3WGFY3xte4BB48o5oEjihjoJharWRis78w==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/@turf/isobands": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/isobands/-/isobands-5.1.5.tgz",
+      "integrity": "sha512-0n3NPfDYQyqjOch00I4hVCCqjKn9Sm+a8qlWOKbkuhmGa9dCDzsu2bZL0ahT+LjwlS4c8/owQXqe6KE2GWqT1Q==",
+      "dependencies": {
+        "@turf/area": "^5.1.5",
+        "@turf/bbox": "^5.1.5",
+        "@turf/boolean-point-in-polygon": "^5.1.5",
+        "@turf/explode": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/@turf/isolines": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/isolines/-/isolines-5.1.5.tgz",
+      "integrity": "sha512-Ehn5pJmiq4hAn2+2jPB2rLt3iF8DDp8zciw9z2pAt5IGVRU/K+x3z4aYG5ra5vbFB/E4G3aHr/X4QPIb9LCJtA==",
+      "dependencies": {
+        "@turf/bbox": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/@turf/kinks": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/kinks/-/kinks-5.1.5.tgz",
+      "integrity": "sha512-G38sC8/+MYqQpVocT3XahhV42cqEAVJAZwUND9YOfKJZfjUn7FKmWhPURs5py95me48UuI0C0jLLAMzBkUc2nQ==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/@turf/length": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/length/-/length-5.1.5.tgz",
+      "integrity": "sha512-0ryx68h512wCoNfwyksLdabxEfwkGNTPg61/QiY+QfGFUOUNhHbP+QimViFpwF5hyX7qmroaSHVclLUqyLGRbg==",
+      "dependencies": {
+        "@turf/distance": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/@turf/line-arc": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/line-arc/-/line-arc-5.1.5.tgz",
+      "integrity": "sha512-Kz5RX/qRIHVrGNqF3BRlD3ACuuCr0G5lpaVyPjNvN+vA7Q4bEDyWIYeqm3DdTn7X2MXitpTNgr2uvX4WoUy4yA==",
+      "dependencies": {
+        "@turf/circle": "^5.1.5",
+        "@turf/destination": "^5.1.5",
+        "@turf/helpers": "^5.1.5"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/@turf/line-chunk": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/line-chunk/-/line-chunk-5.1.5.tgz",
+      "integrity": "sha512-mKvTUMahnb3EsYUMI8tQmygsliQkgQ1FZAY915zoTrm+WV246loa+84+h7i5d8W2O8gGJWuY7jQTpM7toTeL5w==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/length": "^5.1.5",
+        "@turf/line-slice-along": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/@turf/line-intersect": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/line-intersect/-/line-intersect-5.1.5.tgz",
+      "integrity": "sha512-9DajJbHhJauLI2qVMnqZ7SeFsinFroVICOSUheODk7j5teuwNABuZ2Z6WmKATzEsPkEJ1iVykqB+F9vGMVKB6g==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/line-segment": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "geojson-rbush": "2.1.0"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/@turf/line-offset": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/line-offset/-/line-offset-5.1.5.tgz",
+      "integrity": "sha512-VccGDgFfBSiCTqrHdQgxD7Rs9lnJmDOJ5gqQRculKPsCNUyRFMYIZud7l2dTs83g66evfOwkZCrTxtSoBY3Jxg==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/@turf/line-overlap": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/line-overlap/-/line-overlap-5.1.5.tgz",
+      "integrity": "sha512-hMz3XARXEbfGwLF9WXyErqQjzhZYMKvGQwlPGOoth+2o9Uga9mfWfevduJvozJAE1MKxtFttMjIXMzcShW3O8A==",
+      "dependencies": {
+        "@turf/boolean-point-on-line": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/line-segment": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "@turf/nearest-point-on-line": "^5.1.5",
+        "geojson-rbush": "2.1.0"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/@turf/line-segment": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/line-segment/-/line-segment-5.1.5.tgz",
+      "integrity": "sha512-wIrRtWuLuLXhnSkqdVG1SDayTU0/CmZf+a+BBhEf0vFIsAedJnrY3a2cbCEvtfuk6ZsAbhOi7/kYiaR/F+rEzg==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/@turf/line-slice": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/line-slice/-/line-slice-5.1.5.tgz",
+      "integrity": "sha512-Fo+CuD+fj6T702BofHO+rgiXUgzCk0iO2JqMPtttMtgzfKkVTUOQoauMNS1LNNaG/7n/TfKGh5gRCEDRNaNwYA==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/nearest-point-on-line": "^5.1.5"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/@turf/line-slice-along": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/line-slice-along/-/line-slice-along-5.1.5.tgz",
+      "integrity": "sha512-yKvSDtULztLtlPIMowm9l8pS6XLAEpCPmrARZA0sIWFX8XrcSzISBaXZbiMMzg3nxQJMXfGIgWDk10B7+J8Tqw==",
+      "dependencies": {
+        "@turf/bearing": "^5.1.5",
+        "@turf/destination": "^5.1.5",
+        "@turf/distance": "^5.1.5",
+        "@turf/helpers": "^5.1.5"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/@turf/line-split": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/line-split/-/line-split-5.1.5.tgz",
+      "integrity": "sha512-gtUUBwZL3hcSu5MpqHTl68hgAJBNHcr1APDj8E5o6iX5xFX+wvl4ohQXyMs5HOATCI8Iy83wLuggcY6maNw7LQ==",
+      "dependencies": {
+        "@turf/bbox": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/line-intersect": "^5.1.5",
+        "@turf/line-segment": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "@turf/nearest-point-on-line": "^5.1.5",
+        "@turf/square": "^5.1.5",
+        "@turf/truncate": "^5.1.5",
+        "geojson-rbush": "2.1.0"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/@turf/line-to-polygon": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/line-to-polygon/-/line-to-polygon-5.1.5.tgz",
+      "integrity": "sha512-hGiDAPd6j986kZZLDgEAkVD7O6DmIqHQliBedspoKperPJOUJJzdzSnF6OAWSsxY+j8fWtQnIo5TTqdO/KfamA==",
+      "dependencies": {
+        "@turf/bbox": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/@turf/mask": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/mask/-/mask-5.1.5.tgz",
+      "integrity": "sha512-2eOuxA3ammZAGsjlsy/H7IpeJxjl3hrgkcKM6kTKRJGft4QyKwCxqQP7RN5j0zIYvAurgs9JOLe/dpd5sE5HXQ==",
+      "dependencies": {
+        "@turf/bbox": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "@turf/union": "^5.1.5",
+        "rbush": "^2.0.1"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/@turf/meta": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-5.1.6.tgz",
+      "integrity": "sha512-lv+6LCgoc3LVitQZ4TScN/8a/fcctq8bIoxBTMJVq4aU8xoHeY1851Dq8MCU37EzbH33utkx8/jENaQP+aeElg==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/@turf/midpoint": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/midpoint/-/midpoint-5.1.5.tgz",
+      "integrity": "sha512-0pDQAKHyK/zxlvUx3XNxwvqftf4sV32QxnHfqSs4AXaODUGUbPhzAD7aXgDScBeUOVLwpAzFRQfitUvUMTGC6A==",
+      "dependencies": {
+        "@turf/bearing": "^5.1.5",
+        "@turf/destination": "^5.1.5",
+        "@turf/distance": "^5.1.5",
+        "@turf/helpers": "^5.1.5"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/@turf/nearest-point": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/nearest-point/-/nearest-point-5.1.5.tgz",
+      "integrity": "sha512-tZQXI7OE7keNKK4OvYOJ5gervCEuu2pJ6psu59QW9yhe2Di3Gl+HAdLvVa6RZ8s5Fndr3u0JWKsmxve3fCxc9g==",
+      "dependencies": {
+        "@turf/clone": "^5.1.5",
+        "@turf/distance": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/@turf/nearest-point-on-line": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/nearest-point-on-line/-/nearest-point-on-line-5.1.5.tgz",
+      "integrity": "sha512-qT7BLTwToo8cq0oNoz921oLlRPJamyRg/rZgll+kNBadyDPmJI4W66riHcpM9RQcAJ6TPvDveIIBeGJH7iG88w==",
+      "dependencies": {
+        "@turf/bearing": "^5.1.5",
+        "@turf/destination": "^5.1.5",
+        "@turf/distance": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/line-intersect": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/@turf/nearest-point-to-line": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/@turf/nearest-point-to-line/-/nearest-point-to-line-5.1.6.tgz",
+      "integrity": "sha512-ZSvDIEiHhifn/vNwLXZI/E8xmEz5yBPqfUR7BVHRZrB1cP7jLhKZvkbidjG//uW8Fr1Ulc+PFOXczLspIcx/lw==",
+      "dependencies": {
+        "@turf/helpers": "6.x",
+        "@turf/invariant": "6.x",
+        "@turf/meta": "6.x",
+        "@turf/point-to-line-distance": "^5.1.5",
+        "object-assign": "*"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/@turf/nearest-point-to-line/node_modules/@turf/helpers": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.5.0.tgz",
+      "integrity": "sha512-VbI1dV5bLFzohYYdgqwikdMVpe7pJ9X3E+dlr425wa2/sMJqYDhTO++ec38/pcPvPE6oD9WEEeU3Xu3gza+VPw==",
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/@turf/nearest-point-to-line/node_modules/@turf/invariant": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-6.5.0.tgz",
+      "integrity": "sha512-Wv8PRNCtPD31UVbdJE/KVAWKe7l6US+lJItRR/HOEW3eh+U/JwRCSUl/KZ7bmjM/C+zLNoreM2TU6OoLACs4eg==",
+      "dependencies": {
+        "@turf/helpers": "^6.5.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/@turf/nearest-point-to-line/node_modules/@turf/meta": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-6.5.0.tgz",
+      "integrity": "sha512-RrArvtsV0vdsCBegoBtOalgdSOfkBrTJ07VkpiCnq/491W67hnMWmDu7e6Ztw0C3WldRYTXkg3SumfdzZxLBHA==",
+      "dependencies": {
+        "@turf/helpers": "^6.5.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/@turf/planepoint": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/planepoint/-/planepoint-5.1.5.tgz",
+      "integrity": "sha512-+Tp+SQ0Db2tqwLbxfXJPysT9IxcOHSMIin2dJb/j3Qn5+g0LRus6rczZl6dWNAIjqBPMawj/V/dZhMu6Q9O9wA==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/@turf/point-grid": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/point-grid/-/point-grid-5.1.5.tgz",
+      "integrity": "sha512-4ibozguP9YJ297Q7i9e8/ypGSycvt1re2jrPXTxeuZ4/L/NE5B1nOBLG+tw121nMjD+S+v2RWOtqD+FZ3Ga+ew==",
+      "dependencies": {
+        "@turf/boolean-within": "^5.1.5",
+        "@turf/distance": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/@turf/point-on-feature": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/point-on-feature/-/point-on-feature-5.1.5.tgz",
+      "integrity": "sha512-NTcpe5xZjybRh0aTL+7td1cm0s49GGbAt5u8Cdec4W9ix2PsehRcLUbmQIQsODN2kiVyUSpnhECIpsyN5MjX7A==",
+      "dependencies": {
+        "@turf/boolean-point-in-polygon": "^5.1.5",
+        "@turf/center": "^5.1.5",
+        "@turf/explode": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/nearest-point": "^5.1.5"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/@turf/point-to-line-distance": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/@turf/point-to-line-distance/-/point-to-line-distance-5.1.6.tgz",
+      "integrity": "sha512-PE3hiTeeDEi4ZLPtI8XAzFYW9nHo1EVsZGm/4ZVV8jo39d3X1oLVHxY3e1PkCmWwRapXy4QLqvnTQ7nU4wspNw==",
+      "dependencies": {
+        "@turf/bearing": "6.x",
+        "@turf/distance": "6.x",
+        "@turf/helpers": "6.x",
+        "@turf/invariant": "6.x",
+        "@turf/meta": "6.x",
+        "@turf/projection": "6.x",
+        "@turf/rhumb-bearing": "6.x",
+        "@turf/rhumb-distance": "6.x"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/@turf/point-to-line-distance/node_modules/@turf/bearing": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/bearing/-/bearing-6.5.0.tgz",
+      "integrity": "sha512-dxINYhIEMzgDOztyMZc20I7ssYVNEpSv04VbMo5YPQsqa80KO3TFvbuCahMsCAW5z8Tncc8dwBlEFrmRjJG33A==",
+      "dependencies": {
+        "@turf/helpers": "^6.5.0",
+        "@turf/invariant": "^6.5.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/@turf/point-to-line-distance/node_modules/@turf/distance": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/distance/-/distance-6.5.0.tgz",
+      "integrity": "sha512-xzykSLfoURec5qvQJcfifw/1mJa+5UwByZZ5TZ8iaqjGYN0vomhV9aiSLeYdUGtYRESZ+DYC/OzY+4RclZYgMg==",
+      "dependencies": {
+        "@turf/helpers": "^6.5.0",
+        "@turf/invariant": "^6.5.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/@turf/point-to-line-distance/node_modules/@turf/helpers": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.5.0.tgz",
+      "integrity": "sha512-VbI1dV5bLFzohYYdgqwikdMVpe7pJ9X3E+dlr425wa2/sMJqYDhTO++ec38/pcPvPE6oD9WEEeU3Xu3gza+VPw==",
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/@turf/point-to-line-distance/node_modules/@turf/invariant": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-6.5.0.tgz",
+      "integrity": "sha512-Wv8PRNCtPD31UVbdJE/KVAWKe7l6US+lJItRR/HOEW3eh+U/JwRCSUl/KZ7bmjM/C+zLNoreM2TU6OoLACs4eg==",
+      "dependencies": {
+        "@turf/helpers": "^6.5.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/@turf/point-to-line-distance/node_modules/@turf/meta": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-6.5.0.tgz",
+      "integrity": "sha512-RrArvtsV0vdsCBegoBtOalgdSOfkBrTJ07VkpiCnq/491W67hnMWmDu7e6Ztw0C3WldRYTXkg3SumfdzZxLBHA==",
+      "dependencies": {
+        "@turf/helpers": "^6.5.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/@turf/points-within-polygon": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/points-within-polygon/-/points-within-polygon-5.1.5.tgz",
+      "integrity": "sha512-nexe2AHVOY8wEBvs+CYSOp10NyOCkyZ1gkhIfsx0mzU8LPYBxD9ctjlKveheKh4AAldLcFupd/gSCBTKF1JS7A==",
+      "dependencies": {
+        "@turf/boolean-point-in-polygon": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/@turf/polygon-tangents": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/polygon-tangents/-/polygon-tangents-5.1.5.tgz",
+      "integrity": "sha512-uoZfKvFhl6rf0+CDWucru9fZ4mJB5Nsg37TS/7emrzjoVxXyOdxc/s1HFCjcKflMue7MjU/gT6AitJyrvdztDg==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/@turf/polygon-to-line": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/polygon-to-line/-/polygon-to-line-5.1.5.tgz",
+      "integrity": "sha512-kVo0owPqyccy5+qZGvaxGvMsYkgueKE2OOgX2UV/HyrXF3uI3TomK1txjApqeFsLvwuSANxesvVbYLrYiIwvGw==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/@turf/polygonize": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/polygonize/-/polygonize-5.1.5.tgz",
+      "integrity": "sha512-qzhtuzoOhldqZHm+ZPsWAs9nDpnkcDfsr+I0twmBF+wjAmo0HKiy9++sRQ4kEePpdwbMpF07D/NdZqYdmOJkGQ==",
+      "dependencies": {
+        "@turf/boolean-point-in-polygon": "^5.1.5",
+        "@turf/envelope": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/@turf/random": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/random/-/random-5.1.5.tgz",
+      "integrity": "sha512-oitpBwEb6YXqoUkIAOVMK+vrTPxUi2rqITmtTa/FBHr6J8TDwMWq6bufE3Gmgjxsss50O2ITJunOksxrouWGDQ==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/@turf/rewind": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/rewind/-/rewind-5.1.5.tgz",
+      "integrity": "sha512-Gdem7JXNu+G4hMllQHXRFRihJl3+pNl7qY+l4qhQFxq+hiU1cQoVFnyoleIqWKIrdK/i2YubaSwc3SCM7N5mMw==",
+      "dependencies": {
+        "@turf/boolean-clockwise": "^5.1.5",
+        "@turf/clone": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/@turf/rhumb-destination": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/rhumb-destination/-/rhumb-destination-5.1.5.tgz",
+      "integrity": "sha512-FdDUCSRfRAfsRmUaWjc76Wk32QYFJ6ckmSt6Ls6nEczO6eg/RgH1atF8CIYwR5ifl0Sk1rQzKiOSbpCyvVwQtw==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/@turf/sample": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/sample/-/sample-5.1.5.tgz",
+      "integrity": "sha512-EJE8yx+5x7rXejTzwBdOKpvT4tOCS0jwYJfycyTVDuLUSh2rETeYdjy7EeJbofnxm9CRPXqWQMPWIBKWxNTjow==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/@turf/sector": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/sector/-/sector-5.1.5.tgz",
+      "integrity": "sha512-dnWVifL3xWTqPPs8mfbbV9muDimNJtxRk4ogrkOLEDQ9ZZ1ALQMtQdYrg7kI3iC+L+LscV37tl+E8bayWyX8YA==",
+      "dependencies": {
+        "@turf/circle": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/line-arc": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/@turf/shortest-path": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/shortest-path/-/shortest-path-5.1.5.tgz",
+      "integrity": "sha512-ZGC8kSBj02GKWiI56Z5FNdrZ+fS0xyeOUNrPJWzudAlrv9wKGaRuWoIVRLGBu0j0OuO1HCwggic2c6WV/AhP0A==",
+      "dependencies": {
+        "@turf/bbox": "^5.1.5",
+        "@turf/bbox-polygon": "^5.1.5",
+        "@turf/boolean-point-in-polygon": "^5.1.5",
+        "@turf/clean-coords": "^5.1.5",
+        "@turf/distance": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "@turf/transform-scale": "^5.1.5"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/@turf/simplify": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/simplify/-/simplify-5.1.5.tgz",
+      "integrity": "sha512-IuBXEYdGSxbDOK3v949ajaPvs6NhjhTCTbKA6mSGuVbwGS7gzAuRiPSG4K/MvCVuQy3PKpkPcUGD+Uvt2Ov2PQ==",
+      "dependencies": {
+        "@turf/clean-coords": "^5.1.5",
+        "@turf/clone": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/@turf/square": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/square/-/square-5.1.5.tgz",
+      "integrity": "sha512-GgP2le9ksoW6vsVef5wFkjmWQiLPTJvcjGXqmoGWT4oMwDpvTJVQ91RBLs8qQbI4KACCQevz94N69klk3ah30Q==",
+      "dependencies": {
+        "@turf/distance": "^5.1.5",
+        "@turf/helpers": "^5.1.5"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/@turf/square-grid": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/square-grid/-/square-grid-5.1.5.tgz",
+      "integrity": "sha512-/pusEL4FmOwNWLcZfIXUyqUe0fOdkfaLO4wLhDlg/ZL1jWr/wZjhVlMU0tQ27kVN6dJTvlzNc9e0JWNw6yt2eQ==",
+      "dependencies": {
+        "@turf/boolean-contains": "^5.1.5",
+        "@turf/boolean-overlap": "^5.1.5",
+        "@turf/distance": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/intersect": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/@turf/standard-deviational-ellipse": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/standard-deviational-ellipse/-/standard-deviational-ellipse-5.1.5.tgz",
+      "integrity": "sha512-GOaxGKeeJAXV1H3Zz2fjQ5XeSbMKz1OkFRlTDBUipiAawe/9qTCF55L87I2ZPnO80B5BaaIT+AN2n0lMcAklzA==",
+      "dependencies": {
+        "@turf/center-mean": "^5.1.5",
+        "@turf/ellipse": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "@turf/points-within-polygon": "^5.1.5"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/@turf/tag": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/tag/-/tag-5.1.5.tgz",
+      "integrity": "sha512-XI3QFpva6tEsRnzFe1tJGdAAWlzjnXZPfJ9EKShTxEW8ZgPzm92b2odjiSAt2KuQusK82ltNfdw5Frlna5xGYQ==",
+      "dependencies": {
+        "@turf/boolean-point-in-polygon": "^5.1.5",
+        "@turf/clone": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/@turf/tesselate": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/tesselate/-/tesselate-5.1.5.tgz",
+      "integrity": "sha512-Rs/jAij26bcU4OzvFXkWDase1G3kSwyuuKZPFU0t7OmJu7eQJOR12WOZLGcVxd5oBlklo4xPE4EBQUqpQUsQgg==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "earcut": "^2.0.0"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/@turf/tin": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/tin/-/tin-5.1.5.tgz",
+      "integrity": "sha512-lDyCTYKoThBIKmkBxBMupqEpFbvTDAYuZIs8qrWnmux2vntSb8OFGi7ZbGPC6apS2hdVwZZae3YB88Tp+Fg+xw==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/@turf/transform-rotate": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/transform-rotate/-/transform-rotate-5.1.5.tgz",
+      "integrity": "sha512-3QKckeHKPXu5O5vEuT+nkszGDI6aknDD06ePb00+6H2oA7MZj7nj+fVQIJLs41MRb76IyKr4n5NvuKZU6idESA==",
+      "dependencies": {
+        "@turf/centroid": "^5.1.5",
+        "@turf/clone": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "@turf/rhumb-bearing": "^5.1.5",
+        "@turf/rhumb-destination": "^5.1.5",
+        "@turf/rhumb-distance": "^5.1.5"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/@turf/transform-rotate/node_modules/@turf/rhumb-bearing": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/rhumb-bearing/-/rhumb-bearing-5.1.5.tgz",
+      "integrity": "sha512-zXTl2khjwf7mx2D1uPo5vgpGgP4sM2VrKDbJNKyulPu4TO4ELt8x7FsKyCBlRTzzQf284t/xnNcZOfUbkkd70g==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/@turf/transform-rotate/node_modules/@turf/rhumb-distance": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/rhumb-distance/-/rhumb-distance-5.1.5.tgz",
+      "integrity": "sha512-AGA/ky5/BJJZtzQqafy2GvJfcUXSzCCrPFp8sDRPSKBoUN4gMBHN15ijDWYYLFoWFFj0urcauVx7chQlHZ/Qfw==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/@turf/transform-scale": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/transform-scale/-/transform-scale-5.1.5.tgz",
+      "integrity": "sha512-t1fCZX29ONA7DJiqCKA4YZy0+hCzhppWNOZhglBUv9vKHsWCFYZDUKfFInciaypUInsZyvm8eKxxixBVPdPGsw==",
+      "dependencies": {
+        "@turf/bbox": "^5.1.5",
+        "@turf/center": "^5.1.5",
+        "@turf/centroid": "^5.1.5",
+        "@turf/clone": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "@turf/rhumb-bearing": "^5.1.5",
+        "@turf/rhumb-destination": "^5.1.5",
+        "@turf/rhumb-distance": "^5.1.5"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/@turf/transform-scale/node_modules/@turf/rhumb-bearing": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/rhumb-bearing/-/rhumb-bearing-5.1.5.tgz",
+      "integrity": "sha512-zXTl2khjwf7mx2D1uPo5vgpGgP4sM2VrKDbJNKyulPu4TO4ELt8x7FsKyCBlRTzzQf284t/xnNcZOfUbkkd70g==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/@turf/transform-scale/node_modules/@turf/rhumb-distance": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/rhumb-distance/-/rhumb-distance-5.1.5.tgz",
+      "integrity": "sha512-AGA/ky5/BJJZtzQqafy2GvJfcUXSzCCrPFp8sDRPSKBoUN4gMBHN15ijDWYYLFoWFFj0urcauVx7chQlHZ/Qfw==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/@turf/transform-translate": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/transform-translate/-/transform-translate-5.1.5.tgz",
+      "integrity": "sha512-GdLFp7I7198oRQt311B8EjiqHupndeMSQ3Zclzki5L/niUrb1ptOIpo+mxSidSy03m+1Q5ylWlENroI1WBcQ3Q==",
+      "dependencies": {
+        "@turf/clone": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "@turf/rhumb-destination": "^5.1.5"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/@turf/triangle-grid": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/triangle-grid/-/triangle-grid-5.1.5.tgz",
+      "integrity": "sha512-jmCRcynI80xsVqd+0rv0YxP6mvZn4BAaJv8dwthg2T3WfHB9OD+rNUMohMuUY8HmI0zRT3s/Ypdy2Cdri9u/tw==",
+      "dependencies": {
+        "@turf/distance": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/intersect": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/@turf/truncate": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/truncate/-/truncate-5.1.5.tgz",
+      "integrity": "sha512-WjWGsRE6o1vUqULGb/O7O1eK6B4Eu6R/RBZWnF0rH0Os6WVel6tHktkeJdlKwz9WElIEO12wDIu6uKd54t7DDQ==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/@turf/turf": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/@turf/turf/-/turf-5.1.6.tgz",
+      "integrity": "sha512-NIjkt5jAbOrom+56ELw9ERZF6qsdf1xAIHyC9/PkDMIOQAxe7FVe2HaqbQ+x88F0q5FaSX4dtpIEf08md6h5/A==",
+      "dependencies": {
+        "@turf/along": "5.1.x",
+        "@turf/area": "5.1.x",
+        "@turf/bbox": "5.1.x",
+        "@turf/bbox-clip": "5.1.x",
+        "@turf/bbox-polygon": "5.1.x",
+        "@turf/bearing": "5.1.x",
+        "@turf/bezier-spline": "5.1.x",
+        "@turf/boolean-clockwise": "5.1.x",
+        "@turf/boolean-contains": "5.1.x",
+        "@turf/boolean-crosses": "5.1.x",
+        "@turf/boolean-disjoint": "5.1.x",
+        "@turf/boolean-equal": "5.1.x",
+        "@turf/boolean-overlap": "5.1.x",
+        "@turf/boolean-parallel": "5.1.x",
+        "@turf/boolean-point-in-polygon": "5.1.x",
+        "@turf/boolean-point-on-line": "5.1.x",
+        "@turf/boolean-within": "5.1.x",
+        "@turf/buffer": "5.1.x",
+        "@turf/center": "5.1.x",
+        "@turf/center-mean": "5.1.x",
+        "@turf/center-median": "5.1.x",
+        "@turf/center-of-mass": "5.1.x",
+        "@turf/centroid": "5.1.x",
+        "@turf/circle": "5.1.x",
+        "@turf/clean-coords": "5.1.x",
+        "@turf/clone": "5.1.x",
+        "@turf/clusters": "5.1.x",
+        "@turf/clusters-dbscan": "5.1.x",
+        "@turf/clusters-kmeans": "5.1.x",
+        "@turf/collect": "5.1.x",
+        "@turf/combine": "5.1.x",
+        "@turf/concave": "5.1.x",
+        "@turf/convex": "5.1.x",
+        "@turf/destination": "5.1.x",
+        "@turf/difference": "5.1.x",
+        "@turf/dissolve": "5.1.x",
+        "@turf/distance": "5.1.x",
+        "@turf/ellipse": "5.1.x",
+        "@turf/envelope": "5.1.x",
+        "@turf/explode": "5.1.x",
+        "@turf/flatten": "5.1.x",
+        "@turf/flip": "5.1.x",
+        "@turf/great-circle": "5.1.x",
+        "@turf/helpers": "5.1.x",
+        "@turf/hex-grid": "5.1.x",
+        "@turf/interpolate": "5.1.x",
+        "@turf/intersect": "5.1.x",
+        "@turf/invariant": "5.1.x",
+        "@turf/isobands": "5.1.x",
+        "@turf/isolines": "5.1.x",
+        "@turf/kinks": "5.1.x",
+        "@turf/length": "5.1.x",
+        "@turf/line-arc": "5.1.x",
+        "@turf/line-chunk": "5.1.x",
+        "@turf/line-intersect": "5.1.x",
+        "@turf/line-offset": "5.1.x",
+        "@turf/line-overlap": "5.1.x",
+        "@turf/line-segment": "5.1.x",
+        "@turf/line-slice": "5.1.x",
+        "@turf/line-slice-along": "5.1.x",
+        "@turf/line-split": "5.1.x",
+        "@turf/line-to-polygon": "5.1.x",
+        "@turf/mask": "5.1.x",
+        "@turf/meta": "5.1.x",
+        "@turf/midpoint": "5.1.x",
+        "@turf/nearest-point": "5.1.x",
+        "@turf/nearest-point-on-line": "5.1.x",
+        "@turf/nearest-point-to-line": "5.1.x",
+        "@turf/planepoint": "5.1.x",
+        "@turf/point-grid": "5.1.x",
+        "@turf/point-on-feature": "5.1.x",
+        "@turf/point-to-line-distance": "5.1.x",
+        "@turf/points-within-polygon": "5.1.x",
+        "@turf/polygon-tangents": "5.1.x",
+        "@turf/polygon-to-line": "5.1.x",
+        "@turf/polygonize": "5.1.x",
+        "@turf/projection": "5.1.x",
+        "@turf/random": "5.1.x",
+        "@turf/rewind": "5.1.x",
+        "@turf/rhumb-bearing": "5.1.x",
+        "@turf/rhumb-destination": "5.1.x",
+        "@turf/rhumb-distance": "5.1.x",
+        "@turf/sample": "5.1.x",
+        "@turf/sector": "5.1.x",
+        "@turf/shortest-path": "5.1.x",
+        "@turf/simplify": "5.1.x",
+        "@turf/square": "5.1.x",
+        "@turf/square-grid": "5.1.x",
+        "@turf/standard-deviational-ellipse": "5.1.x",
+        "@turf/tag": "5.1.x",
+        "@turf/tesselate": "5.1.x",
+        "@turf/tin": "5.1.x",
+        "@turf/transform-rotate": "5.1.x",
+        "@turf/transform-scale": "5.1.x",
+        "@turf/transform-translate": "5.1.x",
+        "@turf/triangle-grid": "5.1.x",
+        "@turf/truncate": "5.1.x",
+        "@turf/union": "5.1.x",
+        "@turf/unkink-polygon": "5.1.x",
+        "@turf/voronoi": "5.1.x"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/@turf/turf/node_modules/@turf/projection": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/projection/-/projection-5.1.5.tgz",
+      "integrity": "sha512-TWKJDFeEKQhI4Ce1+2PuOSDggn4cnMibqyUoCpIW+4KxUC1R88SE3/SYomqzwxMn00O09glHSycPkGD5JzHd8A==",
+      "dependencies": {
+        "@turf/clone": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/@turf/turf/node_modules/@turf/rhumb-bearing": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/rhumb-bearing/-/rhumb-bearing-5.1.5.tgz",
+      "integrity": "sha512-zXTl2khjwf7mx2D1uPo5vgpGgP4sM2VrKDbJNKyulPu4TO4ELt8x7FsKyCBlRTzzQf284t/xnNcZOfUbkkd70g==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/@turf/turf/node_modules/@turf/rhumb-distance": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/rhumb-distance/-/rhumb-distance-5.1.5.tgz",
+      "integrity": "sha512-AGA/ky5/BJJZtzQqafy2GvJfcUXSzCCrPFp8sDRPSKBoUN4gMBHN15ijDWYYLFoWFFj0urcauVx7chQlHZ/Qfw==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/@turf/union": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/union/-/union-5.1.5.tgz",
+      "integrity": "sha512-wBy1ixxC68PpsTeEDebk/EfnbI1Za5dCyY7xFY9NMzrtVEOy0l0lQ5syOsaqY4Ire+dbsDM66p2GGxmefoyIEA==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "turf-jsts": "*"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/@turf/unkink-polygon": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/unkink-polygon/-/unkink-polygon-5.1.5.tgz",
+      "integrity": "sha512-lzSrgsfSuyxIc4pkE2qyM2dsHxR992e6oItoZAT8G58A2Ef4qc5gRocmXPWZakGx41fQobegSo7wlo4I49wyHg==",
+      "dependencies": {
+        "@turf/area": "^5.1.5",
+        "@turf/boolean-point-in-polygon": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "rbush": "^2.0.1"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/@turf/voronoi": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/voronoi/-/voronoi-5.1.5.tgz",
+      "integrity": "sha512-Ad0HZAyYjOpMIZfDGV+Q+30M9PQHIirTyn32kWyTjEI1O6uhL5NOYjzSha4Sr77xOls3hGzKOj+JET7eDtOvsg==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "d3-voronoi": "1.1.2"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/geojson-rbush": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/geojson-rbush/-/geojson-rbush-2.1.0.tgz",
+      "integrity": "sha512-9HvLGhmAJBYkYYDdPlCrlfkKGwNW3PapiS0xPekdJLobkZE4rjtduKJXsO7+kUr97SsUlz4VtMcPuSIbjjJaQg==",
+      "dependencies": {
+        "@turf/helpers": "*",
+        "@turf/meta": "*",
+        "rbush": "*"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/geostyler-openlayers-parser": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/geostyler-openlayers-parser/-/geostyler-openlayers-parser-2.5.0.tgz",
+      "integrity": "sha512-Uum/lDci8oqhBA/c0RZbD91aXP4ycjlsAp4ZoVAPDHT6Og0XyF5Tze8wg0Ux44CerE6W+m2DfWkOTAP+iaakzQ==",
+      "dependencies": {
+        "@terrestris/ol-util": "^4.0.1",
+        "geostyler-style": "^4.0.0",
+        "lodash": "^4.17.15"
+      },
+      "peerDependencies": {
+        "ol": "^6.0.0"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/geostyler-style": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/geostyler-style/-/geostyler-style-4.0.3.tgz",
+      "integrity": "sha512-51esHVZz86HFoSvKRA/Kfqd2Mytek88zgHSSt8ZZg30o4dqyZuQluxwIjqkSLp5hdvmA0nwCAyqxHy6aMyJ5lQ==",
+      "dependencies": {
+        "@types/lodash": "^4.14.168",
+        "lodash": "^4.17.21"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/jszip": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-2.6.1.tgz",
+      "integrity": "sha512-C4Z++nYQv+CudUkCWUdz+yKVhQiFJjuWSmRJ5Sg3d3/OzcJ6U4ooUYlmE3+rJXrVk89KWQaiJ9mPp/VLQ4D66g==",
+      "dependencies": {
+        "pako": "~1.0.2"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/lru-cache": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+      "integrity": "sha512-WpibWJ60c3AgAz8a2iYErDrcT2C7OmKnsWhIcHOjkUHFjkXncJhtLxNSqUmxRxRunpb5I8Vprd7aNSd2NtksJQ=="
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/ol": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/ol/-/ol-6.5.0.tgz",
+      "integrity": "sha512-a5ebahrjF5yCPFle1rc0aHzKp/9A4LlUnjh+S3I+x4EgcvcddDhpOX3WDOs0Pg9/wEElrikHSGEvbeej2Hh4Ug==",
+      "dependencies": {
+        "ol-mapbox-style": "^6.1.1",
+        "pbf": "3.2.1",
+        "rbush": "^3.0.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/openlayers"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/ol-mapbox-style": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/ol-mapbox-style/-/ol-mapbox-style-6.9.0.tgz",
+      "integrity": "sha512-Isxk+IPB6pCBD2Pubz9cpQcZjEeuPhxyk/QsLZjb2+KwvyGaIFltdlxnxx/QXJ7rOxUiLvS/XhsOyiK0c7prEw==",
+      "dependencies": {
+        "@mapbox/mapbox-gl-style-spec": "^13.20.1",
+        "mapbox-to-css-font": "^2.4.1",
+        "webfont-matcher": "^1.1.0"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/ol/node_modules/rbush": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/rbush/-/rbush-3.0.1.tgz",
+      "integrity": "sha512-XRaVO0YecOpEuIvbhbpTrZgoiI6xBlz6hnlr6EHhd+0x9ase6EmeN+hdwwUaJvLcsFFQ8iWVF1GAK1yB0BWi0w==",
+      "dependencies": {
+        "quickselect": "^2.0.0"
+      }
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/quickselect": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
+      "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw=="
+    },
+    "node_modules/@camptocamp/inkmap/node_modules/shpjs": {
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/shpjs/-/shpjs-3.6.3.tgz",
+      "integrity": "sha512-wcR2S3WL/7RnEIm+YO+H/mZR9z9FCV46op+SZt+W5PtPs26Omb9U93f+EPI1DOpNKBuAIrWjHWh0SxlnBahJkg==",
+      "dependencies": {
+        "jszip": "^2.4.0",
+        "lie": "^3.0.1",
+        "lru-cache": "^2.7.0",
+        "parsedbf": "^1.1.0",
+        "proj4": "^2.1.4"
+      }
+    },
     "node_modules/@ctrl/tinycolor": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/@ctrl/tinycolor/-/tinycolor-3.4.0.tgz",
@@ -2477,6 +3920,15 @@
       "dependencies": {
         "jest-get-type": "^28.0.2"
       },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "node_modules/@jest/expect-utils/node_modules/jest-get-type": {
+      "version": "28.0.2",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-28.0.2.tgz",
+      "integrity": "sha512-ioj2w9/DxSYHfOm5lJKCdcAmPJzQXmbM/Url3rhlghrPvT3tt+7a/+oXc9azkKmLvoiXjtV83bEWqi+vs5nlPA==",
+      "dev": true,
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
       }
@@ -3647,18 +5099,18 @@
       }
     },
     "node_modules/@terrestris/eslint-config-typescript": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@terrestris/eslint-config-typescript/-/eslint-config-typescript-3.0.0.tgz",
-      "integrity": "sha512-dpAztRrJ/M036lTI5eqJoNbX4/80zTh2fRWxrXRG16RHorQoIbBsd8WqWtF7K42yTrSHz2kmEwWX4Yo0YBc2rQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@terrestris/eslint-config-typescript/-/eslint-config-typescript-2.1.0.tgz",
+      "integrity": "sha512-fRAAfa2bIht5Nf/GZBbhhgVwnxNc3VG8YdyYwsauCwAn5XPHl/JDeJkyMpIu/NVML9LGSFbQBZChUEpZRhntwg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/parser": "^5.28.0",
-        "typescript": ">= ~4"
+        "@typescript-eslint/parser": "^5.15.0",
+        "typescript": ">= 3"
       },
       "peerDependencies": {
-        "@typescript-eslint/eslint-plugin": ">= ~5",
-        "eslint": ">= ~8",
-        "typescript": ">= ~4"
+        "@typescript-eslint/eslint-plugin": ">= 4",
+        "eslint": ">= 7",
+        "typescript": ">= 3"
       }
     },
     "node_modules/@terrestris/ol-util": {
@@ -3683,9 +5135,9 @@
       }
     },
     "node_modules/@testing-library/dom": {
-      "version": "8.14.0",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.14.0.tgz",
-      "integrity": "sha512-m8FOdUo77iMTwVRCyzWcqxlEIk+GnopbrRI15a0EaLbpZSCinIVI4kSQzWhkShK83GogvEFJSsHF3Ws0z1vrqA==",
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.13.0.tgz",
+      "integrity": "sha512-9VHgfIatKNXQNaZTtLnalIy0jNZzY35a4S3oi08YAt9Hv1VsfZ/DfA45lM8D/UhtHBGJ4/lGwp0PZkVndRkoOQ==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
@@ -3888,9 +5340,9 @@
       }
     },
     "node_modules/@testing-library/user-event": {
-      "version": "14.2.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.2.1.tgz",
-      "integrity": "sha512-HOr1QiODrq+0j9lKU5i10y9TbhxMBMRMGimNx10asdmau9cb8Xb1Vyg0GvTwyIL2ziQyh2kAloOtAQFBQVuecA==",
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.2.0.tgz",
+      "integrity": "sha512-+hIlG4nJS6ivZrKnOP7OGsDu9Fxmryj9vCl8x0ZINtTJcCHs2zLsYif5GzuRiBF2ck5GZG2aQr7Msg+EHlnYVQ==",
       "dev": true,
       "engines": {
         "node": ">=12",
@@ -3921,30 +5373,6 @@
       "engines": {
         "node": ">= 10"
       }
-    },
-    "node_modules/@tsconfig/node10": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
-      "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
-      "dev": true
-    },
-    "node_modules/@tsconfig/node12": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
-      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
-      "dev": true
-    },
-    "node_modules/@tsconfig/node14": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
-      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
-      "dev": true
-    },
-    "node_modules/@tsconfig/node16": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
-      "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
-      "dev": true
     },
     "node_modules/@turf/along": {
       "version": "6.5.0",
@@ -5669,47 +7097,14 @@
       }
     },
     "node_modules/@types/jest": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-28.1.3.tgz",
-      "integrity": "sha512-Tsbjk8Y2hkBaY/gJsataeb4q9Mubw9EOz7+4RjPkzD5KjTvHHs7cpws22InaoXxAVAhF5HfFbzJjo6oKWqSZLw==",
-      "dev": true,
-      "dependencies": {
-        "jest-matcher-utils": "^28.0.0",
-        "pretty-format": "^28.0.0"
-      }
-    },
-    "node_modules/@types/jest/node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@types/jest/node_modules/pretty-format": {
       "version": "28.1.1",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-28.1.1.tgz",
-      "integrity": "sha512-wwJbVTGFHeucr5Jw2bQ9P+VYHyLdAqedFLEkdQUVaBF/eiidDwH5OpilINq4mEfhbCjLnirt6HTTDhv1HaTIQw==",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-28.1.1.tgz",
+      "integrity": "sha512-C2p7yqleUKtCkVjlOur9BWVA4HgUQmEj/HWCt5WzZ5mLXrWnyIfl0wGuArc+kBXsy0ZZfLp+7dywB4HtSVYGVA==",
       "dev": true,
       "dependencies": {
-        "@jest/schemas": "^28.0.2",
-        "ansi-regex": "^5.0.1",
-        "ansi-styles": "^5.0.0",
-        "react-is": "^18.0.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+        "jest-matcher-utils": "^27.0.0",
+        "pretty-format": "^27.0.0"
       }
-    },
-    "node_modules/@types/jest/node_modules/react-is": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
-      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
-      "dev": true
     },
     "node_modules/@types/jsdom": {
       "version": "16.2.14",
@@ -5794,9 +7189,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.0.0.tgz",
-      "integrity": "sha512-cHlGmko4gWLVI27cGJntjs/Sj8th9aYwplmZFwmmgYQQvL5NUsgVJG7OddLvNfLqYS31KFN0s3qlaD9qCaxACA=="
+      "version": "17.0.42",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.42.tgz",
+      "integrity": "sha512-Q5BPGyGKcvQgAMbsr7qEGN/kIPN6zZecYYABeTDBizOsau+2NMdSVTar9UQw21A2+JyA2KRNDYaYrPB0Rpk2oQ=="
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.1",
@@ -6005,14 +7400,14 @@
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "5.29.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.29.0.tgz",
-      "integrity": "sha512-kgTsISt9pM53yRFQmLZ4npj99yGl3x3Pl7z4eA66OuTzAGC4bQB5H5fuLwPnqTKU3yyrrg4MIhjF17UYnL4c0w==",
+      "version": "5.27.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.27.1.tgz",
+      "integrity": "sha512-6dM5NKT57ZduNnJfpY81Phe9nc9wolnMCnknb1im6brWi1RYv84nbMS3olJa27B6+irUVV1X/Wb+Am0FjJdGFw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.29.0",
-        "@typescript-eslint/type-utils": "5.29.0",
-        "@typescript-eslint/utils": "5.29.0",
+        "@typescript-eslint/scope-manager": "5.27.1",
+        "@typescript-eslint/type-utils": "5.27.1",
+        "@typescript-eslint/utils": "5.27.1",
         "debug": "^4.3.4",
         "functional-red-black-tree": "^1.0.1",
         "ignore": "^5.2.0",
@@ -6053,14 +7448,14 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "5.29.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.29.0.tgz",
-      "integrity": "sha512-ruKWTv+x0OOxbzIw9nW5oWlUopvP/IQDjB5ZqmTglLIoDTctLlAJpAQFpNPJP/ZI7hTT9sARBosEfaKbcFuECw==",
+      "version": "5.27.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.27.1.tgz",
+      "integrity": "sha512-7Va2ZOkHi5NP+AZwb5ReLgNF6nWLGTeUJfxdkVUAPPSaAdbWNnFZzLZ4EGGmmiCTg+AwlbE1KyUYTBglosSLHQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.29.0",
-        "@typescript-eslint/types": "5.29.0",
-        "@typescript-eslint/typescript-estree": "5.29.0",
+        "@typescript-eslint/scope-manager": "5.27.1",
+        "@typescript-eslint/types": "5.27.1",
+        "@typescript-eslint/typescript-estree": "5.27.1",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -6080,13 +7475,13 @@
       }
     },
     "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.29.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.29.0.tgz",
-      "integrity": "sha512-etbXUT0FygFi2ihcxDZjz21LtC+Eps9V2xVx09zFoN44RRHPrkMflidGMI+2dUs821zR1tDS6Oc9IXxIjOUZwA==",
+      "version": "5.27.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.27.1.tgz",
+      "integrity": "sha512-fQEOSa/QroWE6fAEg+bJxtRZJTH8NTskggybogHt4H9Da8zd4cJji76gA5SBlR0MgtwF7rebxTbDKB49YUCpAg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.29.0",
-        "@typescript-eslint/visitor-keys": "5.29.0"
+        "@typescript-eslint/types": "5.27.1",
+        "@typescript-eslint/visitor-keys": "5.27.1"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -6097,9 +7492,9 @@
       }
     },
     "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/types": {
-      "version": "5.29.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.29.0.tgz",
-      "integrity": "sha512-X99VbqvAXOMdVyfFmksMy3u8p8yoRGITgU1joBJPzeYa0rhdf5ok9S56/itRoUSh99fiDoMtarSIJXo7H/SnOg==",
+      "version": "5.27.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.27.1.tgz",
+      "integrity": "sha512-LgogNVkBhCTZU/m8XgEYIWICD6m4dmEDbKXESCbqOXfKZxRKeqpiJXQIErv66sdopRKZPo5l32ymNqibYEH/xg==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -6110,13 +7505,13 @@
       }
     },
     "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.29.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.29.0.tgz",
-      "integrity": "sha512-mQvSUJ/JjGBdvo+1LwC+GY2XmSYjK1nAaVw2emp/E61wEVYEyibRHCqm1I1vEKbXCpUKuW4G7u9ZCaZhJbLoNQ==",
+      "version": "5.27.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.27.1.tgz",
+      "integrity": "sha512-DnZvvq3TAJ5ke+hk0LklvxwYsnXpRdqUY5gaVS0D4raKtbznPz71UJGnPTHEFo0GDxqLOLdMkkmVZjSpET1hFw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.29.0",
-        "@typescript-eslint/visitor-keys": "5.29.0",
+        "@typescript-eslint/types": "5.27.1",
+        "@typescript-eslint/visitor-keys": "5.27.1",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -6137,12 +7532,12 @@
       }
     },
     "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.29.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.29.0.tgz",
-      "integrity": "sha512-Hpb/mCWsjILvikMQoZIE3voc9wtQcS0A9FUw3h8bhr9UxBdtI/tw1ZDZUOXHXLOVMedKCH5NxyzATwnU78bWCQ==",
+      "version": "5.27.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.27.1.tgz",
+      "integrity": "sha512-xYs6ffo01nhdJgPieyk7HAOpjhTsx7r/oB9LWEhwAXgwn33tkr+W8DI2ChboqhZlC4q3TC6geDYPoiX8ROqyOQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.29.0",
+        "@typescript-eslint/types": "5.27.1",
         "eslint-visitor-keys": "^3.3.0"
       },
       "engines": {
@@ -6178,13 +7573,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.29.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.29.0.tgz",
-      "integrity": "sha512-etbXUT0FygFi2ihcxDZjz21LtC+Eps9V2xVx09zFoN44RRHPrkMflidGMI+2dUs821zR1tDS6Oc9IXxIjOUZwA==",
+      "version": "5.27.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.27.1.tgz",
+      "integrity": "sha512-fQEOSa/QroWE6fAEg+bJxtRZJTH8NTskggybogHt4H9Da8zd4cJji76gA5SBlR0MgtwF7rebxTbDKB49YUCpAg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.29.0",
-        "@typescript-eslint/visitor-keys": "5.29.0"
+        "@typescript-eslint/types": "5.27.1",
+        "@typescript-eslint/visitor-keys": "5.27.1"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -6195,12 +7590,12 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "5.29.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.29.0.tgz",
-      "integrity": "sha512-JK6bAaaiJozbox3K220VRfCzLa9n0ib/J+FHIwnaV3Enw/TO267qe0pM1b1QrrEuy6xun374XEAsRlA86JJnyg==",
+      "version": "5.27.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.27.1.tgz",
+      "integrity": "sha512-+UC1vVUWaDHRnC2cQrCJ4QtVjpjjCgjNFpg8b03nERmkHv9JV9X5M19D7UFMd+/G7T/sgFwX2pGmWK38rqyvXw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/utils": "5.29.0",
+        "@typescript-eslint/utils": "5.27.1",
         "debug": "^4.3.4",
         "tsutils": "^3.21.0"
       },
@@ -6221,9 +7616,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "5.29.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.29.0.tgz",
-      "integrity": "sha512-X99VbqvAXOMdVyfFmksMy3u8p8yoRGITgU1joBJPzeYa0rhdf5ok9S56/itRoUSh99fiDoMtarSIJXo7H/SnOg==",
+      "version": "5.27.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.27.1.tgz",
+      "integrity": "sha512-LgogNVkBhCTZU/m8XgEYIWICD6m4dmEDbKXESCbqOXfKZxRKeqpiJXQIErv66sdopRKZPo5l32ymNqibYEH/xg==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -6234,13 +7629,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.29.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.29.0.tgz",
-      "integrity": "sha512-mQvSUJ/JjGBdvo+1LwC+GY2XmSYjK1nAaVw2emp/E61wEVYEyibRHCqm1I1vEKbXCpUKuW4G7u9ZCaZhJbLoNQ==",
+      "version": "5.27.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.27.1.tgz",
+      "integrity": "sha512-DnZvvq3TAJ5ke+hk0LklvxwYsnXpRdqUY5gaVS0D4raKtbznPz71UJGnPTHEFo0GDxqLOLdMkkmVZjSpET1hFw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.29.0",
-        "@typescript-eslint/visitor-keys": "5.29.0",
+        "@typescript-eslint/types": "5.27.1",
+        "@typescript-eslint/visitor-keys": "5.27.1",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -6276,15 +7671,15 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "5.29.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.29.0.tgz",
-      "integrity": "sha512-3Eos6uP1nyLOBayc/VUdKZikV90HahXE5Dx9L5YlSd/7ylQPXhLk1BYb29SDgnBnTp+jmSZUU0QxUiyHgW4p7A==",
+      "version": "5.27.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.27.1.tgz",
+      "integrity": "sha512-mZ9WEn1ZLDaVrhRaYgzbkXBkTPghPFsup8zDbbsYTxC5OmqrFE7skkKS/sraVsLP3TcT3Ki5CSyEFBRkLH/H/w==",
       "dev": true,
       "dependencies": {
         "@types/json-schema": "^7.0.9",
-        "@typescript-eslint/scope-manager": "5.29.0",
-        "@typescript-eslint/types": "5.29.0",
-        "@typescript-eslint/typescript-estree": "5.29.0",
+        "@typescript-eslint/scope-manager": "5.27.1",
+        "@typescript-eslint/types": "5.27.1",
+        "@typescript-eslint/typescript-estree": "5.27.1",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^3.0.0"
       },
@@ -6300,12 +7695,12 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.29.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.29.0.tgz",
-      "integrity": "sha512-Hpb/mCWsjILvikMQoZIE3voc9wtQcS0A9FUw3h8bhr9UxBdtI/tw1ZDZUOXHXLOVMedKCH5NxyzATwnU78bWCQ==",
+      "version": "5.27.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.27.1.tgz",
+      "integrity": "sha512-xYs6ffo01nhdJgPieyk7HAOpjhTsx7r/oB9LWEhwAXgwn33tkr+W8DI2ChboqhZlC4q3TC6geDYPoiX8ROqyOQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.29.0",
+        "@typescript-eslint/types": "5.27.1",
         "eslint-visitor-keys": "^3.3.0"
       },
       "engines": {
@@ -6905,12 +8300,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/arg": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-      "dev": true
     },
     "node_modules/argparse": {
       "version": "1.0.10",
@@ -9312,20 +10701,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/conventional-changelog-conventionalcommits": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-5.0.0.tgz",
-      "integrity": "sha512-lCDbA+ZqVFQGUj7h9QBKoIpLhl8iihkO0nCTyRNzuXtcd7ubODpYB04IFy31JloiJgG0Uovu8ot8oxRzn7Nwtw==",
-      "dev": true,
-      "dependencies": {
-        "compare-func": "^2.0.0",
-        "lodash": "^4.17.15",
-        "q": "^1.5.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/conventional-changelog-writer": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-5.0.1.tgz",
@@ -9621,25 +10996,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/cosmiconfig-typescript-loader": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-2.0.1.tgz",
-      "integrity": "sha512-B9s6sX/omXq7I6gC6+YgLmrBFMJhPWew7ty/X5Tuwtd2zOSgWaUdXjkuVwbe3qqcdETo60+1nSVMekq//LIXVA==",
-      "dev": true,
-      "dependencies": {
-        "cosmiconfig": "^7",
-        "ts-node": "^10.8.0"
-      },
-      "engines": {
-        "node": ">=12",
-        "npm": ">=6"
-      },
-      "peerDependencies": {
-        "@types/node": "*",
-        "cosmiconfig": ">=7",
-        "typescript": ">=3"
-      }
-    },
     "node_modules/coveralls": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.1.1.tgz",
@@ -9658,12 +11014,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/create-require": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-      "dev": true
     },
     "node_modules/cross-fetch": {
       "version": "3.1.5",
@@ -9867,15 +11217,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/d3-voronoi/-/d3-voronoi-1.1.2.tgz",
       "integrity": "sha1-Fodmfo8TotFYyAwUgMWinLDYlzw="
-    },
-    "node_modules/dargs": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/dargs/-/dargs-7.0.0.tgz",
-      "integrity": "sha512-2iy1EkLdlBzQGvbweYRFxmFath8+K7+AKB0TlhHWkNuH+TmovaMH/Wp7V7R4u7f4SnX3OgLsU9t1NI9ioDnUpg==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/dashdash": {
       "version": "1.14.1",
@@ -10371,22 +11712,13 @@
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
     },
-    "node_modules/diff": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.3.1"
-      }
-    },
     "node_modules/diff-sequences": {
-      "version": "28.1.1",
-      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-28.1.1.tgz",
-      "integrity": "sha512-FU0iFaH/E23a+a718l8Qa/19bF9p06kgE0KipMOMadwa3SjnaElKzPaUC0vnibs6/B/9ni97s61mcejk8W1fQw==",
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-27.5.1.tgz",
+      "integrity": "sha512-k1gCAXAsNgLwEL+Y8Wvl+M6oEFj5bgazfZULpS5CneoPPXRaCCW7dm+q21Ky2VEE5X+VeRDBVg1Pcvvsr4TtNQ==",
       "dev": true,
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
     "node_modules/dir-glob": {
@@ -10974,9 +12306,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.18.0.tgz",
-      "integrity": "sha512-As1EfFMVk7Xc6/CvhssHUjsAQSkpfXvUGMFC3ce8JDe6WvqCgRrLOBQbVpsBFr1X1V+RACOadnzVvcUS5ni2bA==",
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.17.0.tgz",
+      "integrity": "sha512-gq0m0BTJfci60Fz4nczYxNAlED+sMcihltndR8t9t1evnU/azx53x3t2UHXC/uRjcbvRw/XctpaNygSTcQD+Iw==",
       "dev": true,
       "dependencies": {
         "@eslint/eslintrc": "^1.3.0",
@@ -11088,9 +12420,9 @@
       }
     },
     "node_modules/eslint-plugin-react-hooks": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz",
-      "integrity": "sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.5.0.tgz",
+      "integrity": "sha512-8k1gRt7D7h03kd+SAAlzXkQwWK22BnK6GKZG+FJA6BAGy22CFvl8kCIXKpVux0cCxMWDQUPqSok0LKaZ0aOcCw==",
       "dev": true,
       "engines": {
         "node": ">=10"
@@ -11673,6 +13005,157 @@
       },
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "node_modules/expect/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/expect/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/expect/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/expect/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/expect/node_modules/diff-sequences": {
+      "version": "28.1.1",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-28.1.1.tgz",
+      "integrity": "sha512-FU0iFaH/E23a+a718l8Qa/19bF9p06kgE0KipMOMadwa3SjnaElKzPaUC0vnibs6/B/9ni97s61mcejk8W1fQw==",
+      "dev": true,
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "node_modules/expect/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/expect/node_modules/jest-diff": {
+      "version": "28.1.1",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-28.1.1.tgz",
+      "integrity": "sha512-/MUUxeR2fHbqHoMMiffe/Afm+U8U4olFRJ0hiVG2lZatPJcnGxx292ustVu7bULhjV65IYMxRdploAKLbcrsyg==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "diff-sequences": "^28.1.1",
+        "jest-get-type": "^28.0.2",
+        "pretty-format": "^28.1.1"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "node_modules/expect/node_modules/jest-get-type": {
+      "version": "28.0.2",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-28.0.2.tgz",
+      "integrity": "sha512-ioj2w9/DxSYHfOm5lJKCdcAmPJzQXmbM/Url3rhlghrPvT3tt+7a/+oXc9azkKmLvoiXjtV83bEWqi+vs5nlPA==",
+      "dev": true,
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "node_modules/expect/node_modules/jest-matcher-utils": {
+      "version": "28.1.1",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-28.1.1.tgz",
+      "integrity": "sha512-NPJPRWrbmR2nAJ+1nmnfcKKzSwgfaciCCrYZzVnNoxVoyusYWIjkBMNvu0RHJe7dNj4hH3uZOPZsQA+xAYWqsw==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "jest-diff": "^28.1.1",
+        "jest-get-type": "^28.0.2",
+        "pretty-format": "^28.1.1"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "node_modules/expect/node_modules/pretty-format": {
+      "version": "28.1.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-28.1.1.tgz",
+      "integrity": "sha512-wwJbVTGFHeucr5Jw2bQ9P+VYHyLdAqedFLEkdQUVaBF/eiidDwH5OpilINq4mEfhbCjLnirt6HTTDhv1HaTIQw==",
+      "dev": true,
+      "dependencies": {
+        "@jest/schemas": "^28.0.2",
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "node_modules/expect/node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/expect/node_modules/react-is": {
+      "version": "18.1.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.1.0.tgz",
+      "integrity": "sha512-Fl7FuabXsJnV5Q1qIOQwx/sagGF18kogb4gpfcG4gjLBWO0WDiiz1ko/ExayuxE7InyQkBLkxRFG5oxY6Uu3Kg==",
+      "dev": true
+    },
+    "node_modules/expect/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/express": {
@@ -12640,1405 +14123,21 @@
       }
     },
     "node_modules/geostyler-openlayers-parser": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/geostyler-openlayers-parser/-/geostyler-openlayers-parser-2.5.0.tgz",
-      "integrity": "sha512-Uum/lDci8oqhBA/c0RZbD91aXP4ycjlsAp4ZoVAPDHT6Og0XyF5Tze8wg0Ux44CerE6W+m2DfWkOTAP+iaakzQ==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/geostyler-openlayers-parser/-/geostyler-openlayers-parser-3.0.2.tgz",
+      "integrity": "sha512-HiEjaobWR/UU/1NoSyobV85OIdoX7gxQaaTVQaFIyo7+8zN+RWRMf99chmY9PSasX8b5khN1LJfVL1ySUKwcsQ==",
       "dependencies": {
-        "@terrestris/ol-util": "^4.0.1",
-        "geostyler-style": "^4.0.0",
-        "lodash": "^4.17.15"
+        "geostyler-style": "^5.0.2",
+        "lodash": "^4.17.21"
       },
       "peerDependencies": {
         "ol": "^6.0.0"
       }
     },
-    "node_modules/geostyler-openlayers-parser/node_modules/@terrestris/ol-util": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/@terrestris/ol-util/-/ol-util-4.1.3.tgz",
-      "integrity": "sha512-vTS7rXxOcvTpXQzRGR6DVldEYcbFjADQ9/ArSKeq9yCmmY9wb3dkeGKw+rN/dltu6oZbaswjsUsBQe060kiMOQ==",
-      "dependencies": {
-        "@terrestris/base-util": "^1.0.0",
-        "@turf/turf": "^5.1.6",
-        "lodash": "^4.17.20",
-        "proj4": "^2.7.0",
-        "shpjs": "^3.6.3"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "ol": "~6.5"
-      }
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/@turf/along": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/along/-/along-5.1.5.tgz",
-      "integrity": "sha512-N7BN1xvj6VWMe3UpjQDdVI0j0oY/EZ0bWgOgBXc4DlJ411uEsKCh6iBv0b2MSxQ3YUXEez3oc5FcgO9eVSs7iQ==",
-      "dependencies": {
-        "@turf/bearing": "^5.1.5",
-        "@turf/destination": "^5.1.5",
-        "@turf/distance": "^5.1.5",
-        "@turf/helpers": "^5.1.5"
-      }
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/@turf/area": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/area/-/area-5.1.5.tgz",
-      "integrity": "sha512-lz16gqtvoz+j1jD9y3zj0Z5JnGNd3YfS0h+DQY1EcZymvi75Frm9i5YbEyth0RfxYZeOVufY7YIS3LXbJlI57g==",
-      "dependencies": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/meta": "^5.1.5"
-      }
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/@turf/bbox": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/bbox/-/bbox-5.1.5.tgz",
-      "integrity": "sha512-sYQU4fqsOYYJoD8UndC1n2hy8hV/lGIAmMLKWuzwmPUWqWOuSKWUcoRWDi9mGB0GvQQe/ow2IxZr8UaVaGz3sQ==",
-      "dependencies": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/meta": "^5.1.5"
-      }
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/@turf/bbox-clip": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/bbox-clip/-/bbox-clip-5.1.5.tgz",
-      "integrity": "sha512-KP64aoTvjcXxWHeM/Hs25vOQUBJgyJi7DlRVEoZofFJiR1kPnmDQrK7Xj+60lAk5cxuqzFnaPPxUk9Q+3v4p1Q==",
-      "dependencies": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "lineclip": "^1.1.5"
-      }
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/@turf/bbox-polygon": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/bbox-polygon/-/bbox-polygon-5.1.5.tgz",
-      "integrity": "sha512-PKVPF5LABFWZJud8KzzfesLGm5ihiwLbVa54HJjYySe6yqU/cr5q/qcN9TWptynOFhNktG1dr0KXVG0I2FZmfw==",
-      "dependencies": {
-        "@turf/helpers": "^5.1.5"
-      }
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/@turf/bearing": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/bearing/-/bearing-5.1.5.tgz",
-      "integrity": "sha512-PrvZuJjnXGseB8hUatIjsrK3tgD3wttyRnVYXTbSfXYJZzaOfHDMplgO4lxXQp7diraZhGhCdSlbMvRRXItbUQ==",
-      "dependencies": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
-      }
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/@turf/bezier-spline": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/bezier-spline/-/bezier-spline-5.1.5.tgz",
-      "integrity": "sha512-Y9NoComaGgFFFe9TWWE/cEMg2+EnBfU1R3112ec2wlx21ygDmFGXs4boOS71WM4ySwm/dbS3wxnbVxs4j68sKw==",
-      "dependencies": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
-      }
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/@turf/boolean-clockwise": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/boolean-clockwise/-/boolean-clockwise-5.1.5.tgz",
-      "integrity": "sha512-FqbmEEOJ4rU4/2t7FKx0HUWmjFEVqR+NJrFP7ymGSjja2SQ7Q91nnBihGuT+yuHHl6ElMjQ3ttsB/eTmyCycxA==",
-      "dependencies": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
-      }
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/@turf/boolean-contains": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/boolean-contains/-/boolean-contains-5.1.5.tgz",
-      "integrity": "sha512-x2HeEieeE9vBQrTdCuj4swnAXlpKbj9ChxMdDTV479c0m2gVmfea83ocmkj3w+9cvAaS63L8WqFyNVSmkwqljQ==",
-      "dependencies": {
-        "@turf/bbox": "^5.1.5",
-        "@turf/boolean-point-in-polygon": "^5.1.5",
-        "@turf/boolean-point-on-line": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
-      }
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/@turf/boolean-crosses": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/boolean-crosses/-/boolean-crosses-5.1.5.tgz",
-      "integrity": "sha512-odljvS7INr9k/8yXeyXQVry7GqEaChOmXawP0+SoTfGO3hgptiik59TLU/Yjn/SLFjE2Ul54Ga1jKFSL7vvH0Q==",
-      "dependencies": {
-        "@turf/boolean-point-in-polygon": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/line-intersect": "^5.1.5",
-        "@turf/polygon-to-line": "^5.1.5"
-      }
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/@turf/boolean-disjoint": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/@turf/boolean-disjoint/-/boolean-disjoint-5.1.6.tgz",
-      "integrity": "sha512-KHvUS6SBNYHBCLIJEJrg04pF5Oy+Fqn8V5G9U+9pti5vI9tyX7Ln2g7RSB7iJ1Cxsz8QAi6OukhXjEF2/8ZpGg==",
-      "dependencies": {
-        "@turf/boolean-point-in-polygon": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/line-intersect": "^5.1.5",
-        "@turf/meta": "^5.1.5",
-        "@turf/polygon-to-line": "^5.1.5"
-      }
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/@turf/boolean-equal": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/boolean-equal/-/boolean-equal-5.1.5.tgz",
-      "integrity": "sha512-QEMbhDPV+J8PlRkMlVg6m5oSLaYUpOx2VUhDDekQ73FlpnhFBKRIlidhvHtS6CYnEw8d+/zA3h8Z18B4W4mq9Q==",
-      "dependencies": {
-        "@turf/clean-coords": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "geojson-equality": "0.1.6"
-      }
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/@turf/boolean-overlap": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/boolean-overlap/-/boolean-overlap-5.1.5.tgz",
-      "integrity": "sha512-lizojgU559KME0G705YAgWVa0B3/tsWNobMzOEWDx/1rABWTojCY4uxw2rFxpOsP++s8JJHrGWXRLh1PbdAvRQ==",
-      "dependencies": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/line-intersect": "^5.1.5",
-        "@turf/line-overlap": "^5.1.5",
-        "@turf/meta": "^5.1.5",
-        "geojson-equality": "0.1.6"
-      }
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/@turf/boolean-parallel": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/boolean-parallel/-/boolean-parallel-5.1.5.tgz",
-      "integrity": "sha512-eeuGgDhnas3nJ22A/DD8aiH0kg9dSzbQChIMAqYRPGg3pWNK41aGAbeh5z0GO5N/EVFX1+ga5a0vsPmiRgQB5g==",
-      "dependencies": {
-        "@turf/clean-coords": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/line-segment": "^5.1.5",
-        "@turf/rhumb-bearing": "^5.1.5"
-      }
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/@turf/boolean-parallel/node_modules/@turf/rhumb-bearing": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/rhumb-bearing/-/rhumb-bearing-5.1.5.tgz",
-      "integrity": "sha512-zXTl2khjwf7mx2D1uPo5vgpGgP4sM2VrKDbJNKyulPu4TO4ELt8x7FsKyCBlRTzzQf284t/xnNcZOfUbkkd70g==",
-      "dependencies": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
-      }
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/@turf/boolean-point-in-polygon": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/boolean-point-in-polygon/-/boolean-point-in-polygon-5.1.5.tgz",
-      "integrity": "sha512-y+gbAhLmsAZH9uYhv+C68pu06mxsGIm3o7l0hzVkc/PXYdbkr+vKe7n7PfSN3xpVA3qoDLKLpCGOqeW8/ThaJA==",
-      "dependencies": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
-      }
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/@turf/boolean-point-on-line": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/boolean-point-on-line/-/boolean-point-on-line-5.1.5.tgz",
-      "integrity": "sha512-Zf4d28mckV2tYfLWf2iqxQ8eeLZqi2HGimM26mptf1OCEIwc1wfkKgLRRJXMu94Crvd/pJxjRAjoYGcGliP6Vg==",
-      "dependencies": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
-      }
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/@turf/boolean-within": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/boolean-within/-/boolean-within-5.1.5.tgz",
-      "integrity": "sha512-CNAtrvm4HiUwV/vhpGhvJzfhV9CN7VhPC5y4tTfQicK82fYY6ifPz0iaNpUOmshU6+TAot/fsVQVgDJ4t7HXcA==",
-      "dependencies": {
-        "@turf/bbox": "^5.1.5",
-        "@turf/boolean-point-in-polygon": "^5.1.5",
-        "@turf/boolean-point-on-line": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
-      }
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/@turf/buffer": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/buffer/-/buffer-5.1.5.tgz",
-      "integrity": "sha512-U3LU0HF/JNFUNabpB5ArpNG6yPla7yR5XPrZvzZRH48vvbr/N0rkSRI0tJFRWTz7ntugVm9X0OD9Y382NTJRhA==",
-      "dependencies": {
-        "@turf/bbox": "^5.1.5",
-        "@turf/center": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/meta": "^5.1.5",
-        "@turf/projection": "^5.1.5",
-        "d3-geo": "1.7.1",
-        "turf-jsts": "*"
-      }
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/@turf/buffer/node_modules/@turf/projection": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/projection/-/projection-5.1.5.tgz",
-      "integrity": "sha512-TWKJDFeEKQhI4Ce1+2PuOSDggn4cnMibqyUoCpIW+4KxUC1R88SE3/SYomqzwxMn00O09glHSycPkGD5JzHd8A==",
-      "dependencies": {
-        "@turf/clone": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/meta": "^5.1.5"
-      }
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/@turf/center": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/center/-/center-5.1.5.tgz",
-      "integrity": "sha512-Dy1TvAv2oHKFddZcWqlVsanxurfcZV1Mmb1E+7H7GRKI+fXZTfRjwCdbiZCbO/tPwxt8jWQHWdLHn8E9lecc3A==",
-      "dependencies": {
-        "@turf/bbox": "^5.1.5",
-        "@turf/helpers": "^5.1.5"
-      }
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/@turf/center-mean": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/center-mean/-/center-mean-5.1.5.tgz",
-      "integrity": "sha512-XdkBXzFUuyCqu5EPlBwgkv8FLA8pIGBnt7xy5cxxhxKOYLMrKqwMPPHPA84TjeQpNti0gH0CVuOk2r1f/Pp8iQ==",
-      "dependencies": {
-        "@turf/bbox": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/meta": "^5.1.5"
-      }
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/@turf/center-median": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/center-median/-/center-median-5.1.5.tgz",
-      "integrity": "sha512-M+O6bSNsIDKZ4utk/YzSOIg6W0isjLVWud+TCLWyrDCWTSERlSJlhOaVE1y7cObhG8nYBHvmszqZyoAY6nufQw==",
-      "dependencies": {
-        "@turf/center-mean": "^5.1.5",
-        "@turf/centroid": "^5.1.5",
-        "@turf/distance": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/meta": "^5.1.5"
-      }
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/@turf/center-of-mass": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/center-of-mass/-/center-of-mass-5.1.5.tgz",
-      "integrity": "sha512-UvI7q6GgW3afCVIDOyTRuLT54v9Xwv65Xudxh4FIT6w7HNU4KUBtTGnx0NuhODZcgvZgWVWVakhmIcHQTMjYYA==",
-      "dependencies": {
-        "@turf/centroid": "^5.1.5",
-        "@turf/convex": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/meta": "^5.1.5"
-      }
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/@turf/centroid": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/centroid/-/centroid-5.1.5.tgz",
-      "integrity": "sha512-0m9ZAZJB4YXLDxF2fWGqlE/g9Y68cebeWaRNOMN+e6Bti1fz0JKQuaEqJV+J8xOmODPHSMbZZ1SqSDVRgVHP2Q==",
-      "dependencies": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/meta": "^5.1.5"
-      }
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/@turf/circle": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/circle/-/circle-5.1.5.tgz",
-      "integrity": "sha512-CNaEtvp38Q+TSFJHdzdl5iYNjBFZRluRTFikIuEcennSeMJD60nP0dMubP58TR/QQn541eNDUyED90V4KuOjyQ==",
-      "dependencies": {
-        "@turf/destination": "^5.1.5",
-        "@turf/helpers": "^5.1.5"
-      }
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/@turf/clean-coords": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/clean-coords/-/clean-coords-5.1.5.tgz",
-      "integrity": "sha512-xd/iSM0McVUxbu81KCKDqirCsYkKk3EAwpDjYI8vIQ+eKf/MLSdteRcm3PB7wo2y6JcYp4dMGv2cr9IP7V+dXQ==",
-      "dependencies": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
-      }
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/@turf/clone": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/clone/-/clone-5.1.5.tgz",
-      "integrity": "sha512-//pITsQ8xUdcQ9pVb4JqXiSqG4dos5Q9N4sYFoWghX21tfOV2dhc5TGqYOhnHrQS7RiKQL1vQ48kIK34gQ5oRg==",
-      "dependencies": {
-        "@turf/helpers": "^5.1.5"
-      }
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/@turf/clusters": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/clusters/-/clusters-5.1.5.tgz",
-      "integrity": "sha512-+rQe+g66xfbIXz58tveXQCDdE9hzqRJtDVSw5xth92TvCcL4J60ZKN8mHNUSn1ZZvpUHtVPe4dYcbtk5bW8fXQ==",
-      "dependencies": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/meta": "^5.1.5"
-      }
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/@turf/clusters-dbscan": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/clusters-dbscan/-/clusters-dbscan-5.1.5.tgz",
-      "integrity": "sha512-X3qLLHJkwMuv+xdWQ08NtOc6BgeqCKKSAltyyAZ7iImE65f0C+sW024DfHSbTMsZVXBFst2Q6RQY8RVUf3QBeQ==",
-      "dependencies": {
-        "@turf/clone": "^5.1.5",
-        "@turf/distance": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/meta": "^5.1.5",
-        "density-clustering": "1.3.0"
-      }
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/@turf/clusters-kmeans": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/clusters-kmeans/-/clusters-kmeans-5.1.5.tgz",
-      "integrity": "sha512-W6raiv9+fRgmJxCvKrpSacbLXzh7beZUk0A1pjF82Fv3CFTrXAJbgAyIbdlmgXezYSXhOT5NMUugnbkUy2oBZw==",
-      "dependencies": {
-        "@turf/clone": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/meta": "^5.1.5",
-        "skmeans": "0.9.7"
-      }
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/@turf/collect": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/collect/-/collect-5.1.5.tgz",
-      "integrity": "sha512-voFWu6EGPcNuIbAp43yvGf2Ip4/q8TTeWhOSJ2yDEHgOfbAwrNUwUJCclEjcUVsnc7ypKNrFn3/8bmR9tI0NQg==",
-      "dependencies": {
-        "@turf/bbox": "^5.1.5",
-        "@turf/boolean-point-in-polygon": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "rbush": "^2.0.1"
-      }
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/@turf/combine": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/combine/-/combine-5.1.5.tgz",
-      "integrity": "sha512-/RqmfCvduHquINVyNmzKOcZtZjfaEHMhghgmj8MYnzepN3ro+E2QXoaQGGrQ7nChAvGgWPAvN8EveVSc1MvzPg==",
-      "dependencies": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/meta": "^5.1.5"
-      }
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/@turf/concave": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/concave/-/concave-5.1.5.tgz",
-      "integrity": "sha512-NvR5vmAunmgjEPjNzmvjLRvPcj7C6WuqCf+vu/aqyc4h2c1B/x399bDsSM64iFT+PYesFuoS1ZhJHWivXG8Y5g==",
-      "dependencies": {
-        "@turf/clone": "^5.1.5",
-        "@turf/distance": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/meta": "^5.1.5",
-        "@turf/tin": "^5.1.5",
-        "topojson-client": "3.x",
-        "topojson-server": "3.x"
-      }
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/@turf/convex": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/convex/-/convex-5.1.5.tgz",
-      "integrity": "sha512-ZEk4kIAoYR/mjO3C8rMe2StgmwhdwmbxVvNxg3udeahe2m0ZzbfkRC4HiJAaBgfR4TLJUAEewynESReTPwASBQ==",
-      "dependencies": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/meta": "^5.1.5",
-        "concaveman": "*"
-      }
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/@turf/destination": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/destination/-/destination-5.1.5.tgz",
-      "integrity": "sha512-EWwZnd4wxUO9d8UWzJt88jQlFf6W/6SE1930MMzzIR9o+RfqhrS/BL1eUDrg5I5drsymf6PZsK0j/V0q6jqkFQ==",
-      "dependencies": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
-      }
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/@turf/difference": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/difference/-/difference-5.1.5.tgz",
-      "integrity": "sha512-hIjiUHS8WiDfnmADQrhh6QcXWc3zNtjIpPQ5g/2NZ3k1mjnOdmGBVObkSJG4WEUNqyj3PKlsZ8W9xnSu+lLF1Q==",
-      "dependencies": {
-        "@turf/area": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/meta": "^5.1.5",
-        "turf-jsts": "*"
-      }
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/@turf/dissolve": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/dissolve/-/dissolve-5.1.5.tgz",
-      "integrity": "sha512-YcQgyp7pvhyZHCmbqqItVH6vHs43R9N0jzP/LnAG03oMiY4wves/BO1du6VDDbnJSXeRKf1afmY9tRGKYrm9ag==",
-      "dependencies": {
-        "@turf/boolean-overlap": "^5.1.5",
-        "@turf/clone": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/line-intersect": "^5.1.5",
-        "@turf/meta": "^5.1.5",
-        "@turf/union": "^5.1.5",
-        "geojson-rbush": "2.1.0",
-        "get-closest": "*"
-      }
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/@turf/distance": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/distance/-/distance-5.1.5.tgz",
-      "integrity": "sha512-sYCAgYZ2MjNKMtx17EijHlK9qHwpA0MuuQWbR4P30LTCl52UlG/reBfV899wKyF3HuDL9ux78IbILwOfeQ4zgA==",
-      "dependencies": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
-      }
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/@turf/ellipse": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/ellipse/-/ellipse-5.1.5.tgz",
-      "integrity": "sha512-oVTzEyDOi3d9isgB7Ah+YiOoUKB1eHMtMDXVl1oT+vC/T+6KR2aq+HjjbF11A0cjuh3VhjSWUZaS+2TYY0pu0w==",
-      "dependencies": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/rhumb-destination": "^5.1.5",
-        "@turf/transform-rotate": "^5.1.5"
-      }
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/@turf/envelope": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/envelope/-/envelope-5.1.5.tgz",
-      "integrity": "sha512-Mxl5A2euAxq3RZVN65/MVyaO91kzGU8MJXfegPdep6SN4bONDadEp0olwW5qSRf2U3cJ8Jppl089X6AeifD3IA==",
-      "dependencies": {
-        "@turf/bbox": "^5.1.5",
-        "@turf/bbox-polygon": "^5.1.5",
-        "@turf/helpers": "^5.1.5"
-      }
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/@turf/explode": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/explode/-/explode-5.1.5.tgz",
-      "integrity": "sha512-v/hC9DB9RKRW9/ZjnKoQelIp08JNa5wew0889465s//tfgY8+JEGkSGMag2L2NnVARWmzI/vlLgMK36qwkyDIA==",
-      "dependencies": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/meta": "^5.1.5"
-      }
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/@turf/flatten": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/flatten/-/flatten-5.1.5.tgz",
-      "integrity": "sha512-aagHz5tjHmOtb8eMb5fd10+HJwdlhkhsPql1vRXQNnpv0Q9xL/4SsbvXZ6lPqkRAjiZuy087mvaz+ERml76/jg==",
-      "dependencies": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/meta": "^5.1.5"
-      }
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/@turf/flip": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/flip/-/flip-5.1.5.tgz",
-      "integrity": "sha512-7+IYM3QQAkV4co3wjEmM726/OkXqUCCHWWyIqrI9hiK+LR628qkoqP1hk6rQ4vZJrAYuvSlK+FZnr24OtgY0cw==",
-      "dependencies": {
-        "@turf/clone": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/meta": "^5.1.5"
-      }
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/@turf/great-circle": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/great-circle/-/great-circle-5.1.5.tgz",
-      "integrity": "sha512-k6FWwlt+YCQoD5VS1NybQjriNL7apYHO+tm2HbIFQ85blPUX4IyLppHIFevfD/k+K2bJqhFCze8JNVMBwdrzVw==",
-      "dependencies": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
-      }
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/@turf/helpers": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-5.1.5.tgz",
-      "integrity": "sha512-/lF+JR+qNDHZ8bF9d+Cp58nxtZWJ3sqFe6n3u3Vpj+/0cqkjk4nXKYBSY0azm+GIYB5mWKxUXvuP/m0ZnKj1bw=="
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/@turf/hex-grid": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/hex-grid/-/hex-grid-5.1.5.tgz",
-      "integrity": "sha512-rwDL+DlUyxDNL1aVHIKKCmrt1131ZULF3irExYIO/um6/SwRzsBw+522/RcxD/mg/Shtrpozb6bz8aJJ/3RXHA==",
-      "dependencies": {
-        "@turf/distance": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/intersect": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
-      }
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/@turf/interpolate": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/interpolate/-/interpolate-5.1.5.tgz",
-      "integrity": "sha512-LfmvtIUWc3NVkqPkX6j3CAIjF7y1LAZqfDd+2Ii+0fN7XOOGMWcb1uiTTAb8zDQjhTsygcUYgaz6mMYDCWYKPg==",
-      "dependencies": {
-        "@turf/bbox": "^5.1.5",
-        "@turf/centroid": "^5.1.5",
-        "@turf/clone": "^5.1.5",
-        "@turf/distance": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/hex-grid": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/meta": "^5.1.5",
-        "@turf/point-grid": "^5.1.5",
-        "@turf/square-grid": "^5.1.5",
-        "@turf/triangle-grid": "^5.1.5"
-      }
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/@turf/intersect": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/@turf/intersect/-/intersect-5.1.6.tgz",
-      "integrity": "sha512-KXyNv/GXdoGAOy03qZF53rgtXC2tNhF/4jLwTKiVRrBQH6kcEpipGStdJ+QkYIlarQPa8f7I9UlVAB19et4MfQ==",
-      "dependencies": {
-        "@turf/clean-coords": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/truncate": "^5.1.5",
-        "turf-jsts": "*"
-      }
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/@turf/invariant": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-5.1.5.tgz",
-      "integrity": "sha512-4elbC8GVQ8XxrnWLWpFFXTK3qnzIYzIVtSkJrY9eefA8WNZzwcwT3WGFY3xte4BB48o5oEjihjoJharWRis78w==",
-      "dependencies": {
-        "@turf/helpers": "^5.1.5"
-      }
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/@turf/isobands": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/isobands/-/isobands-5.1.5.tgz",
-      "integrity": "sha512-0n3NPfDYQyqjOch00I4hVCCqjKn9Sm+a8qlWOKbkuhmGa9dCDzsu2bZL0ahT+LjwlS4c8/owQXqe6KE2GWqT1Q==",
-      "dependencies": {
-        "@turf/area": "^5.1.5",
-        "@turf/bbox": "^5.1.5",
-        "@turf/boolean-point-in-polygon": "^5.1.5",
-        "@turf/explode": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/meta": "^5.1.5"
-      }
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/@turf/isolines": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/isolines/-/isolines-5.1.5.tgz",
-      "integrity": "sha512-Ehn5pJmiq4hAn2+2jPB2rLt3iF8DDp8zciw9z2pAt5IGVRU/K+x3z4aYG5ra5vbFB/E4G3aHr/X4QPIb9LCJtA==",
-      "dependencies": {
-        "@turf/bbox": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/meta": "^5.1.5"
-      }
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/@turf/kinks": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/kinks/-/kinks-5.1.5.tgz",
-      "integrity": "sha512-G38sC8/+MYqQpVocT3XahhV42cqEAVJAZwUND9YOfKJZfjUn7FKmWhPURs5py95me48UuI0C0jLLAMzBkUc2nQ==",
-      "dependencies": {
-        "@turf/helpers": "^5.1.5"
-      }
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/@turf/length": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/length/-/length-5.1.5.tgz",
-      "integrity": "sha512-0ryx68h512wCoNfwyksLdabxEfwkGNTPg61/QiY+QfGFUOUNhHbP+QimViFpwF5hyX7qmroaSHVclLUqyLGRbg==",
-      "dependencies": {
-        "@turf/distance": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/meta": "^5.1.5"
-      }
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/@turf/line-arc": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/line-arc/-/line-arc-5.1.5.tgz",
-      "integrity": "sha512-Kz5RX/qRIHVrGNqF3BRlD3ACuuCr0G5lpaVyPjNvN+vA7Q4bEDyWIYeqm3DdTn7X2MXitpTNgr2uvX4WoUy4yA==",
-      "dependencies": {
-        "@turf/circle": "^5.1.5",
-        "@turf/destination": "^5.1.5",
-        "@turf/helpers": "^5.1.5"
-      }
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/@turf/line-chunk": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/line-chunk/-/line-chunk-5.1.5.tgz",
-      "integrity": "sha512-mKvTUMahnb3EsYUMI8tQmygsliQkgQ1FZAY915zoTrm+WV246loa+84+h7i5d8W2O8gGJWuY7jQTpM7toTeL5w==",
-      "dependencies": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/length": "^5.1.5",
-        "@turf/line-slice-along": "^5.1.5",
-        "@turf/meta": "^5.1.5"
-      }
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/@turf/line-intersect": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/line-intersect/-/line-intersect-5.1.5.tgz",
-      "integrity": "sha512-9DajJbHhJauLI2qVMnqZ7SeFsinFroVICOSUheODk7j5teuwNABuZ2Z6WmKATzEsPkEJ1iVykqB+F9vGMVKB6g==",
-      "dependencies": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/line-segment": "^5.1.5",
-        "@turf/meta": "^5.1.5",
-        "geojson-rbush": "2.1.0"
-      }
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/@turf/line-offset": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/line-offset/-/line-offset-5.1.5.tgz",
-      "integrity": "sha512-VccGDgFfBSiCTqrHdQgxD7Rs9lnJmDOJ5gqQRculKPsCNUyRFMYIZud7l2dTs83g66evfOwkZCrTxtSoBY3Jxg==",
-      "dependencies": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/meta": "^5.1.5"
-      }
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/@turf/line-overlap": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/line-overlap/-/line-overlap-5.1.5.tgz",
-      "integrity": "sha512-hMz3XARXEbfGwLF9WXyErqQjzhZYMKvGQwlPGOoth+2o9Uga9mfWfevduJvozJAE1MKxtFttMjIXMzcShW3O8A==",
-      "dependencies": {
-        "@turf/boolean-point-on-line": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/line-segment": "^5.1.5",
-        "@turf/meta": "^5.1.5",
-        "@turf/nearest-point-on-line": "^5.1.5",
-        "geojson-rbush": "2.1.0"
-      }
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/@turf/line-segment": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/line-segment/-/line-segment-5.1.5.tgz",
-      "integrity": "sha512-wIrRtWuLuLXhnSkqdVG1SDayTU0/CmZf+a+BBhEf0vFIsAedJnrY3a2cbCEvtfuk6ZsAbhOi7/kYiaR/F+rEzg==",
-      "dependencies": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/meta": "^5.1.5"
-      }
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/@turf/line-slice": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/line-slice/-/line-slice-5.1.5.tgz",
-      "integrity": "sha512-Fo+CuD+fj6T702BofHO+rgiXUgzCk0iO2JqMPtttMtgzfKkVTUOQoauMNS1LNNaG/7n/TfKGh5gRCEDRNaNwYA==",
-      "dependencies": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/nearest-point-on-line": "^5.1.5"
-      }
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/@turf/line-slice-along": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/line-slice-along/-/line-slice-along-5.1.5.tgz",
-      "integrity": "sha512-yKvSDtULztLtlPIMowm9l8pS6XLAEpCPmrARZA0sIWFX8XrcSzISBaXZbiMMzg3nxQJMXfGIgWDk10B7+J8Tqw==",
-      "dependencies": {
-        "@turf/bearing": "^5.1.5",
-        "@turf/destination": "^5.1.5",
-        "@turf/distance": "^5.1.5",
-        "@turf/helpers": "^5.1.5"
-      }
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/@turf/line-split": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/line-split/-/line-split-5.1.5.tgz",
-      "integrity": "sha512-gtUUBwZL3hcSu5MpqHTl68hgAJBNHcr1APDj8E5o6iX5xFX+wvl4ohQXyMs5HOATCI8Iy83wLuggcY6maNw7LQ==",
-      "dependencies": {
-        "@turf/bbox": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/line-intersect": "^5.1.5",
-        "@turf/line-segment": "^5.1.5",
-        "@turf/meta": "^5.1.5",
-        "@turf/nearest-point-on-line": "^5.1.5",
-        "@turf/square": "^5.1.5",
-        "@turf/truncate": "^5.1.5",
-        "geojson-rbush": "2.1.0"
-      }
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/@turf/line-to-polygon": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/line-to-polygon/-/line-to-polygon-5.1.5.tgz",
-      "integrity": "sha512-hGiDAPd6j986kZZLDgEAkVD7O6DmIqHQliBedspoKperPJOUJJzdzSnF6OAWSsxY+j8fWtQnIo5TTqdO/KfamA==",
-      "dependencies": {
-        "@turf/bbox": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
-      }
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/@turf/mask": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/mask/-/mask-5.1.5.tgz",
-      "integrity": "sha512-2eOuxA3ammZAGsjlsy/H7IpeJxjl3hrgkcKM6kTKRJGft4QyKwCxqQP7RN5j0zIYvAurgs9JOLe/dpd5sE5HXQ==",
-      "dependencies": {
-        "@turf/bbox": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/meta": "^5.1.5",
-        "@turf/union": "^5.1.5",
-        "rbush": "^2.0.1"
-      }
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/@turf/meta": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-5.1.6.tgz",
-      "integrity": "sha512-lv+6LCgoc3LVitQZ4TScN/8a/fcctq8bIoxBTMJVq4aU8xoHeY1851Dq8MCU37EzbH33utkx8/jENaQP+aeElg==",
-      "dependencies": {
-        "@turf/helpers": "^5.1.5"
-      }
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/@turf/midpoint": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/midpoint/-/midpoint-5.1.5.tgz",
-      "integrity": "sha512-0pDQAKHyK/zxlvUx3XNxwvqftf4sV32QxnHfqSs4AXaODUGUbPhzAD7aXgDScBeUOVLwpAzFRQfitUvUMTGC6A==",
-      "dependencies": {
-        "@turf/bearing": "^5.1.5",
-        "@turf/destination": "^5.1.5",
-        "@turf/distance": "^5.1.5",
-        "@turf/helpers": "^5.1.5"
-      }
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/@turf/nearest-point": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/nearest-point/-/nearest-point-5.1.5.tgz",
-      "integrity": "sha512-tZQXI7OE7keNKK4OvYOJ5gervCEuu2pJ6psu59QW9yhe2Di3Gl+HAdLvVa6RZ8s5Fndr3u0JWKsmxve3fCxc9g==",
-      "dependencies": {
-        "@turf/clone": "^5.1.5",
-        "@turf/distance": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/meta": "^5.1.5"
-      }
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/@turf/nearest-point-on-line": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/nearest-point-on-line/-/nearest-point-on-line-5.1.5.tgz",
-      "integrity": "sha512-qT7BLTwToo8cq0oNoz921oLlRPJamyRg/rZgll+kNBadyDPmJI4W66riHcpM9RQcAJ6TPvDveIIBeGJH7iG88w==",
-      "dependencies": {
-        "@turf/bearing": "^5.1.5",
-        "@turf/destination": "^5.1.5",
-        "@turf/distance": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/line-intersect": "^5.1.5",
-        "@turf/meta": "^5.1.5"
-      }
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/@turf/nearest-point-to-line": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/@turf/nearest-point-to-line/-/nearest-point-to-line-5.1.6.tgz",
-      "integrity": "sha512-ZSvDIEiHhifn/vNwLXZI/E8xmEz5yBPqfUR7BVHRZrB1cP7jLhKZvkbidjG//uW8Fr1Ulc+PFOXczLspIcx/lw==",
-      "dependencies": {
-        "@turf/helpers": "6.x",
-        "@turf/invariant": "6.x",
-        "@turf/meta": "6.x",
-        "@turf/point-to-line-distance": "^5.1.5",
-        "object-assign": "*"
-      }
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/@turf/nearest-point-to-line/node_modules/@turf/helpers": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.5.0.tgz",
-      "integrity": "sha512-VbI1dV5bLFzohYYdgqwikdMVpe7pJ9X3E+dlr425wa2/sMJqYDhTO++ec38/pcPvPE6oD9WEEeU3Xu3gza+VPw==",
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/@turf/nearest-point-to-line/node_modules/@turf/invariant": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-6.5.0.tgz",
-      "integrity": "sha512-Wv8PRNCtPD31UVbdJE/KVAWKe7l6US+lJItRR/HOEW3eh+U/JwRCSUl/KZ7bmjM/C+zLNoreM2TU6OoLACs4eg==",
-      "dependencies": {
-        "@turf/helpers": "^6.5.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/@turf/nearest-point-to-line/node_modules/@turf/meta": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-6.5.0.tgz",
-      "integrity": "sha512-RrArvtsV0vdsCBegoBtOalgdSOfkBrTJ07VkpiCnq/491W67hnMWmDu7e6Ztw0C3WldRYTXkg3SumfdzZxLBHA==",
-      "dependencies": {
-        "@turf/helpers": "^6.5.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/@turf/planepoint": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/planepoint/-/planepoint-5.1.5.tgz",
-      "integrity": "sha512-+Tp+SQ0Db2tqwLbxfXJPysT9IxcOHSMIin2dJb/j3Qn5+g0LRus6rczZl6dWNAIjqBPMawj/V/dZhMu6Q9O9wA==",
-      "dependencies": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
-      }
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/@turf/point-grid": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/point-grid/-/point-grid-5.1.5.tgz",
-      "integrity": "sha512-4ibozguP9YJ297Q7i9e8/ypGSycvt1re2jrPXTxeuZ4/L/NE5B1nOBLG+tw121nMjD+S+v2RWOtqD+FZ3Ga+ew==",
-      "dependencies": {
-        "@turf/boolean-within": "^5.1.5",
-        "@turf/distance": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
-      }
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/@turf/point-on-feature": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/point-on-feature/-/point-on-feature-5.1.5.tgz",
-      "integrity": "sha512-NTcpe5xZjybRh0aTL+7td1cm0s49GGbAt5u8Cdec4W9ix2PsehRcLUbmQIQsODN2kiVyUSpnhECIpsyN5MjX7A==",
-      "dependencies": {
-        "@turf/boolean-point-in-polygon": "^5.1.5",
-        "@turf/center": "^5.1.5",
-        "@turf/explode": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/nearest-point": "^5.1.5"
-      }
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/@turf/point-to-line-distance": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/@turf/point-to-line-distance/-/point-to-line-distance-5.1.6.tgz",
-      "integrity": "sha512-PE3hiTeeDEi4ZLPtI8XAzFYW9nHo1EVsZGm/4ZVV8jo39d3X1oLVHxY3e1PkCmWwRapXy4QLqvnTQ7nU4wspNw==",
-      "dependencies": {
-        "@turf/bearing": "6.x",
-        "@turf/distance": "6.x",
-        "@turf/helpers": "6.x",
-        "@turf/invariant": "6.x",
-        "@turf/meta": "6.x",
-        "@turf/projection": "6.x",
-        "@turf/rhumb-bearing": "6.x",
-        "@turf/rhumb-distance": "6.x"
-      }
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/@turf/point-to-line-distance/node_modules/@turf/bearing": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@turf/bearing/-/bearing-6.5.0.tgz",
-      "integrity": "sha512-dxINYhIEMzgDOztyMZc20I7ssYVNEpSv04VbMo5YPQsqa80KO3TFvbuCahMsCAW5z8Tncc8dwBlEFrmRjJG33A==",
-      "dependencies": {
-        "@turf/helpers": "^6.5.0",
-        "@turf/invariant": "^6.5.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/@turf/point-to-line-distance/node_modules/@turf/distance": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@turf/distance/-/distance-6.5.0.tgz",
-      "integrity": "sha512-xzykSLfoURec5qvQJcfifw/1mJa+5UwByZZ5TZ8iaqjGYN0vomhV9aiSLeYdUGtYRESZ+DYC/OzY+4RclZYgMg==",
-      "dependencies": {
-        "@turf/helpers": "^6.5.0",
-        "@turf/invariant": "^6.5.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/@turf/point-to-line-distance/node_modules/@turf/helpers": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.5.0.tgz",
-      "integrity": "sha512-VbI1dV5bLFzohYYdgqwikdMVpe7pJ9X3E+dlr425wa2/sMJqYDhTO++ec38/pcPvPE6oD9WEEeU3Xu3gza+VPw==",
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/@turf/point-to-line-distance/node_modules/@turf/invariant": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-6.5.0.tgz",
-      "integrity": "sha512-Wv8PRNCtPD31UVbdJE/KVAWKe7l6US+lJItRR/HOEW3eh+U/JwRCSUl/KZ7bmjM/C+zLNoreM2TU6OoLACs4eg==",
-      "dependencies": {
-        "@turf/helpers": "^6.5.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/@turf/point-to-line-distance/node_modules/@turf/meta": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-6.5.0.tgz",
-      "integrity": "sha512-RrArvtsV0vdsCBegoBtOalgdSOfkBrTJ07VkpiCnq/491W67hnMWmDu7e6Ztw0C3WldRYTXkg3SumfdzZxLBHA==",
-      "dependencies": {
-        "@turf/helpers": "^6.5.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/@turf/points-within-polygon": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/points-within-polygon/-/points-within-polygon-5.1.5.tgz",
-      "integrity": "sha512-nexe2AHVOY8wEBvs+CYSOp10NyOCkyZ1gkhIfsx0mzU8LPYBxD9ctjlKveheKh4AAldLcFupd/gSCBTKF1JS7A==",
-      "dependencies": {
-        "@turf/boolean-point-in-polygon": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/meta": "^5.1.5"
-      }
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/@turf/polygon-tangents": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/polygon-tangents/-/polygon-tangents-5.1.5.tgz",
-      "integrity": "sha512-uoZfKvFhl6rf0+CDWucru9fZ4mJB5Nsg37TS/7emrzjoVxXyOdxc/s1HFCjcKflMue7MjU/gT6AitJyrvdztDg==",
-      "dependencies": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
-      }
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/@turf/polygon-to-line": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/polygon-to-line/-/polygon-to-line-5.1.5.tgz",
-      "integrity": "sha512-kVo0owPqyccy5+qZGvaxGvMsYkgueKE2OOgX2UV/HyrXF3uI3TomK1txjApqeFsLvwuSANxesvVbYLrYiIwvGw==",
-      "dependencies": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
-      }
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/@turf/polygonize": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/polygonize/-/polygonize-5.1.5.tgz",
-      "integrity": "sha512-qzhtuzoOhldqZHm+ZPsWAs9nDpnkcDfsr+I0twmBF+wjAmo0HKiy9++sRQ4kEePpdwbMpF07D/NdZqYdmOJkGQ==",
-      "dependencies": {
-        "@turf/boolean-point-in-polygon": "^5.1.5",
-        "@turf/envelope": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/meta": "^5.1.5"
-      }
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/@turf/random": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/random/-/random-5.1.5.tgz",
-      "integrity": "sha512-oitpBwEb6YXqoUkIAOVMK+vrTPxUi2rqITmtTa/FBHr6J8TDwMWq6bufE3Gmgjxsss50O2ITJunOksxrouWGDQ==",
-      "dependencies": {
-        "@turf/helpers": "^5.1.5"
-      }
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/@turf/rewind": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/rewind/-/rewind-5.1.5.tgz",
-      "integrity": "sha512-Gdem7JXNu+G4hMllQHXRFRihJl3+pNl7qY+l4qhQFxq+hiU1cQoVFnyoleIqWKIrdK/i2YubaSwc3SCM7N5mMw==",
-      "dependencies": {
-        "@turf/boolean-clockwise": "^5.1.5",
-        "@turf/clone": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/meta": "^5.1.5"
-      }
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/@turf/rhumb-destination": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/rhumb-destination/-/rhumb-destination-5.1.5.tgz",
-      "integrity": "sha512-FdDUCSRfRAfsRmUaWjc76Wk32QYFJ6ckmSt6Ls6nEczO6eg/RgH1atF8CIYwR5ifl0Sk1rQzKiOSbpCyvVwQtw==",
-      "dependencies": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
-      }
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/@turf/sample": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/sample/-/sample-5.1.5.tgz",
-      "integrity": "sha512-EJE8yx+5x7rXejTzwBdOKpvT4tOCS0jwYJfycyTVDuLUSh2rETeYdjy7EeJbofnxm9CRPXqWQMPWIBKWxNTjow==",
-      "dependencies": {
-        "@turf/helpers": "^5.1.5"
-      }
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/@turf/sector": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/sector/-/sector-5.1.5.tgz",
-      "integrity": "sha512-dnWVifL3xWTqPPs8mfbbV9muDimNJtxRk4ogrkOLEDQ9ZZ1ALQMtQdYrg7kI3iC+L+LscV37tl+E8bayWyX8YA==",
-      "dependencies": {
-        "@turf/circle": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/line-arc": "^5.1.5",
-        "@turf/meta": "^5.1.5"
-      }
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/@turf/shortest-path": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/shortest-path/-/shortest-path-5.1.5.tgz",
-      "integrity": "sha512-ZGC8kSBj02GKWiI56Z5FNdrZ+fS0xyeOUNrPJWzudAlrv9wKGaRuWoIVRLGBu0j0OuO1HCwggic2c6WV/AhP0A==",
-      "dependencies": {
-        "@turf/bbox": "^5.1.5",
-        "@turf/bbox-polygon": "^5.1.5",
-        "@turf/boolean-point-in-polygon": "^5.1.5",
-        "@turf/clean-coords": "^5.1.5",
-        "@turf/distance": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/meta": "^5.1.5",
-        "@turf/transform-scale": "^5.1.5"
-      }
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/@turf/simplify": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/simplify/-/simplify-5.1.5.tgz",
-      "integrity": "sha512-IuBXEYdGSxbDOK3v949ajaPvs6NhjhTCTbKA6mSGuVbwGS7gzAuRiPSG4K/MvCVuQy3PKpkPcUGD+Uvt2Ov2PQ==",
-      "dependencies": {
-        "@turf/clean-coords": "^5.1.5",
-        "@turf/clone": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/meta": "^5.1.5"
-      }
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/@turf/square": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/square/-/square-5.1.5.tgz",
-      "integrity": "sha512-GgP2le9ksoW6vsVef5wFkjmWQiLPTJvcjGXqmoGWT4oMwDpvTJVQ91RBLs8qQbI4KACCQevz94N69klk3ah30Q==",
-      "dependencies": {
-        "@turf/distance": "^5.1.5",
-        "@turf/helpers": "^5.1.5"
-      }
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/@turf/square-grid": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/square-grid/-/square-grid-5.1.5.tgz",
-      "integrity": "sha512-/pusEL4FmOwNWLcZfIXUyqUe0fOdkfaLO4wLhDlg/ZL1jWr/wZjhVlMU0tQ27kVN6dJTvlzNc9e0JWNw6yt2eQ==",
-      "dependencies": {
-        "@turf/boolean-contains": "^5.1.5",
-        "@turf/boolean-overlap": "^5.1.5",
-        "@turf/distance": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/intersect": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
-      }
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/@turf/standard-deviational-ellipse": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/standard-deviational-ellipse/-/standard-deviational-ellipse-5.1.5.tgz",
-      "integrity": "sha512-GOaxGKeeJAXV1H3Zz2fjQ5XeSbMKz1OkFRlTDBUipiAawe/9qTCF55L87I2ZPnO80B5BaaIT+AN2n0lMcAklzA==",
-      "dependencies": {
-        "@turf/center-mean": "^5.1.5",
-        "@turf/ellipse": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/meta": "^5.1.5",
-        "@turf/points-within-polygon": "^5.1.5"
-      }
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/@turf/tag": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/tag/-/tag-5.1.5.tgz",
-      "integrity": "sha512-XI3QFpva6tEsRnzFe1tJGdAAWlzjnXZPfJ9EKShTxEW8ZgPzm92b2odjiSAt2KuQusK82ltNfdw5Frlna5xGYQ==",
-      "dependencies": {
-        "@turf/boolean-point-in-polygon": "^5.1.5",
-        "@turf/clone": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/meta": "^5.1.5"
-      }
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/@turf/tesselate": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/tesselate/-/tesselate-5.1.5.tgz",
-      "integrity": "sha512-Rs/jAij26bcU4OzvFXkWDase1G3kSwyuuKZPFU0t7OmJu7eQJOR12WOZLGcVxd5oBlklo4xPE4EBQUqpQUsQgg==",
-      "dependencies": {
-        "@turf/helpers": "^5.1.5",
-        "earcut": "^2.0.0"
-      }
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/@turf/tin": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/tin/-/tin-5.1.5.tgz",
-      "integrity": "sha512-lDyCTYKoThBIKmkBxBMupqEpFbvTDAYuZIs8qrWnmux2vntSb8OFGi7ZbGPC6apS2hdVwZZae3YB88Tp+Fg+xw==",
-      "dependencies": {
-        "@turf/helpers": "^5.1.5"
-      }
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/@turf/transform-rotate": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/transform-rotate/-/transform-rotate-5.1.5.tgz",
-      "integrity": "sha512-3QKckeHKPXu5O5vEuT+nkszGDI6aknDD06ePb00+6H2oA7MZj7nj+fVQIJLs41MRb76IyKr4n5NvuKZU6idESA==",
-      "dependencies": {
-        "@turf/centroid": "^5.1.5",
-        "@turf/clone": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/meta": "^5.1.5",
-        "@turf/rhumb-bearing": "^5.1.5",
-        "@turf/rhumb-destination": "^5.1.5",
-        "@turf/rhumb-distance": "^5.1.5"
-      }
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/@turf/transform-rotate/node_modules/@turf/rhumb-bearing": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/rhumb-bearing/-/rhumb-bearing-5.1.5.tgz",
-      "integrity": "sha512-zXTl2khjwf7mx2D1uPo5vgpGgP4sM2VrKDbJNKyulPu4TO4ELt8x7FsKyCBlRTzzQf284t/xnNcZOfUbkkd70g==",
-      "dependencies": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
-      }
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/@turf/transform-rotate/node_modules/@turf/rhumb-distance": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/rhumb-distance/-/rhumb-distance-5.1.5.tgz",
-      "integrity": "sha512-AGA/ky5/BJJZtzQqafy2GvJfcUXSzCCrPFp8sDRPSKBoUN4gMBHN15ijDWYYLFoWFFj0urcauVx7chQlHZ/Qfw==",
-      "dependencies": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
-      }
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/@turf/transform-scale": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/transform-scale/-/transform-scale-5.1.5.tgz",
-      "integrity": "sha512-t1fCZX29ONA7DJiqCKA4YZy0+hCzhppWNOZhglBUv9vKHsWCFYZDUKfFInciaypUInsZyvm8eKxxixBVPdPGsw==",
-      "dependencies": {
-        "@turf/bbox": "^5.1.5",
-        "@turf/center": "^5.1.5",
-        "@turf/centroid": "^5.1.5",
-        "@turf/clone": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/meta": "^5.1.5",
-        "@turf/rhumb-bearing": "^5.1.5",
-        "@turf/rhumb-destination": "^5.1.5",
-        "@turf/rhumb-distance": "^5.1.5"
-      }
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/@turf/transform-scale/node_modules/@turf/rhumb-bearing": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/rhumb-bearing/-/rhumb-bearing-5.1.5.tgz",
-      "integrity": "sha512-zXTl2khjwf7mx2D1uPo5vgpGgP4sM2VrKDbJNKyulPu4TO4ELt8x7FsKyCBlRTzzQf284t/xnNcZOfUbkkd70g==",
-      "dependencies": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
-      }
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/@turf/transform-scale/node_modules/@turf/rhumb-distance": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/rhumb-distance/-/rhumb-distance-5.1.5.tgz",
-      "integrity": "sha512-AGA/ky5/BJJZtzQqafy2GvJfcUXSzCCrPFp8sDRPSKBoUN4gMBHN15ijDWYYLFoWFFj0urcauVx7chQlHZ/Qfw==",
-      "dependencies": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
-      }
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/@turf/transform-translate": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/transform-translate/-/transform-translate-5.1.5.tgz",
-      "integrity": "sha512-GdLFp7I7198oRQt311B8EjiqHupndeMSQ3Zclzki5L/niUrb1ptOIpo+mxSidSy03m+1Q5ylWlENroI1WBcQ3Q==",
-      "dependencies": {
-        "@turf/clone": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/meta": "^5.1.5",
-        "@turf/rhumb-destination": "^5.1.5"
-      }
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/@turf/triangle-grid": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/triangle-grid/-/triangle-grid-5.1.5.tgz",
-      "integrity": "sha512-jmCRcynI80xsVqd+0rv0YxP6mvZn4BAaJv8dwthg2T3WfHB9OD+rNUMohMuUY8HmI0zRT3s/Ypdy2Cdri9u/tw==",
-      "dependencies": {
-        "@turf/distance": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/intersect": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
-      }
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/@turf/truncate": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/truncate/-/truncate-5.1.5.tgz",
-      "integrity": "sha512-WjWGsRE6o1vUqULGb/O7O1eK6B4Eu6R/RBZWnF0rH0Os6WVel6tHktkeJdlKwz9WElIEO12wDIu6uKd54t7DDQ==",
-      "dependencies": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/meta": "^5.1.5"
-      }
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/@turf/turf": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/@turf/turf/-/turf-5.1.6.tgz",
-      "integrity": "sha512-NIjkt5jAbOrom+56ELw9ERZF6qsdf1xAIHyC9/PkDMIOQAxe7FVe2HaqbQ+x88F0q5FaSX4dtpIEf08md6h5/A==",
-      "dependencies": {
-        "@turf/along": "5.1.x",
-        "@turf/area": "5.1.x",
-        "@turf/bbox": "5.1.x",
-        "@turf/bbox-clip": "5.1.x",
-        "@turf/bbox-polygon": "5.1.x",
-        "@turf/bearing": "5.1.x",
-        "@turf/bezier-spline": "5.1.x",
-        "@turf/boolean-clockwise": "5.1.x",
-        "@turf/boolean-contains": "5.1.x",
-        "@turf/boolean-crosses": "5.1.x",
-        "@turf/boolean-disjoint": "5.1.x",
-        "@turf/boolean-equal": "5.1.x",
-        "@turf/boolean-overlap": "5.1.x",
-        "@turf/boolean-parallel": "5.1.x",
-        "@turf/boolean-point-in-polygon": "5.1.x",
-        "@turf/boolean-point-on-line": "5.1.x",
-        "@turf/boolean-within": "5.1.x",
-        "@turf/buffer": "5.1.x",
-        "@turf/center": "5.1.x",
-        "@turf/center-mean": "5.1.x",
-        "@turf/center-median": "5.1.x",
-        "@turf/center-of-mass": "5.1.x",
-        "@turf/centroid": "5.1.x",
-        "@turf/circle": "5.1.x",
-        "@turf/clean-coords": "5.1.x",
-        "@turf/clone": "5.1.x",
-        "@turf/clusters": "5.1.x",
-        "@turf/clusters-dbscan": "5.1.x",
-        "@turf/clusters-kmeans": "5.1.x",
-        "@turf/collect": "5.1.x",
-        "@turf/combine": "5.1.x",
-        "@turf/concave": "5.1.x",
-        "@turf/convex": "5.1.x",
-        "@turf/destination": "5.1.x",
-        "@turf/difference": "5.1.x",
-        "@turf/dissolve": "5.1.x",
-        "@turf/distance": "5.1.x",
-        "@turf/ellipse": "5.1.x",
-        "@turf/envelope": "5.1.x",
-        "@turf/explode": "5.1.x",
-        "@turf/flatten": "5.1.x",
-        "@turf/flip": "5.1.x",
-        "@turf/great-circle": "5.1.x",
-        "@turf/helpers": "5.1.x",
-        "@turf/hex-grid": "5.1.x",
-        "@turf/interpolate": "5.1.x",
-        "@turf/intersect": "5.1.x",
-        "@turf/invariant": "5.1.x",
-        "@turf/isobands": "5.1.x",
-        "@turf/isolines": "5.1.x",
-        "@turf/kinks": "5.1.x",
-        "@turf/length": "5.1.x",
-        "@turf/line-arc": "5.1.x",
-        "@turf/line-chunk": "5.1.x",
-        "@turf/line-intersect": "5.1.x",
-        "@turf/line-offset": "5.1.x",
-        "@turf/line-overlap": "5.1.x",
-        "@turf/line-segment": "5.1.x",
-        "@turf/line-slice": "5.1.x",
-        "@turf/line-slice-along": "5.1.x",
-        "@turf/line-split": "5.1.x",
-        "@turf/line-to-polygon": "5.1.x",
-        "@turf/mask": "5.1.x",
-        "@turf/meta": "5.1.x",
-        "@turf/midpoint": "5.1.x",
-        "@turf/nearest-point": "5.1.x",
-        "@turf/nearest-point-on-line": "5.1.x",
-        "@turf/nearest-point-to-line": "5.1.x",
-        "@turf/planepoint": "5.1.x",
-        "@turf/point-grid": "5.1.x",
-        "@turf/point-on-feature": "5.1.x",
-        "@turf/point-to-line-distance": "5.1.x",
-        "@turf/points-within-polygon": "5.1.x",
-        "@turf/polygon-tangents": "5.1.x",
-        "@turf/polygon-to-line": "5.1.x",
-        "@turf/polygonize": "5.1.x",
-        "@turf/projection": "5.1.x",
-        "@turf/random": "5.1.x",
-        "@turf/rewind": "5.1.x",
-        "@turf/rhumb-bearing": "5.1.x",
-        "@turf/rhumb-destination": "5.1.x",
-        "@turf/rhumb-distance": "5.1.x",
-        "@turf/sample": "5.1.x",
-        "@turf/sector": "5.1.x",
-        "@turf/shortest-path": "5.1.x",
-        "@turf/simplify": "5.1.x",
-        "@turf/square": "5.1.x",
-        "@turf/square-grid": "5.1.x",
-        "@turf/standard-deviational-ellipse": "5.1.x",
-        "@turf/tag": "5.1.x",
-        "@turf/tesselate": "5.1.x",
-        "@turf/tin": "5.1.x",
-        "@turf/transform-rotate": "5.1.x",
-        "@turf/transform-scale": "5.1.x",
-        "@turf/transform-translate": "5.1.x",
-        "@turf/triangle-grid": "5.1.x",
-        "@turf/truncate": "5.1.x",
-        "@turf/union": "5.1.x",
-        "@turf/unkink-polygon": "5.1.x",
-        "@turf/voronoi": "5.1.x"
-      }
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/@turf/turf/node_modules/@turf/projection": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/projection/-/projection-5.1.5.tgz",
-      "integrity": "sha512-TWKJDFeEKQhI4Ce1+2PuOSDggn4cnMibqyUoCpIW+4KxUC1R88SE3/SYomqzwxMn00O09glHSycPkGD5JzHd8A==",
-      "dependencies": {
-        "@turf/clone": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/meta": "^5.1.5"
-      }
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/@turf/turf/node_modules/@turf/rhumb-bearing": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/rhumb-bearing/-/rhumb-bearing-5.1.5.tgz",
-      "integrity": "sha512-zXTl2khjwf7mx2D1uPo5vgpGgP4sM2VrKDbJNKyulPu4TO4ELt8x7FsKyCBlRTzzQf284t/xnNcZOfUbkkd70g==",
-      "dependencies": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
-      }
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/@turf/turf/node_modules/@turf/rhumb-distance": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/rhumb-distance/-/rhumb-distance-5.1.5.tgz",
-      "integrity": "sha512-AGA/ky5/BJJZtzQqafy2GvJfcUXSzCCrPFp8sDRPSKBoUN4gMBHN15ijDWYYLFoWFFj0urcauVx7chQlHZ/Qfw==",
-      "dependencies": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
-      }
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/@turf/union": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/union/-/union-5.1.5.tgz",
-      "integrity": "sha512-wBy1ixxC68PpsTeEDebk/EfnbI1Za5dCyY7xFY9NMzrtVEOy0l0lQ5syOsaqY4Ire+dbsDM66p2GGxmefoyIEA==",
-      "dependencies": {
-        "@turf/helpers": "^5.1.5",
-        "turf-jsts": "*"
-      }
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/@turf/unkink-polygon": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/unkink-polygon/-/unkink-polygon-5.1.5.tgz",
-      "integrity": "sha512-lzSrgsfSuyxIc4pkE2qyM2dsHxR992e6oItoZAT8G58A2Ef4qc5gRocmXPWZakGx41fQobegSo7wlo4I49wyHg==",
-      "dependencies": {
-        "@turf/area": "^5.1.5",
-        "@turf/boolean-point-in-polygon": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/meta": "^5.1.5",
-        "rbush": "^2.0.1"
-      }
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/@turf/voronoi": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/voronoi/-/voronoi-5.1.5.tgz",
-      "integrity": "sha512-Ad0HZAyYjOpMIZfDGV+Q+30M9PQHIirTyn32kWyTjEI1O6uhL5NOYjzSha4Sr77xOls3hGzKOj+JET7eDtOvsg==",
-      "dependencies": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "d3-voronoi": "1.1.2"
-      }
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/geojson-rbush": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/geojson-rbush/-/geojson-rbush-2.1.0.tgz",
-      "integrity": "sha512-9HvLGhmAJBYkYYDdPlCrlfkKGwNW3PapiS0xPekdJLobkZE4rjtduKJXsO7+kUr97SsUlz4VtMcPuSIbjjJaQg==",
-      "dependencies": {
-        "@turf/helpers": "*",
-        "@turf/meta": "*",
-        "rbush": "*"
-      }
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/jszip": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/jszip/-/jszip-2.6.1.tgz",
-      "integrity": "sha512-C4Z++nYQv+CudUkCWUdz+yKVhQiFJjuWSmRJ5Sg3d3/OzcJ6U4ooUYlmE3+rJXrVk89KWQaiJ9mPp/VLQ4D66g==",
-      "dependencies": {
-        "pako": "~1.0.2"
-      }
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/lru-cache": {
-      "version": "2.7.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
-      "integrity": "sha512-WpibWJ60c3AgAz8a2iYErDrcT2C7OmKnsWhIcHOjkUHFjkXncJhtLxNSqUmxRxRunpb5I8Vprd7aNSd2NtksJQ=="
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/pako": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
-      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
-    },
-    "node_modules/geostyler-openlayers-parser/node_modules/shpjs": {
-      "version": "3.6.3",
-      "resolved": "https://registry.npmjs.org/shpjs/-/shpjs-3.6.3.tgz",
-      "integrity": "sha512-wcR2S3WL/7RnEIm+YO+H/mZR9z9FCV46op+SZt+W5PtPs26Omb9U93f+EPI1DOpNKBuAIrWjHWh0SxlnBahJkg==",
-      "dependencies": {
-        "jszip": "^2.4.0",
-        "lie": "^3.0.1",
-        "lru-cache": "^2.7.0",
-        "parsedbf": "^1.1.0",
-        "proj4": "^2.1.4"
-      }
-    },
     "node_modules/geostyler-style": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/geostyler-style/-/geostyler-style-4.0.3.tgz",
-      "integrity": "sha512-51esHVZz86HFoSvKRA/Kfqd2Mytek88zgHSSt8ZZg30o4dqyZuQluxwIjqkSLp5hdvmA0nwCAyqxHy6aMyJ5lQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/geostyler-style/-/geostyler-style-5.1.0.tgz",
+      "integrity": "sha512-AJzQBomzuTGr01uRYvu7bocJTBB6vrgBdxsIoSHDATbnNF07XnAtsrbkjXlMsKaRnbqE2MGLhQqBmBx6C2Gubg==",
       "dependencies": {
         "@types/lodash": "^4.14.168",
         "lodash": "^4.17.21"
@@ -33298,6 +33397,1429 @@
         "ol": "^6.5.0",
         "proj4": "^2.6.3",
         "rxjs": "^6.6.3"
+      },
+      "dependencies": {
+        "@terrestris/ol-util": {
+          "version": "4.1.3",
+          "resolved": "https://registry.npmjs.org/@terrestris/ol-util/-/ol-util-4.1.3.tgz",
+          "integrity": "sha512-vTS7rXxOcvTpXQzRGR6DVldEYcbFjADQ9/ArSKeq9yCmmY9wb3dkeGKw+rN/dltu6oZbaswjsUsBQe060kiMOQ==",
+          "requires": {
+            "@terrestris/base-util": "^1.0.0",
+            "@turf/turf": "^5.1.6",
+            "lodash": "^4.17.20",
+            "proj4": "^2.7.0",
+            "shpjs": "^3.6.3"
+          }
+        },
+        "@turf/along": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/along/-/along-5.1.5.tgz",
+          "integrity": "sha512-N7BN1xvj6VWMe3UpjQDdVI0j0oY/EZ0bWgOgBXc4DlJ411uEsKCh6iBv0b2MSxQ3YUXEez3oc5FcgO9eVSs7iQ==",
+          "requires": {
+            "@turf/bearing": "^5.1.5",
+            "@turf/destination": "^5.1.5",
+            "@turf/distance": "^5.1.5",
+            "@turf/helpers": "^5.1.5"
+          }
+        },
+        "@turf/area": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/area/-/area-5.1.5.tgz",
+          "integrity": "sha512-lz16gqtvoz+j1jD9y3zj0Z5JnGNd3YfS0h+DQY1EcZymvi75Frm9i5YbEyth0RfxYZeOVufY7YIS3LXbJlI57g==",
+          "requires": {
+            "@turf/helpers": "^5.1.5",
+            "@turf/meta": "^5.1.5"
+          }
+        },
+        "@turf/bbox": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/bbox/-/bbox-5.1.5.tgz",
+          "integrity": "sha512-sYQU4fqsOYYJoD8UndC1n2hy8hV/lGIAmMLKWuzwmPUWqWOuSKWUcoRWDi9mGB0GvQQe/ow2IxZr8UaVaGz3sQ==",
+          "requires": {
+            "@turf/helpers": "^5.1.5",
+            "@turf/meta": "^5.1.5"
+          }
+        },
+        "@turf/bbox-clip": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/bbox-clip/-/bbox-clip-5.1.5.tgz",
+          "integrity": "sha512-KP64aoTvjcXxWHeM/Hs25vOQUBJgyJi7DlRVEoZofFJiR1kPnmDQrK7Xj+60lAk5cxuqzFnaPPxUk9Q+3v4p1Q==",
+          "requires": {
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5",
+            "lineclip": "^1.1.5"
+          }
+        },
+        "@turf/bbox-polygon": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/bbox-polygon/-/bbox-polygon-5.1.5.tgz",
+          "integrity": "sha512-PKVPF5LABFWZJud8KzzfesLGm5ihiwLbVa54HJjYySe6yqU/cr5q/qcN9TWptynOFhNktG1dr0KXVG0I2FZmfw==",
+          "requires": {
+            "@turf/helpers": "^5.1.5"
+          }
+        },
+        "@turf/bearing": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/bearing/-/bearing-5.1.5.tgz",
+          "integrity": "sha512-PrvZuJjnXGseB8hUatIjsrK3tgD3wttyRnVYXTbSfXYJZzaOfHDMplgO4lxXQp7diraZhGhCdSlbMvRRXItbUQ==",
+          "requires": {
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5"
+          }
+        },
+        "@turf/bezier-spline": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/bezier-spline/-/bezier-spline-5.1.5.tgz",
+          "integrity": "sha512-Y9NoComaGgFFFe9TWWE/cEMg2+EnBfU1R3112ec2wlx21ygDmFGXs4boOS71WM4ySwm/dbS3wxnbVxs4j68sKw==",
+          "requires": {
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5"
+          }
+        },
+        "@turf/boolean-clockwise": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/boolean-clockwise/-/boolean-clockwise-5.1.5.tgz",
+          "integrity": "sha512-FqbmEEOJ4rU4/2t7FKx0HUWmjFEVqR+NJrFP7ymGSjja2SQ7Q91nnBihGuT+yuHHl6ElMjQ3ttsB/eTmyCycxA==",
+          "requires": {
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5"
+          }
+        },
+        "@turf/boolean-contains": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/boolean-contains/-/boolean-contains-5.1.5.tgz",
+          "integrity": "sha512-x2HeEieeE9vBQrTdCuj4swnAXlpKbj9ChxMdDTV479c0m2gVmfea83ocmkj3w+9cvAaS63L8WqFyNVSmkwqljQ==",
+          "requires": {
+            "@turf/bbox": "^5.1.5",
+            "@turf/boolean-point-in-polygon": "^5.1.5",
+            "@turf/boolean-point-on-line": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5"
+          }
+        },
+        "@turf/boolean-crosses": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/boolean-crosses/-/boolean-crosses-5.1.5.tgz",
+          "integrity": "sha512-odljvS7INr9k/8yXeyXQVry7GqEaChOmXawP0+SoTfGO3hgptiik59TLU/Yjn/SLFjE2Ul54Ga1jKFSL7vvH0Q==",
+          "requires": {
+            "@turf/boolean-point-in-polygon": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5",
+            "@turf/line-intersect": "^5.1.5",
+            "@turf/polygon-to-line": "^5.1.5"
+          }
+        },
+        "@turf/boolean-disjoint": {
+          "version": "5.1.6",
+          "resolved": "https://registry.npmjs.org/@turf/boolean-disjoint/-/boolean-disjoint-5.1.6.tgz",
+          "integrity": "sha512-KHvUS6SBNYHBCLIJEJrg04pF5Oy+Fqn8V5G9U+9pti5vI9tyX7Ln2g7RSB7iJ1Cxsz8QAi6OukhXjEF2/8ZpGg==",
+          "requires": {
+            "@turf/boolean-point-in-polygon": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/line-intersect": "^5.1.5",
+            "@turf/meta": "^5.1.5",
+            "@turf/polygon-to-line": "^5.1.5"
+          }
+        },
+        "@turf/boolean-equal": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/boolean-equal/-/boolean-equal-5.1.5.tgz",
+          "integrity": "sha512-QEMbhDPV+J8PlRkMlVg6m5oSLaYUpOx2VUhDDekQ73FlpnhFBKRIlidhvHtS6CYnEw8d+/zA3h8Z18B4W4mq9Q==",
+          "requires": {
+            "@turf/clean-coords": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5",
+            "geojson-equality": "0.1.6"
+          }
+        },
+        "@turf/boolean-overlap": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/boolean-overlap/-/boolean-overlap-5.1.5.tgz",
+          "integrity": "sha512-lizojgU559KME0G705YAgWVa0B3/tsWNobMzOEWDx/1rABWTojCY4uxw2rFxpOsP++s8JJHrGWXRLh1PbdAvRQ==",
+          "requires": {
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5",
+            "@turf/line-intersect": "^5.1.5",
+            "@turf/line-overlap": "^5.1.5",
+            "@turf/meta": "^5.1.5",
+            "geojson-equality": "0.1.6"
+          }
+        },
+        "@turf/boolean-parallel": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/boolean-parallel/-/boolean-parallel-5.1.5.tgz",
+          "integrity": "sha512-eeuGgDhnas3nJ22A/DD8aiH0kg9dSzbQChIMAqYRPGg3pWNK41aGAbeh5z0GO5N/EVFX1+ga5a0vsPmiRgQB5g==",
+          "requires": {
+            "@turf/clean-coords": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/line-segment": "^5.1.5",
+            "@turf/rhumb-bearing": "^5.1.5"
+          },
+          "dependencies": {
+            "@turf/rhumb-bearing": {
+              "version": "5.1.5",
+              "resolved": "https://registry.npmjs.org/@turf/rhumb-bearing/-/rhumb-bearing-5.1.5.tgz",
+              "integrity": "sha512-zXTl2khjwf7mx2D1uPo5vgpGgP4sM2VrKDbJNKyulPu4TO4ELt8x7FsKyCBlRTzzQf284t/xnNcZOfUbkkd70g==",
+              "requires": {
+                "@turf/helpers": "^5.1.5",
+                "@turf/invariant": "^5.1.5"
+              }
+            }
+          }
+        },
+        "@turf/boolean-point-in-polygon": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/boolean-point-in-polygon/-/boolean-point-in-polygon-5.1.5.tgz",
+          "integrity": "sha512-y+gbAhLmsAZH9uYhv+C68pu06mxsGIm3o7l0hzVkc/PXYdbkr+vKe7n7PfSN3xpVA3qoDLKLpCGOqeW8/ThaJA==",
+          "requires": {
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5"
+          }
+        },
+        "@turf/boolean-point-on-line": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/boolean-point-on-line/-/boolean-point-on-line-5.1.5.tgz",
+          "integrity": "sha512-Zf4d28mckV2tYfLWf2iqxQ8eeLZqi2HGimM26mptf1OCEIwc1wfkKgLRRJXMu94Crvd/pJxjRAjoYGcGliP6Vg==",
+          "requires": {
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5"
+          }
+        },
+        "@turf/boolean-within": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/boolean-within/-/boolean-within-5.1.5.tgz",
+          "integrity": "sha512-CNAtrvm4HiUwV/vhpGhvJzfhV9CN7VhPC5y4tTfQicK82fYY6ifPz0iaNpUOmshU6+TAot/fsVQVgDJ4t7HXcA==",
+          "requires": {
+            "@turf/bbox": "^5.1.5",
+            "@turf/boolean-point-in-polygon": "^5.1.5",
+            "@turf/boolean-point-on-line": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5"
+          }
+        },
+        "@turf/buffer": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/buffer/-/buffer-5.1.5.tgz",
+          "integrity": "sha512-U3LU0HF/JNFUNabpB5ArpNG6yPla7yR5XPrZvzZRH48vvbr/N0rkSRI0tJFRWTz7ntugVm9X0OD9Y382NTJRhA==",
+          "requires": {
+            "@turf/bbox": "^5.1.5",
+            "@turf/center": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/meta": "^5.1.5",
+            "@turf/projection": "^5.1.5",
+            "d3-geo": "1.7.1",
+            "turf-jsts": "*"
+          },
+          "dependencies": {
+            "@turf/projection": {
+              "version": "5.1.5",
+              "resolved": "https://registry.npmjs.org/@turf/projection/-/projection-5.1.5.tgz",
+              "integrity": "sha512-TWKJDFeEKQhI4Ce1+2PuOSDggn4cnMibqyUoCpIW+4KxUC1R88SE3/SYomqzwxMn00O09glHSycPkGD5JzHd8A==",
+              "requires": {
+                "@turf/clone": "^5.1.5",
+                "@turf/helpers": "^5.1.5",
+                "@turf/meta": "^5.1.5"
+              }
+            }
+          }
+        },
+        "@turf/center": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/center/-/center-5.1.5.tgz",
+          "integrity": "sha512-Dy1TvAv2oHKFddZcWqlVsanxurfcZV1Mmb1E+7H7GRKI+fXZTfRjwCdbiZCbO/tPwxt8jWQHWdLHn8E9lecc3A==",
+          "requires": {
+            "@turf/bbox": "^5.1.5",
+            "@turf/helpers": "^5.1.5"
+          }
+        },
+        "@turf/center-mean": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/center-mean/-/center-mean-5.1.5.tgz",
+          "integrity": "sha512-XdkBXzFUuyCqu5EPlBwgkv8FLA8pIGBnt7xy5cxxhxKOYLMrKqwMPPHPA84TjeQpNti0gH0CVuOk2r1f/Pp8iQ==",
+          "requires": {
+            "@turf/bbox": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/meta": "^5.1.5"
+          }
+        },
+        "@turf/center-median": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/center-median/-/center-median-5.1.5.tgz",
+          "integrity": "sha512-M+O6bSNsIDKZ4utk/YzSOIg6W0isjLVWud+TCLWyrDCWTSERlSJlhOaVE1y7cObhG8nYBHvmszqZyoAY6nufQw==",
+          "requires": {
+            "@turf/center-mean": "^5.1.5",
+            "@turf/centroid": "^5.1.5",
+            "@turf/distance": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/meta": "^5.1.5"
+          }
+        },
+        "@turf/center-of-mass": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/center-of-mass/-/center-of-mass-5.1.5.tgz",
+          "integrity": "sha512-UvI7q6GgW3afCVIDOyTRuLT54v9Xwv65Xudxh4FIT6w7HNU4KUBtTGnx0NuhODZcgvZgWVWVakhmIcHQTMjYYA==",
+          "requires": {
+            "@turf/centroid": "^5.1.5",
+            "@turf/convex": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5",
+            "@turf/meta": "^5.1.5"
+          }
+        },
+        "@turf/centroid": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/centroid/-/centroid-5.1.5.tgz",
+          "integrity": "sha512-0m9ZAZJB4YXLDxF2fWGqlE/g9Y68cebeWaRNOMN+e6Bti1fz0JKQuaEqJV+J8xOmODPHSMbZZ1SqSDVRgVHP2Q==",
+          "requires": {
+            "@turf/helpers": "^5.1.5",
+            "@turf/meta": "^5.1.5"
+          }
+        },
+        "@turf/circle": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/circle/-/circle-5.1.5.tgz",
+          "integrity": "sha512-CNaEtvp38Q+TSFJHdzdl5iYNjBFZRluRTFikIuEcennSeMJD60nP0dMubP58TR/QQn541eNDUyED90V4KuOjyQ==",
+          "requires": {
+            "@turf/destination": "^5.1.5",
+            "@turf/helpers": "^5.1.5"
+          }
+        },
+        "@turf/clean-coords": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/clean-coords/-/clean-coords-5.1.5.tgz",
+          "integrity": "sha512-xd/iSM0McVUxbu81KCKDqirCsYkKk3EAwpDjYI8vIQ+eKf/MLSdteRcm3PB7wo2y6JcYp4dMGv2cr9IP7V+dXQ==",
+          "requires": {
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5"
+          }
+        },
+        "@turf/clone": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/clone/-/clone-5.1.5.tgz",
+          "integrity": "sha512-//pITsQ8xUdcQ9pVb4JqXiSqG4dos5Q9N4sYFoWghX21tfOV2dhc5TGqYOhnHrQS7RiKQL1vQ48kIK34gQ5oRg==",
+          "requires": {
+            "@turf/helpers": "^5.1.5"
+          }
+        },
+        "@turf/clusters": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/clusters/-/clusters-5.1.5.tgz",
+          "integrity": "sha512-+rQe+g66xfbIXz58tveXQCDdE9hzqRJtDVSw5xth92TvCcL4J60ZKN8mHNUSn1ZZvpUHtVPe4dYcbtk5bW8fXQ==",
+          "requires": {
+            "@turf/helpers": "^5.1.5",
+            "@turf/meta": "^5.1.5"
+          }
+        },
+        "@turf/clusters-dbscan": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/clusters-dbscan/-/clusters-dbscan-5.1.5.tgz",
+          "integrity": "sha512-X3qLLHJkwMuv+xdWQ08NtOc6BgeqCKKSAltyyAZ7iImE65f0C+sW024DfHSbTMsZVXBFst2Q6RQY8RVUf3QBeQ==",
+          "requires": {
+            "@turf/clone": "^5.1.5",
+            "@turf/distance": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5",
+            "@turf/meta": "^5.1.5",
+            "density-clustering": "1.3.0"
+          }
+        },
+        "@turf/clusters-kmeans": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/clusters-kmeans/-/clusters-kmeans-5.1.5.tgz",
+          "integrity": "sha512-W6raiv9+fRgmJxCvKrpSacbLXzh7beZUk0A1pjF82Fv3CFTrXAJbgAyIbdlmgXezYSXhOT5NMUugnbkUy2oBZw==",
+          "requires": {
+            "@turf/clone": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5",
+            "@turf/meta": "^5.1.5",
+            "skmeans": "0.9.7"
+          }
+        },
+        "@turf/collect": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/collect/-/collect-5.1.5.tgz",
+          "integrity": "sha512-voFWu6EGPcNuIbAp43yvGf2Ip4/q8TTeWhOSJ2yDEHgOfbAwrNUwUJCclEjcUVsnc7ypKNrFn3/8bmR9tI0NQg==",
+          "requires": {
+            "@turf/bbox": "^5.1.5",
+            "@turf/boolean-point-in-polygon": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "rbush": "^2.0.1"
+          }
+        },
+        "@turf/combine": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/combine/-/combine-5.1.5.tgz",
+          "integrity": "sha512-/RqmfCvduHquINVyNmzKOcZtZjfaEHMhghgmj8MYnzepN3ro+E2QXoaQGGrQ7nChAvGgWPAvN8EveVSc1MvzPg==",
+          "requires": {
+            "@turf/helpers": "^5.1.5",
+            "@turf/meta": "^5.1.5"
+          }
+        },
+        "@turf/concave": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/concave/-/concave-5.1.5.tgz",
+          "integrity": "sha512-NvR5vmAunmgjEPjNzmvjLRvPcj7C6WuqCf+vu/aqyc4h2c1B/x399bDsSM64iFT+PYesFuoS1ZhJHWivXG8Y5g==",
+          "requires": {
+            "@turf/clone": "^5.1.5",
+            "@turf/distance": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5",
+            "@turf/meta": "^5.1.5",
+            "@turf/tin": "^5.1.5",
+            "topojson-client": "3.x",
+            "topojson-server": "3.x"
+          }
+        },
+        "@turf/convex": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/convex/-/convex-5.1.5.tgz",
+          "integrity": "sha512-ZEk4kIAoYR/mjO3C8rMe2StgmwhdwmbxVvNxg3udeahe2m0ZzbfkRC4HiJAaBgfR4TLJUAEewynESReTPwASBQ==",
+          "requires": {
+            "@turf/helpers": "^5.1.5",
+            "@turf/meta": "^5.1.5",
+            "concaveman": "*"
+          }
+        },
+        "@turf/destination": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/destination/-/destination-5.1.5.tgz",
+          "integrity": "sha512-EWwZnd4wxUO9d8UWzJt88jQlFf6W/6SE1930MMzzIR9o+RfqhrS/BL1eUDrg5I5drsymf6PZsK0j/V0q6jqkFQ==",
+          "requires": {
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5"
+          }
+        },
+        "@turf/difference": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/difference/-/difference-5.1.5.tgz",
+          "integrity": "sha512-hIjiUHS8WiDfnmADQrhh6QcXWc3zNtjIpPQ5g/2NZ3k1mjnOdmGBVObkSJG4WEUNqyj3PKlsZ8W9xnSu+lLF1Q==",
+          "requires": {
+            "@turf/area": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5",
+            "@turf/meta": "^5.1.5",
+            "turf-jsts": "*"
+          }
+        },
+        "@turf/dissolve": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/dissolve/-/dissolve-5.1.5.tgz",
+          "integrity": "sha512-YcQgyp7pvhyZHCmbqqItVH6vHs43R9N0jzP/LnAG03oMiY4wves/BO1du6VDDbnJSXeRKf1afmY9tRGKYrm9ag==",
+          "requires": {
+            "@turf/boolean-overlap": "^5.1.5",
+            "@turf/clone": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5",
+            "@turf/line-intersect": "^5.1.5",
+            "@turf/meta": "^5.1.5",
+            "@turf/union": "^5.1.5",
+            "geojson-rbush": "2.1.0",
+            "get-closest": "*"
+          }
+        },
+        "@turf/distance": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/distance/-/distance-5.1.5.tgz",
+          "integrity": "sha512-sYCAgYZ2MjNKMtx17EijHlK9qHwpA0MuuQWbR4P30LTCl52UlG/reBfV899wKyF3HuDL9ux78IbILwOfeQ4zgA==",
+          "requires": {
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5"
+          }
+        },
+        "@turf/ellipse": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/ellipse/-/ellipse-5.1.5.tgz",
+          "integrity": "sha512-oVTzEyDOi3d9isgB7Ah+YiOoUKB1eHMtMDXVl1oT+vC/T+6KR2aq+HjjbF11A0cjuh3VhjSWUZaS+2TYY0pu0w==",
+          "requires": {
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5",
+            "@turf/rhumb-destination": "^5.1.5",
+            "@turf/transform-rotate": "^5.1.5"
+          }
+        },
+        "@turf/envelope": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/envelope/-/envelope-5.1.5.tgz",
+          "integrity": "sha512-Mxl5A2euAxq3RZVN65/MVyaO91kzGU8MJXfegPdep6SN4bONDadEp0olwW5qSRf2U3cJ8Jppl089X6AeifD3IA==",
+          "requires": {
+            "@turf/bbox": "^5.1.5",
+            "@turf/bbox-polygon": "^5.1.5",
+            "@turf/helpers": "^5.1.5"
+          }
+        },
+        "@turf/explode": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/explode/-/explode-5.1.5.tgz",
+          "integrity": "sha512-v/hC9DB9RKRW9/ZjnKoQelIp08JNa5wew0889465s//tfgY8+JEGkSGMag2L2NnVARWmzI/vlLgMK36qwkyDIA==",
+          "requires": {
+            "@turf/helpers": "^5.1.5",
+            "@turf/meta": "^5.1.5"
+          }
+        },
+        "@turf/flatten": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/flatten/-/flatten-5.1.5.tgz",
+          "integrity": "sha512-aagHz5tjHmOtb8eMb5fd10+HJwdlhkhsPql1vRXQNnpv0Q9xL/4SsbvXZ6lPqkRAjiZuy087mvaz+ERml76/jg==",
+          "requires": {
+            "@turf/helpers": "^5.1.5",
+            "@turf/meta": "^5.1.5"
+          }
+        },
+        "@turf/flip": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/flip/-/flip-5.1.5.tgz",
+          "integrity": "sha512-7+IYM3QQAkV4co3wjEmM726/OkXqUCCHWWyIqrI9hiK+LR628qkoqP1hk6rQ4vZJrAYuvSlK+FZnr24OtgY0cw==",
+          "requires": {
+            "@turf/clone": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/meta": "^5.1.5"
+          }
+        },
+        "@turf/great-circle": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/great-circle/-/great-circle-5.1.5.tgz",
+          "integrity": "sha512-k6FWwlt+YCQoD5VS1NybQjriNL7apYHO+tm2HbIFQ85blPUX4IyLppHIFevfD/k+K2bJqhFCze8JNVMBwdrzVw==",
+          "requires": {
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5"
+          }
+        },
+        "@turf/helpers": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-5.1.5.tgz",
+          "integrity": "sha512-/lF+JR+qNDHZ8bF9d+Cp58nxtZWJ3sqFe6n3u3Vpj+/0cqkjk4nXKYBSY0azm+GIYB5mWKxUXvuP/m0ZnKj1bw=="
+        },
+        "@turf/hex-grid": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/hex-grid/-/hex-grid-5.1.5.tgz",
+          "integrity": "sha512-rwDL+DlUyxDNL1aVHIKKCmrt1131ZULF3irExYIO/um6/SwRzsBw+522/RcxD/mg/Shtrpozb6bz8aJJ/3RXHA==",
+          "requires": {
+            "@turf/distance": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/intersect": "^5.1.5",
+            "@turf/invariant": "^5.1.5"
+          }
+        },
+        "@turf/interpolate": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/interpolate/-/interpolate-5.1.5.tgz",
+          "integrity": "sha512-LfmvtIUWc3NVkqPkX6j3CAIjF7y1LAZqfDd+2Ii+0fN7XOOGMWcb1uiTTAb8zDQjhTsygcUYgaz6mMYDCWYKPg==",
+          "requires": {
+            "@turf/bbox": "^5.1.5",
+            "@turf/centroid": "^5.1.5",
+            "@turf/clone": "^5.1.5",
+            "@turf/distance": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/hex-grid": "^5.1.5",
+            "@turf/invariant": "^5.1.5",
+            "@turf/meta": "^5.1.5",
+            "@turf/point-grid": "^5.1.5",
+            "@turf/square-grid": "^5.1.5",
+            "@turf/triangle-grid": "^5.1.5"
+          }
+        },
+        "@turf/intersect": {
+          "version": "5.1.6",
+          "resolved": "https://registry.npmjs.org/@turf/intersect/-/intersect-5.1.6.tgz",
+          "integrity": "sha512-KXyNv/GXdoGAOy03qZF53rgtXC2tNhF/4jLwTKiVRrBQH6kcEpipGStdJ+QkYIlarQPa8f7I9UlVAB19et4MfQ==",
+          "requires": {
+            "@turf/clean-coords": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5",
+            "@turf/truncate": "^5.1.5",
+            "turf-jsts": "*"
+          }
+        },
+        "@turf/invariant": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-5.1.5.tgz",
+          "integrity": "sha512-4elbC8GVQ8XxrnWLWpFFXTK3qnzIYzIVtSkJrY9eefA8WNZzwcwT3WGFY3xte4BB48o5oEjihjoJharWRis78w==",
+          "requires": {
+            "@turf/helpers": "^5.1.5"
+          }
+        },
+        "@turf/isobands": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/isobands/-/isobands-5.1.5.tgz",
+          "integrity": "sha512-0n3NPfDYQyqjOch00I4hVCCqjKn9Sm+a8qlWOKbkuhmGa9dCDzsu2bZL0ahT+LjwlS4c8/owQXqe6KE2GWqT1Q==",
+          "requires": {
+            "@turf/area": "^5.1.5",
+            "@turf/bbox": "^5.1.5",
+            "@turf/boolean-point-in-polygon": "^5.1.5",
+            "@turf/explode": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5",
+            "@turf/meta": "^5.1.5"
+          }
+        },
+        "@turf/isolines": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/isolines/-/isolines-5.1.5.tgz",
+          "integrity": "sha512-Ehn5pJmiq4hAn2+2jPB2rLt3iF8DDp8zciw9z2pAt5IGVRU/K+x3z4aYG5ra5vbFB/E4G3aHr/X4QPIb9LCJtA==",
+          "requires": {
+            "@turf/bbox": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5",
+            "@turf/meta": "^5.1.5"
+          }
+        },
+        "@turf/kinks": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/kinks/-/kinks-5.1.5.tgz",
+          "integrity": "sha512-G38sC8/+MYqQpVocT3XahhV42cqEAVJAZwUND9YOfKJZfjUn7FKmWhPURs5py95me48UuI0C0jLLAMzBkUc2nQ==",
+          "requires": {
+            "@turf/helpers": "^5.1.5"
+          }
+        },
+        "@turf/length": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/length/-/length-5.1.5.tgz",
+          "integrity": "sha512-0ryx68h512wCoNfwyksLdabxEfwkGNTPg61/QiY+QfGFUOUNhHbP+QimViFpwF5hyX7qmroaSHVclLUqyLGRbg==",
+          "requires": {
+            "@turf/distance": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/meta": "^5.1.5"
+          }
+        },
+        "@turf/line-arc": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/line-arc/-/line-arc-5.1.5.tgz",
+          "integrity": "sha512-Kz5RX/qRIHVrGNqF3BRlD3ACuuCr0G5lpaVyPjNvN+vA7Q4bEDyWIYeqm3DdTn7X2MXitpTNgr2uvX4WoUy4yA==",
+          "requires": {
+            "@turf/circle": "^5.1.5",
+            "@turf/destination": "^5.1.5",
+            "@turf/helpers": "^5.1.5"
+          }
+        },
+        "@turf/line-chunk": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/line-chunk/-/line-chunk-5.1.5.tgz",
+          "integrity": "sha512-mKvTUMahnb3EsYUMI8tQmygsliQkgQ1FZAY915zoTrm+WV246loa+84+h7i5d8W2O8gGJWuY7jQTpM7toTeL5w==",
+          "requires": {
+            "@turf/helpers": "^5.1.5",
+            "@turf/length": "^5.1.5",
+            "@turf/line-slice-along": "^5.1.5",
+            "@turf/meta": "^5.1.5"
+          }
+        },
+        "@turf/line-intersect": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/line-intersect/-/line-intersect-5.1.5.tgz",
+          "integrity": "sha512-9DajJbHhJauLI2qVMnqZ7SeFsinFroVICOSUheODk7j5teuwNABuZ2Z6WmKATzEsPkEJ1iVykqB+F9vGMVKB6g==",
+          "requires": {
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5",
+            "@turf/line-segment": "^5.1.5",
+            "@turf/meta": "^5.1.5",
+            "geojson-rbush": "2.1.0"
+          }
+        },
+        "@turf/line-offset": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/line-offset/-/line-offset-5.1.5.tgz",
+          "integrity": "sha512-VccGDgFfBSiCTqrHdQgxD7Rs9lnJmDOJ5gqQRculKPsCNUyRFMYIZud7l2dTs83g66evfOwkZCrTxtSoBY3Jxg==",
+          "requires": {
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5",
+            "@turf/meta": "^5.1.5"
+          }
+        },
+        "@turf/line-overlap": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/line-overlap/-/line-overlap-5.1.5.tgz",
+          "integrity": "sha512-hMz3XARXEbfGwLF9WXyErqQjzhZYMKvGQwlPGOoth+2o9Uga9mfWfevduJvozJAE1MKxtFttMjIXMzcShW3O8A==",
+          "requires": {
+            "@turf/boolean-point-on-line": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5",
+            "@turf/line-segment": "^5.1.5",
+            "@turf/meta": "^5.1.5",
+            "@turf/nearest-point-on-line": "^5.1.5",
+            "geojson-rbush": "2.1.0"
+          }
+        },
+        "@turf/line-segment": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/line-segment/-/line-segment-5.1.5.tgz",
+          "integrity": "sha512-wIrRtWuLuLXhnSkqdVG1SDayTU0/CmZf+a+BBhEf0vFIsAedJnrY3a2cbCEvtfuk6ZsAbhOi7/kYiaR/F+rEzg==",
+          "requires": {
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5",
+            "@turf/meta": "^5.1.5"
+          }
+        },
+        "@turf/line-slice": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/line-slice/-/line-slice-5.1.5.tgz",
+          "integrity": "sha512-Fo+CuD+fj6T702BofHO+rgiXUgzCk0iO2JqMPtttMtgzfKkVTUOQoauMNS1LNNaG/7n/TfKGh5gRCEDRNaNwYA==",
+          "requires": {
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5",
+            "@turf/nearest-point-on-line": "^5.1.5"
+          }
+        },
+        "@turf/line-slice-along": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/line-slice-along/-/line-slice-along-5.1.5.tgz",
+          "integrity": "sha512-yKvSDtULztLtlPIMowm9l8pS6XLAEpCPmrARZA0sIWFX8XrcSzISBaXZbiMMzg3nxQJMXfGIgWDk10B7+J8Tqw==",
+          "requires": {
+            "@turf/bearing": "^5.1.5",
+            "@turf/destination": "^5.1.5",
+            "@turf/distance": "^5.1.5",
+            "@turf/helpers": "^5.1.5"
+          }
+        },
+        "@turf/line-split": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/line-split/-/line-split-5.1.5.tgz",
+          "integrity": "sha512-gtUUBwZL3hcSu5MpqHTl68hgAJBNHcr1APDj8E5o6iX5xFX+wvl4ohQXyMs5HOATCI8Iy83wLuggcY6maNw7LQ==",
+          "requires": {
+            "@turf/bbox": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5",
+            "@turf/line-intersect": "^5.1.5",
+            "@turf/line-segment": "^5.1.5",
+            "@turf/meta": "^5.1.5",
+            "@turf/nearest-point-on-line": "^5.1.5",
+            "@turf/square": "^5.1.5",
+            "@turf/truncate": "^5.1.5",
+            "geojson-rbush": "2.1.0"
+          }
+        },
+        "@turf/line-to-polygon": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/line-to-polygon/-/line-to-polygon-5.1.5.tgz",
+          "integrity": "sha512-hGiDAPd6j986kZZLDgEAkVD7O6DmIqHQliBedspoKperPJOUJJzdzSnF6OAWSsxY+j8fWtQnIo5TTqdO/KfamA==",
+          "requires": {
+            "@turf/bbox": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5"
+          }
+        },
+        "@turf/mask": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/mask/-/mask-5.1.5.tgz",
+          "integrity": "sha512-2eOuxA3ammZAGsjlsy/H7IpeJxjl3hrgkcKM6kTKRJGft4QyKwCxqQP7RN5j0zIYvAurgs9JOLe/dpd5sE5HXQ==",
+          "requires": {
+            "@turf/bbox": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/meta": "^5.1.5",
+            "@turf/union": "^5.1.5",
+            "rbush": "^2.0.1"
+          }
+        },
+        "@turf/meta": {
+          "version": "5.1.6",
+          "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-5.1.6.tgz",
+          "integrity": "sha512-lv+6LCgoc3LVitQZ4TScN/8a/fcctq8bIoxBTMJVq4aU8xoHeY1851Dq8MCU37EzbH33utkx8/jENaQP+aeElg==",
+          "requires": {
+            "@turf/helpers": "^5.1.5"
+          }
+        },
+        "@turf/midpoint": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/midpoint/-/midpoint-5.1.5.tgz",
+          "integrity": "sha512-0pDQAKHyK/zxlvUx3XNxwvqftf4sV32QxnHfqSs4AXaODUGUbPhzAD7aXgDScBeUOVLwpAzFRQfitUvUMTGC6A==",
+          "requires": {
+            "@turf/bearing": "^5.1.5",
+            "@turf/destination": "^5.1.5",
+            "@turf/distance": "^5.1.5",
+            "@turf/helpers": "^5.1.5"
+          }
+        },
+        "@turf/nearest-point": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/nearest-point/-/nearest-point-5.1.5.tgz",
+          "integrity": "sha512-tZQXI7OE7keNKK4OvYOJ5gervCEuu2pJ6psu59QW9yhe2Di3Gl+HAdLvVa6RZ8s5Fndr3u0JWKsmxve3fCxc9g==",
+          "requires": {
+            "@turf/clone": "^5.1.5",
+            "@turf/distance": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/meta": "^5.1.5"
+          }
+        },
+        "@turf/nearest-point-on-line": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/nearest-point-on-line/-/nearest-point-on-line-5.1.5.tgz",
+          "integrity": "sha512-qT7BLTwToo8cq0oNoz921oLlRPJamyRg/rZgll+kNBadyDPmJI4W66riHcpM9RQcAJ6TPvDveIIBeGJH7iG88w==",
+          "requires": {
+            "@turf/bearing": "^5.1.5",
+            "@turf/destination": "^5.1.5",
+            "@turf/distance": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5",
+            "@turf/line-intersect": "^5.1.5",
+            "@turf/meta": "^5.1.5"
+          }
+        },
+        "@turf/nearest-point-to-line": {
+          "version": "5.1.6",
+          "resolved": "https://registry.npmjs.org/@turf/nearest-point-to-line/-/nearest-point-to-line-5.1.6.tgz",
+          "integrity": "sha512-ZSvDIEiHhifn/vNwLXZI/E8xmEz5yBPqfUR7BVHRZrB1cP7jLhKZvkbidjG//uW8Fr1Ulc+PFOXczLspIcx/lw==",
+          "requires": {
+            "@turf/helpers": "6.x",
+            "@turf/invariant": "6.x",
+            "@turf/meta": "6.x",
+            "@turf/point-to-line-distance": "^5.1.5",
+            "object-assign": "*"
+          },
+          "dependencies": {
+            "@turf/helpers": {
+              "version": "6.5.0",
+              "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.5.0.tgz",
+              "integrity": "sha512-VbI1dV5bLFzohYYdgqwikdMVpe7pJ9X3E+dlr425wa2/sMJqYDhTO++ec38/pcPvPE6oD9WEEeU3Xu3gza+VPw=="
+            },
+            "@turf/invariant": {
+              "version": "6.5.0",
+              "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-6.5.0.tgz",
+              "integrity": "sha512-Wv8PRNCtPD31UVbdJE/KVAWKe7l6US+lJItRR/HOEW3eh+U/JwRCSUl/KZ7bmjM/C+zLNoreM2TU6OoLACs4eg==",
+              "requires": {
+                "@turf/helpers": "^6.5.0"
+              }
+            },
+            "@turf/meta": {
+              "version": "6.5.0",
+              "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-6.5.0.tgz",
+              "integrity": "sha512-RrArvtsV0vdsCBegoBtOalgdSOfkBrTJ07VkpiCnq/491W67hnMWmDu7e6Ztw0C3WldRYTXkg3SumfdzZxLBHA==",
+              "requires": {
+                "@turf/helpers": "^6.5.0"
+              }
+            }
+          }
+        },
+        "@turf/planepoint": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/planepoint/-/planepoint-5.1.5.tgz",
+          "integrity": "sha512-+Tp+SQ0Db2tqwLbxfXJPysT9IxcOHSMIin2dJb/j3Qn5+g0LRus6rczZl6dWNAIjqBPMawj/V/dZhMu6Q9O9wA==",
+          "requires": {
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5"
+          }
+        },
+        "@turf/point-grid": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/point-grid/-/point-grid-5.1.5.tgz",
+          "integrity": "sha512-4ibozguP9YJ297Q7i9e8/ypGSycvt1re2jrPXTxeuZ4/L/NE5B1nOBLG+tw121nMjD+S+v2RWOtqD+FZ3Ga+ew==",
+          "requires": {
+            "@turf/boolean-within": "^5.1.5",
+            "@turf/distance": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5"
+          }
+        },
+        "@turf/point-on-feature": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/point-on-feature/-/point-on-feature-5.1.5.tgz",
+          "integrity": "sha512-NTcpe5xZjybRh0aTL+7td1cm0s49GGbAt5u8Cdec4W9ix2PsehRcLUbmQIQsODN2kiVyUSpnhECIpsyN5MjX7A==",
+          "requires": {
+            "@turf/boolean-point-in-polygon": "^5.1.5",
+            "@turf/center": "^5.1.5",
+            "@turf/explode": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/nearest-point": "^5.1.5"
+          }
+        },
+        "@turf/point-to-line-distance": {
+          "version": "5.1.6",
+          "resolved": "https://registry.npmjs.org/@turf/point-to-line-distance/-/point-to-line-distance-5.1.6.tgz",
+          "integrity": "sha512-PE3hiTeeDEi4ZLPtI8XAzFYW9nHo1EVsZGm/4ZVV8jo39d3X1oLVHxY3e1PkCmWwRapXy4QLqvnTQ7nU4wspNw==",
+          "requires": {
+            "@turf/bearing": "6.x",
+            "@turf/distance": "6.x",
+            "@turf/helpers": "6.x",
+            "@turf/invariant": "6.x",
+            "@turf/meta": "6.x",
+            "@turf/projection": "6.x",
+            "@turf/rhumb-bearing": "6.x",
+            "@turf/rhumb-distance": "6.x"
+          },
+          "dependencies": {
+            "@turf/bearing": {
+              "version": "6.5.0",
+              "resolved": "https://registry.npmjs.org/@turf/bearing/-/bearing-6.5.0.tgz",
+              "integrity": "sha512-dxINYhIEMzgDOztyMZc20I7ssYVNEpSv04VbMo5YPQsqa80KO3TFvbuCahMsCAW5z8Tncc8dwBlEFrmRjJG33A==",
+              "requires": {
+                "@turf/helpers": "^6.5.0",
+                "@turf/invariant": "^6.5.0"
+              }
+            },
+            "@turf/distance": {
+              "version": "6.5.0",
+              "resolved": "https://registry.npmjs.org/@turf/distance/-/distance-6.5.0.tgz",
+              "integrity": "sha512-xzykSLfoURec5qvQJcfifw/1mJa+5UwByZZ5TZ8iaqjGYN0vomhV9aiSLeYdUGtYRESZ+DYC/OzY+4RclZYgMg==",
+              "requires": {
+                "@turf/helpers": "^6.5.0",
+                "@turf/invariant": "^6.5.0"
+              }
+            },
+            "@turf/helpers": {
+              "version": "6.5.0",
+              "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.5.0.tgz",
+              "integrity": "sha512-VbI1dV5bLFzohYYdgqwikdMVpe7pJ9X3E+dlr425wa2/sMJqYDhTO++ec38/pcPvPE6oD9WEEeU3Xu3gza+VPw=="
+            },
+            "@turf/invariant": {
+              "version": "6.5.0",
+              "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-6.5.0.tgz",
+              "integrity": "sha512-Wv8PRNCtPD31UVbdJE/KVAWKe7l6US+lJItRR/HOEW3eh+U/JwRCSUl/KZ7bmjM/C+zLNoreM2TU6OoLACs4eg==",
+              "requires": {
+                "@turf/helpers": "^6.5.0"
+              }
+            },
+            "@turf/meta": {
+              "version": "6.5.0",
+              "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-6.5.0.tgz",
+              "integrity": "sha512-RrArvtsV0vdsCBegoBtOalgdSOfkBrTJ07VkpiCnq/491W67hnMWmDu7e6Ztw0C3WldRYTXkg3SumfdzZxLBHA==",
+              "requires": {
+                "@turf/helpers": "^6.5.0"
+              }
+            }
+          }
+        },
+        "@turf/points-within-polygon": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/points-within-polygon/-/points-within-polygon-5.1.5.tgz",
+          "integrity": "sha512-nexe2AHVOY8wEBvs+CYSOp10NyOCkyZ1gkhIfsx0mzU8LPYBxD9ctjlKveheKh4AAldLcFupd/gSCBTKF1JS7A==",
+          "requires": {
+            "@turf/boolean-point-in-polygon": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/meta": "^5.1.5"
+          }
+        },
+        "@turf/polygon-tangents": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/polygon-tangents/-/polygon-tangents-5.1.5.tgz",
+          "integrity": "sha512-uoZfKvFhl6rf0+CDWucru9fZ4mJB5Nsg37TS/7emrzjoVxXyOdxc/s1HFCjcKflMue7MjU/gT6AitJyrvdztDg==",
+          "requires": {
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5"
+          }
+        },
+        "@turf/polygon-to-line": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/polygon-to-line/-/polygon-to-line-5.1.5.tgz",
+          "integrity": "sha512-kVo0owPqyccy5+qZGvaxGvMsYkgueKE2OOgX2UV/HyrXF3uI3TomK1txjApqeFsLvwuSANxesvVbYLrYiIwvGw==",
+          "requires": {
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5"
+          }
+        },
+        "@turf/polygonize": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/polygonize/-/polygonize-5.1.5.tgz",
+          "integrity": "sha512-qzhtuzoOhldqZHm+ZPsWAs9nDpnkcDfsr+I0twmBF+wjAmo0HKiy9++sRQ4kEePpdwbMpF07D/NdZqYdmOJkGQ==",
+          "requires": {
+            "@turf/boolean-point-in-polygon": "^5.1.5",
+            "@turf/envelope": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5",
+            "@turf/meta": "^5.1.5"
+          }
+        },
+        "@turf/random": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/random/-/random-5.1.5.tgz",
+          "integrity": "sha512-oitpBwEb6YXqoUkIAOVMK+vrTPxUi2rqITmtTa/FBHr6J8TDwMWq6bufE3Gmgjxsss50O2ITJunOksxrouWGDQ==",
+          "requires": {
+            "@turf/helpers": "^5.1.5"
+          }
+        },
+        "@turf/rewind": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/rewind/-/rewind-5.1.5.tgz",
+          "integrity": "sha512-Gdem7JXNu+G4hMllQHXRFRihJl3+pNl7qY+l4qhQFxq+hiU1cQoVFnyoleIqWKIrdK/i2YubaSwc3SCM7N5mMw==",
+          "requires": {
+            "@turf/boolean-clockwise": "^5.1.5",
+            "@turf/clone": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5",
+            "@turf/meta": "^5.1.5"
+          }
+        },
+        "@turf/rhumb-destination": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/rhumb-destination/-/rhumb-destination-5.1.5.tgz",
+          "integrity": "sha512-FdDUCSRfRAfsRmUaWjc76Wk32QYFJ6ckmSt6Ls6nEczO6eg/RgH1atF8CIYwR5ifl0Sk1rQzKiOSbpCyvVwQtw==",
+          "requires": {
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5"
+          }
+        },
+        "@turf/sample": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/sample/-/sample-5.1.5.tgz",
+          "integrity": "sha512-EJE8yx+5x7rXejTzwBdOKpvT4tOCS0jwYJfycyTVDuLUSh2rETeYdjy7EeJbofnxm9CRPXqWQMPWIBKWxNTjow==",
+          "requires": {
+            "@turf/helpers": "^5.1.5"
+          }
+        },
+        "@turf/sector": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/sector/-/sector-5.1.5.tgz",
+          "integrity": "sha512-dnWVifL3xWTqPPs8mfbbV9muDimNJtxRk4ogrkOLEDQ9ZZ1ALQMtQdYrg7kI3iC+L+LscV37tl+E8bayWyX8YA==",
+          "requires": {
+            "@turf/circle": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5",
+            "@turf/line-arc": "^5.1.5",
+            "@turf/meta": "^5.1.5"
+          }
+        },
+        "@turf/shortest-path": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/shortest-path/-/shortest-path-5.1.5.tgz",
+          "integrity": "sha512-ZGC8kSBj02GKWiI56Z5FNdrZ+fS0xyeOUNrPJWzudAlrv9wKGaRuWoIVRLGBu0j0OuO1HCwggic2c6WV/AhP0A==",
+          "requires": {
+            "@turf/bbox": "^5.1.5",
+            "@turf/bbox-polygon": "^5.1.5",
+            "@turf/boolean-point-in-polygon": "^5.1.5",
+            "@turf/clean-coords": "^5.1.5",
+            "@turf/distance": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5",
+            "@turf/meta": "^5.1.5",
+            "@turf/transform-scale": "^5.1.5"
+          }
+        },
+        "@turf/simplify": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/simplify/-/simplify-5.1.5.tgz",
+          "integrity": "sha512-IuBXEYdGSxbDOK3v949ajaPvs6NhjhTCTbKA6mSGuVbwGS7gzAuRiPSG4K/MvCVuQy3PKpkPcUGD+Uvt2Ov2PQ==",
+          "requires": {
+            "@turf/clean-coords": "^5.1.5",
+            "@turf/clone": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/meta": "^5.1.5"
+          }
+        },
+        "@turf/square": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/square/-/square-5.1.5.tgz",
+          "integrity": "sha512-GgP2le9ksoW6vsVef5wFkjmWQiLPTJvcjGXqmoGWT4oMwDpvTJVQ91RBLs8qQbI4KACCQevz94N69klk3ah30Q==",
+          "requires": {
+            "@turf/distance": "^5.1.5",
+            "@turf/helpers": "^5.1.5"
+          }
+        },
+        "@turf/square-grid": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/square-grid/-/square-grid-5.1.5.tgz",
+          "integrity": "sha512-/pusEL4FmOwNWLcZfIXUyqUe0fOdkfaLO4wLhDlg/ZL1jWr/wZjhVlMU0tQ27kVN6dJTvlzNc9e0JWNw6yt2eQ==",
+          "requires": {
+            "@turf/boolean-contains": "^5.1.5",
+            "@turf/boolean-overlap": "^5.1.5",
+            "@turf/distance": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/intersect": "^5.1.5",
+            "@turf/invariant": "^5.1.5"
+          }
+        },
+        "@turf/standard-deviational-ellipse": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/standard-deviational-ellipse/-/standard-deviational-ellipse-5.1.5.tgz",
+          "integrity": "sha512-GOaxGKeeJAXV1H3Zz2fjQ5XeSbMKz1OkFRlTDBUipiAawe/9qTCF55L87I2ZPnO80B5BaaIT+AN2n0lMcAklzA==",
+          "requires": {
+            "@turf/center-mean": "^5.1.5",
+            "@turf/ellipse": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5",
+            "@turf/meta": "^5.1.5",
+            "@turf/points-within-polygon": "^5.1.5"
+          }
+        },
+        "@turf/tag": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/tag/-/tag-5.1.5.tgz",
+          "integrity": "sha512-XI3QFpva6tEsRnzFe1tJGdAAWlzjnXZPfJ9EKShTxEW8ZgPzm92b2odjiSAt2KuQusK82ltNfdw5Frlna5xGYQ==",
+          "requires": {
+            "@turf/boolean-point-in-polygon": "^5.1.5",
+            "@turf/clone": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/meta": "^5.1.5"
+          }
+        },
+        "@turf/tesselate": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/tesselate/-/tesselate-5.1.5.tgz",
+          "integrity": "sha512-Rs/jAij26bcU4OzvFXkWDase1G3kSwyuuKZPFU0t7OmJu7eQJOR12WOZLGcVxd5oBlklo4xPE4EBQUqpQUsQgg==",
+          "requires": {
+            "@turf/helpers": "^5.1.5",
+            "earcut": "^2.0.0"
+          }
+        },
+        "@turf/tin": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/tin/-/tin-5.1.5.tgz",
+          "integrity": "sha512-lDyCTYKoThBIKmkBxBMupqEpFbvTDAYuZIs8qrWnmux2vntSb8OFGi7ZbGPC6apS2hdVwZZae3YB88Tp+Fg+xw==",
+          "requires": {
+            "@turf/helpers": "^5.1.5"
+          }
+        },
+        "@turf/transform-rotate": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/transform-rotate/-/transform-rotate-5.1.5.tgz",
+          "integrity": "sha512-3QKckeHKPXu5O5vEuT+nkszGDI6aknDD06ePb00+6H2oA7MZj7nj+fVQIJLs41MRb76IyKr4n5NvuKZU6idESA==",
+          "requires": {
+            "@turf/centroid": "^5.1.5",
+            "@turf/clone": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5",
+            "@turf/meta": "^5.1.5",
+            "@turf/rhumb-bearing": "^5.1.5",
+            "@turf/rhumb-destination": "^5.1.5",
+            "@turf/rhumb-distance": "^5.1.5"
+          },
+          "dependencies": {
+            "@turf/rhumb-bearing": {
+              "version": "5.1.5",
+              "resolved": "https://registry.npmjs.org/@turf/rhumb-bearing/-/rhumb-bearing-5.1.5.tgz",
+              "integrity": "sha512-zXTl2khjwf7mx2D1uPo5vgpGgP4sM2VrKDbJNKyulPu4TO4ELt8x7FsKyCBlRTzzQf284t/xnNcZOfUbkkd70g==",
+              "requires": {
+                "@turf/helpers": "^5.1.5",
+                "@turf/invariant": "^5.1.5"
+              }
+            },
+            "@turf/rhumb-distance": {
+              "version": "5.1.5",
+              "resolved": "https://registry.npmjs.org/@turf/rhumb-distance/-/rhumb-distance-5.1.5.tgz",
+              "integrity": "sha512-AGA/ky5/BJJZtzQqafy2GvJfcUXSzCCrPFp8sDRPSKBoUN4gMBHN15ijDWYYLFoWFFj0urcauVx7chQlHZ/Qfw==",
+              "requires": {
+                "@turf/helpers": "^5.1.5",
+                "@turf/invariant": "^5.1.5"
+              }
+            }
+          }
+        },
+        "@turf/transform-scale": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/transform-scale/-/transform-scale-5.1.5.tgz",
+          "integrity": "sha512-t1fCZX29ONA7DJiqCKA4YZy0+hCzhppWNOZhglBUv9vKHsWCFYZDUKfFInciaypUInsZyvm8eKxxixBVPdPGsw==",
+          "requires": {
+            "@turf/bbox": "^5.1.5",
+            "@turf/center": "^5.1.5",
+            "@turf/centroid": "^5.1.5",
+            "@turf/clone": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5",
+            "@turf/meta": "^5.1.5",
+            "@turf/rhumb-bearing": "^5.1.5",
+            "@turf/rhumb-destination": "^5.1.5",
+            "@turf/rhumb-distance": "^5.1.5"
+          },
+          "dependencies": {
+            "@turf/rhumb-bearing": {
+              "version": "5.1.5",
+              "resolved": "https://registry.npmjs.org/@turf/rhumb-bearing/-/rhumb-bearing-5.1.5.tgz",
+              "integrity": "sha512-zXTl2khjwf7mx2D1uPo5vgpGgP4sM2VrKDbJNKyulPu4TO4ELt8x7FsKyCBlRTzzQf284t/xnNcZOfUbkkd70g==",
+              "requires": {
+                "@turf/helpers": "^5.1.5",
+                "@turf/invariant": "^5.1.5"
+              }
+            },
+            "@turf/rhumb-distance": {
+              "version": "5.1.5",
+              "resolved": "https://registry.npmjs.org/@turf/rhumb-distance/-/rhumb-distance-5.1.5.tgz",
+              "integrity": "sha512-AGA/ky5/BJJZtzQqafy2GvJfcUXSzCCrPFp8sDRPSKBoUN4gMBHN15ijDWYYLFoWFFj0urcauVx7chQlHZ/Qfw==",
+              "requires": {
+                "@turf/helpers": "^5.1.5",
+                "@turf/invariant": "^5.1.5"
+              }
+            }
+          }
+        },
+        "@turf/transform-translate": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/transform-translate/-/transform-translate-5.1.5.tgz",
+          "integrity": "sha512-GdLFp7I7198oRQt311B8EjiqHupndeMSQ3Zclzki5L/niUrb1ptOIpo+mxSidSy03m+1Q5ylWlENroI1WBcQ3Q==",
+          "requires": {
+            "@turf/clone": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5",
+            "@turf/meta": "^5.1.5",
+            "@turf/rhumb-destination": "^5.1.5"
+          }
+        },
+        "@turf/triangle-grid": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/triangle-grid/-/triangle-grid-5.1.5.tgz",
+          "integrity": "sha512-jmCRcynI80xsVqd+0rv0YxP6mvZn4BAaJv8dwthg2T3WfHB9OD+rNUMohMuUY8HmI0zRT3s/Ypdy2Cdri9u/tw==",
+          "requires": {
+            "@turf/distance": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/intersect": "^5.1.5",
+            "@turf/invariant": "^5.1.5"
+          }
+        },
+        "@turf/truncate": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/truncate/-/truncate-5.1.5.tgz",
+          "integrity": "sha512-WjWGsRE6o1vUqULGb/O7O1eK6B4Eu6R/RBZWnF0rH0Os6WVel6tHktkeJdlKwz9WElIEO12wDIu6uKd54t7DDQ==",
+          "requires": {
+            "@turf/helpers": "^5.1.5",
+            "@turf/meta": "^5.1.5"
+          }
+        },
+        "@turf/turf": {
+          "version": "5.1.6",
+          "resolved": "https://registry.npmjs.org/@turf/turf/-/turf-5.1.6.tgz",
+          "integrity": "sha512-NIjkt5jAbOrom+56ELw9ERZF6qsdf1xAIHyC9/PkDMIOQAxe7FVe2HaqbQ+x88F0q5FaSX4dtpIEf08md6h5/A==",
+          "requires": {
+            "@turf/along": "5.1.x",
+            "@turf/area": "5.1.x",
+            "@turf/bbox": "5.1.x",
+            "@turf/bbox-clip": "5.1.x",
+            "@turf/bbox-polygon": "5.1.x",
+            "@turf/bearing": "5.1.x",
+            "@turf/bezier-spline": "5.1.x",
+            "@turf/boolean-clockwise": "5.1.x",
+            "@turf/boolean-contains": "5.1.x",
+            "@turf/boolean-crosses": "5.1.x",
+            "@turf/boolean-disjoint": "5.1.x",
+            "@turf/boolean-equal": "5.1.x",
+            "@turf/boolean-overlap": "5.1.x",
+            "@turf/boolean-parallel": "5.1.x",
+            "@turf/boolean-point-in-polygon": "5.1.x",
+            "@turf/boolean-point-on-line": "5.1.x",
+            "@turf/boolean-within": "5.1.x",
+            "@turf/buffer": "5.1.x",
+            "@turf/center": "5.1.x",
+            "@turf/center-mean": "5.1.x",
+            "@turf/center-median": "5.1.x",
+            "@turf/center-of-mass": "5.1.x",
+            "@turf/centroid": "5.1.x",
+            "@turf/circle": "5.1.x",
+            "@turf/clean-coords": "5.1.x",
+            "@turf/clone": "5.1.x",
+            "@turf/clusters": "5.1.x",
+            "@turf/clusters-dbscan": "5.1.x",
+            "@turf/clusters-kmeans": "5.1.x",
+            "@turf/collect": "5.1.x",
+            "@turf/combine": "5.1.x",
+            "@turf/concave": "5.1.x",
+            "@turf/convex": "5.1.x",
+            "@turf/destination": "5.1.x",
+            "@turf/difference": "5.1.x",
+            "@turf/dissolve": "5.1.x",
+            "@turf/distance": "5.1.x",
+            "@turf/ellipse": "5.1.x",
+            "@turf/envelope": "5.1.x",
+            "@turf/explode": "5.1.x",
+            "@turf/flatten": "5.1.x",
+            "@turf/flip": "5.1.x",
+            "@turf/great-circle": "5.1.x",
+            "@turf/helpers": "5.1.x",
+            "@turf/hex-grid": "5.1.x",
+            "@turf/interpolate": "5.1.x",
+            "@turf/intersect": "5.1.x",
+            "@turf/invariant": "5.1.x",
+            "@turf/isobands": "5.1.x",
+            "@turf/isolines": "5.1.x",
+            "@turf/kinks": "5.1.x",
+            "@turf/length": "5.1.x",
+            "@turf/line-arc": "5.1.x",
+            "@turf/line-chunk": "5.1.x",
+            "@turf/line-intersect": "5.1.x",
+            "@turf/line-offset": "5.1.x",
+            "@turf/line-overlap": "5.1.x",
+            "@turf/line-segment": "5.1.x",
+            "@turf/line-slice": "5.1.x",
+            "@turf/line-slice-along": "5.1.x",
+            "@turf/line-split": "5.1.x",
+            "@turf/line-to-polygon": "5.1.x",
+            "@turf/mask": "5.1.x",
+            "@turf/meta": "5.1.x",
+            "@turf/midpoint": "5.1.x",
+            "@turf/nearest-point": "5.1.x",
+            "@turf/nearest-point-on-line": "5.1.x",
+            "@turf/nearest-point-to-line": "5.1.x",
+            "@turf/planepoint": "5.1.x",
+            "@turf/point-grid": "5.1.x",
+            "@turf/point-on-feature": "5.1.x",
+            "@turf/point-to-line-distance": "5.1.x",
+            "@turf/points-within-polygon": "5.1.x",
+            "@turf/polygon-tangents": "5.1.x",
+            "@turf/polygon-to-line": "5.1.x",
+            "@turf/polygonize": "5.1.x",
+            "@turf/projection": "5.1.x",
+            "@turf/random": "5.1.x",
+            "@turf/rewind": "5.1.x",
+            "@turf/rhumb-bearing": "5.1.x",
+            "@turf/rhumb-destination": "5.1.x",
+            "@turf/rhumb-distance": "5.1.x",
+            "@turf/sample": "5.1.x",
+            "@turf/sector": "5.1.x",
+            "@turf/shortest-path": "5.1.x",
+            "@turf/simplify": "5.1.x",
+            "@turf/square": "5.1.x",
+            "@turf/square-grid": "5.1.x",
+            "@turf/standard-deviational-ellipse": "5.1.x",
+            "@turf/tag": "5.1.x",
+            "@turf/tesselate": "5.1.x",
+            "@turf/tin": "5.1.x",
+            "@turf/transform-rotate": "5.1.x",
+            "@turf/transform-scale": "5.1.x",
+            "@turf/transform-translate": "5.1.x",
+            "@turf/triangle-grid": "5.1.x",
+            "@turf/truncate": "5.1.x",
+            "@turf/union": "5.1.x",
+            "@turf/unkink-polygon": "5.1.x",
+            "@turf/voronoi": "5.1.x"
+          },
+          "dependencies": {
+            "@turf/projection": {
+              "version": "5.1.5",
+              "resolved": "https://registry.npmjs.org/@turf/projection/-/projection-5.1.5.tgz",
+              "integrity": "sha512-TWKJDFeEKQhI4Ce1+2PuOSDggn4cnMibqyUoCpIW+4KxUC1R88SE3/SYomqzwxMn00O09glHSycPkGD5JzHd8A==",
+              "requires": {
+                "@turf/clone": "^5.1.5",
+                "@turf/helpers": "^5.1.5",
+                "@turf/meta": "^5.1.5"
+              }
+            },
+            "@turf/rhumb-bearing": {
+              "version": "5.1.5",
+              "resolved": "https://registry.npmjs.org/@turf/rhumb-bearing/-/rhumb-bearing-5.1.5.tgz",
+              "integrity": "sha512-zXTl2khjwf7mx2D1uPo5vgpGgP4sM2VrKDbJNKyulPu4TO4ELt8x7FsKyCBlRTzzQf284t/xnNcZOfUbkkd70g==",
+              "requires": {
+                "@turf/helpers": "^5.1.5",
+                "@turf/invariant": "^5.1.5"
+              }
+            },
+            "@turf/rhumb-distance": {
+              "version": "5.1.5",
+              "resolved": "https://registry.npmjs.org/@turf/rhumb-distance/-/rhumb-distance-5.1.5.tgz",
+              "integrity": "sha512-AGA/ky5/BJJZtzQqafy2GvJfcUXSzCCrPFp8sDRPSKBoUN4gMBHN15ijDWYYLFoWFFj0urcauVx7chQlHZ/Qfw==",
+              "requires": {
+                "@turf/helpers": "^5.1.5",
+                "@turf/invariant": "^5.1.5"
+              }
+            }
+          }
+        },
+        "@turf/union": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/union/-/union-5.1.5.tgz",
+          "integrity": "sha512-wBy1ixxC68PpsTeEDebk/EfnbI1Za5dCyY7xFY9NMzrtVEOy0l0lQ5syOsaqY4Ire+dbsDM66p2GGxmefoyIEA==",
+          "requires": {
+            "@turf/helpers": "^5.1.5",
+            "turf-jsts": "*"
+          }
+        },
+        "@turf/unkink-polygon": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/unkink-polygon/-/unkink-polygon-5.1.5.tgz",
+          "integrity": "sha512-lzSrgsfSuyxIc4pkE2qyM2dsHxR992e6oItoZAT8G58A2Ef4qc5gRocmXPWZakGx41fQobegSo7wlo4I49wyHg==",
+          "requires": {
+            "@turf/area": "^5.1.5",
+            "@turf/boolean-point-in-polygon": "^5.1.5",
+            "@turf/helpers": "^5.1.5",
+            "@turf/meta": "^5.1.5",
+            "rbush": "^2.0.1"
+          }
+        },
+        "@turf/voronoi": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/voronoi/-/voronoi-5.1.5.tgz",
+          "integrity": "sha512-Ad0HZAyYjOpMIZfDGV+Q+30M9PQHIirTyn32kWyTjEI1O6uhL5NOYjzSha4Sr77xOls3hGzKOj+JET7eDtOvsg==",
+          "requires": {
+            "@turf/helpers": "^5.1.5",
+            "@turf/invariant": "^5.1.5",
+            "d3-voronoi": "1.1.2"
+          }
+        },
+        "geojson-rbush": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/geojson-rbush/-/geojson-rbush-2.1.0.tgz",
+          "integrity": "sha512-9HvLGhmAJBYkYYDdPlCrlfkKGwNW3PapiS0xPekdJLobkZE4rjtduKJXsO7+kUr97SsUlz4VtMcPuSIbjjJaQg==",
+          "requires": {
+            "@turf/helpers": "*",
+            "@turf/meta": "*",
+            "rbush": "*"
+          }
+        },
+        "geostyler-openlayers-parser": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/geostyler-openlayers-parser/-/geostyler-openlayers-parser-2.5.0.tgz",
+          "integrity": "sha512-Uum/lDci8oqhBA/c0RZbD91aXP4ycjlsAp4ZoVAPDHT6Og0XyF5Tze8wg0Ux44CerE6W+m2DfWkOTAP+iaakzQ==",
+          "requires": {
+            "@terrestris/ol-util": "^4.0.1",
+            "geostyler-style": "^4.0.0",
+            "lodash": "^4.17.15"
+          }
+        },
+        "geostyler-style": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/geostyler-style/-/geostyler-style-4.0.3.tgz",
+          "integrity": "sha512-51esHVZz86HFoSvKRA/Kfqd2Mytek88zgHSSt8ZZg30o4dqyZuQluxwIjqkSLp5hdvmA0nwCAyqxHy6aMyJ5lQ==",
+          "requires": {
+            "@types/lodash": "^4.14.168",
+            "lodash": "^4.17.21"
+          }
+        },
+        "jszip": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/jszip/-/jszip-2.6.1.tgz",
+          "integrity": "sha512-C4Z++nYQv+CudUkCWUdz+yKVhQiFJjuWSmRJ5Sg3d3/OzcJ6U4ooUYlmE3+rJXrVk89KWQaiJ9mPp/VLQ4D66g==",
+          "requires": {
+            "pako": "~1.0.2"
+          }
+        },
+        "lru-cache": {
+          "version": "2.7.3",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+          "integrity": "sha512-WpibWJ60c3AgAz8a2iYErDrcT2C7OmKnsWhIcHOjkUHFjkXncJhtLxNSqUmxRxRunpb5I8Vprd7aNSd2NtksJQ=="
+        },
+        "ol": {
+          "version": "6.5.0",
+          "resolved": "https://registry.npmjs.org/ol/-/ol-6.5.0.tgz",
+          "integrity": "sha512-a5ebahrjF5yCPFle1rc0aHzKp/9A4LlUnjh+S3I+x4EgcvcddDhpOX3WDOs0Pg9/wEElrikHSGEvbeej2Hh4Ug==",
+          "requires": {
+            "ol-mapbox-style": "^6.1.1",
+            "pbf": "3.2.1",
+            "rbush": "^3.0.1"
+          },
+          "dependencies": {
+            "rbush": {
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/rbush/-/rbush-3.0.1.tgz",
+              "integrity": "sha512-XRaVO0YecOpEuIvbhbpTrZgoiI6xBlz6hnlr6EHhd+0x9ase6EmeN+hdwwUaJvLcsFFQ8iWVF1GAK1yB0BWi0w==",
+              "requires": {
+                "quickselect": "^2.0.0"
+              }
+            }
+          }
+        },
+        "ol-mapbox-style": {
+          "version": "6.9.0",
+          "resolved": "https://registry.npmjs.org/ol-mapbox-style/-/ol-mapbox-style-6.9.0.tgz",
+          "integrity": "sha512-Isxk+IPB6pCBD2Pubz9cpQcZjEeuPhxyk/QsLZjb2+KwvyGaIFltdlxnxx/QXJ7rOxUiLvS/XhsOyiK0c7prEw==",
+          "requires": {
+            "@mapbox/mapbox-gl-style-spec": "^13.20.1",
+            "mapbox-to-css-font": "^2.4.1",
+            "webfont-matcher": "^1.1.0"
+          }
+        },
+        "pako": {
+          "version": "1.0.11",
+          "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+          "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
+        },
+        "quickselect": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
+          "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw=="
+        },
+        "shpjs": {
+          "version": "3.6.3",
+          "resolved": "https://registry.npmjs.org/shpjs/-/shpjs-3.6.3.tgz",
+          "integrity": "sha512-wcR2S3WL/7RnEIm+YO+H/mZR9z9FCV46op+SZt+W5PtPs26Omb9U93f+EPI1DOpNKBuAIrWjHWh0SxlnBahJkg==",
+          "requires": {
+            "jszip": "^2.4.0",
+            "lie": "^3.0.1",
+            "lru-cache": "^2.7.0",
+            "parsedbf": "^1.1.0",
+            "proj4": "^2.1.4"
+          }
+        }
       }
     },
     "@ctrl/tinycolor": {
@@ -33661,6 +35183,14 @@
       "dev": true,
       "requires": {
         "jest-get-type": "^28.0.2"
+      },
+      "dependencies": {
+        "jest-get-type": {
+          "version": "28.0.2",
+          "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-28.0.2.tgz",
+          "integrity": "sha512-ioj2w9/DxSYHfOm5lJKCdcAmPJzQXmbM/Url3rhlghrPvT3tt+7a/+oXc9azkKmLvoiXjtV83bEWqi+vs5nlPA==",
+          "dev": true
+        }
       }
     },
     "@jest/fake-timers": {
@@ -34581,13 +36111,13 @@
       }
     },
     "@terrestris/eslint-config-typescript": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@terrestris/eslint-config-typescript/-/eslint-config-typescript-3.0.0.tgz",
-      "integrity": "sha512-dpAztRrJ/M036lTI5eqJoNbX4/80zTh2fRWxrXRG16RHorQoIbBsd8WqWtF7K42yTrSHz2kmEwWX4Yo0YBc2rQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@terrestris/eslint-config-typescript/-/eslint-config-typescript-2.1.0.tgz",
+      "integrity": "sha512-fRAAfa2bIht5Nf/GZBbhhgVwnxNc3VG8YdyYwsauCwAn5XPHl/JDeJkyMpIu/NVML9LGSFbQBZChUEpZRhntwg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/parser": "^5.28.0",
-        "typescript": ">= ~4"
+        "@typescript-eslint/parser": "^5.15.0",
+        "typescript": ">= 3"
       }
     },
     "@terrestris/ol-util": {
@@ -34605,9 +36135,9 @@
       }
     },
     "@testing-library/dom": {
-      "version": "8.14.0",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.14.0.tgz",
-      "integrity": "sha512-m8FOdUo77iMTwVRCyzWcqxlEIk+GnopbrRI15a0EaLbpZSCinIVI4kSQzWhkShK83GogvEFJSsHF3Ws0z1vrqA==",
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.13.0.tgz",
+      "integrity": "sha512-9VHgfIatKNXQNaZTtLnalIy0jNZzY35a4S3oi08YAt9Hv1VsfZ/DfA45lM8D/UhtHBGJ4/lGwp0PZkVndRkoOQ==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.10.4",
@@ -34762,9 +36292,9 @@
       }
     },
     "@testing-library/user-event": {
-      "version": "14.2.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.2.1.tgz",
-      "integrity": "sha512-HOr1QiODrq+0j9lKU5i10y9TbhxMBMRMGimNx10asdmau9cb8Xb1Vyg0GvTwyIL2ziQyh2kAloOtAQFBQVuecA==",
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.2.0.tgz",
+      "integrity": "sha512-+hIlG4nJS6ivZrKnOP7OGsDu9Fxmryj9vCl8x0ZINtTJcCHs2zLsYif5GzuRiBF2ck5GZG2aQr7Msg+EHlnYVQ==",
       "dev": true,
       "requires": {}
     },
@@ -34781,30 +36311,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
       "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
-      "dev": true
-    },
-    "@tsconfig/node10": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
-      "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
-      "dev": true
-    },
-    "@tsconfig/node12": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
-      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
-      "dev": true
-    },
-    "@tsconfig/node14": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
-      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
-      "dev": true
-    },
-    "@tsconfig/node16": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
-      "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
       "dev": true
     },
     "@turf/along": {
@@ -36209,39 +37715,13 @@
       }
     },
     "@types/jest": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-28.1.3.tgz",
-      "integrity": "sha512-Tsbjk8Y2hkBaY/gJsataeb4q9Mubw9EOz7+4RjPkzD5KjTvHHs7cpws22InaoXxAVAhF5HfFbzJjo6oKWqSZLw==",
+      "version": "28.1.1",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-28.1.1.tgz",
+      "integrity": "sha512-C2p7yqleUKtCkVjlOur9BWVA4HgUQmEj/HWCt5WzZ5mLXrWnyIfl0wGuArc+kBXsy0ZZfLp+7dywB4HtSVYGVA==",
       "dev": true,
       "requires": {
-        "jest-matcher-utils": "^28.0.0",
-        "pretty-format": "^28.0.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-          "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-          "dev": true
-        },
-        "pretty-format": {
-          "version": "28.1.1",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-28.1.1.tgz",
-          "integrity": "sha512-wwJbVTGFHeucr5Jw2bQ9P+VYHyLdAqedFLEkdQUVaBF/eiidDwH5OpilINq4mEfhbCjLnirt6HTTDhv1HaTIQw==",
-          "dev": true,
-          "requires": {
-            "@jest/schemas": "^28.0.2",
-            "ansi-regex": "^5.0.1",
-            "ansi-styles": "^5.0.0",
-            "react-is": "^18.0.0"
-          }
-        },
-        "react-is": {
-          "version": "18.2.0",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
-          "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
-          "dev": true
-        }
+        "jest-matcher-utils": "^27.0.0",
+        "pretty-format": "^27.0.0"
       }
     },
     "@types/jsdom": {
@@ -36325,9 +37805,9 @@
       }
     },
     "@types/node": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.0.0.tgz",
-      "integrity": "sha512-cHlGmko4gWLVI27cGJntjs/Sj8th9aYwplmZFwmmgYQQvL5NUsgVJG7OddLvNfLqYS31KFN0s3qlaD9qCaxACA=="
+      "version": "17.0.42",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.42.tgz",
+      "integrity": "sha512-Q5BPGyGKcvQgAMbsr7qEGN/kIPN6zZecYYABeTDBizOsau+2NMdSVTar9UQw21A2+JyA2KRNDYaYrPB0Rpk2oQ=="
     },
     "@types/normalize-package-data": {
       "version": "2.4.1",
@@ -36532,14 +38012,14 @@
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "5.29.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.29.0.tgz",
-      "integrity": "sha512-kgTsISt9pM53yRFQmLZ4npj99yGl3x3Pl7z4eA66OuTzAGC4bQB5H5fuLwPnqTKU3yyrrg4MIhjF17UYnL4c0w==",
+      "version": "5.27.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.27.1.tgz",
+      "integrity": "sha512-6dM5NKT57ZduNnJfpY81Phe9nc9wolnMCnknb1im6brWi1RYv84nbMS3olJa27B6+irUVV1X/Wb+Am0FjJdGFw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "5.29.0",
-        "@typescript-eslint/type-utils": "5.29.0",
-        "@typescript-eslint/utils": "5.29.0",
+        "@typescript-eslint/scope-manager": "5.27.1",
+        "@typescript-eslint/type-utils": "5.27.1",
+        "@typescript-eslint/utils": "5.27.1",
         "debug": "^4.3.4",
         "functional-red-black-tree": "^1.0.1",
         "ignore": "^5.2.0",
@@ -36560,41 +38040,41 @@
       }
     },
     "@typescript-eslint/parser": {
-      "version": "5.29.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.29.0.tgz",
-      "integrity": "sha512-ruKWTv+x0OOxbzIw9nW5oWlUopvP/IQDjB5ZqmTglLIoDTctLlAJpAQFpNPJP/ZI7hTT9sARBosEfaKbcFuECw==",
+      "version": "5.27.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.27.1.tgz",
+      "integrity": "sha512-7Va2ZOkHi5NP+AZwb5ReLgNF6nWLGTeUJfxdkVUAPPSaAdbWNnFZzLZ4EGGmmiCTg+AwlbE1KyUYTBglosSLHQ==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "5.29.0",
-        "@typescript-eslint/types": "5.29.0",
-        "@typescript-eslint/typescript-estree": "5.29.0",
+        "@typescript-eslint/scope-manager": "5.27.1",
+        "@typescript-eslint/types": "5.27.1",
+        "@typescript-eslint/typescript-estree": "5.27.1",
         "debug": "^4.3.4"
       },
       "dependencies": {
         "@typescript-eslint/scope-manager": {
-          "version": "5.29.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.29.0.tgz",
-          "integrity": "sha512-etbXUT0FygFi2ihcxDZjz21LtC+Eps9V2xVx09zFoN44RRHPrkMflidGMI+2dUs821zR1tDS6Oc9IXxIjOUZwA==",
+          "version": "5.27.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.27.1.tgz",
+          "integrity": "sha512-fQEOSa/QroWE6fAEg+bJxtRZJTH8NTskggybogHt4H9Da8zd4cJji76gA5SBlR0MgtwF7rebxTbDKB49YUCpAg==",
           "dev": true,
           "requires": {
-            "@typescript-eslint/types": "5.29.0",
-            "@typescript-eslint/visitor-keys": "5.29.0"
+            "@typescript-eslint/types": "5.27.1",
+            "@typescript-eslint/visitor-keys": "5.27.1"
           }
         },
         "@typescript-eslint/types": {
-          "version": "5.29.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.29.0.tgz",
-          "integrity": "sha512-X99VbqvAXOMdVyfFmksMy3u8p8yoRGITgU1joBJPzeYa0rhdf5ok9S56/itRoUSh99fiDoMtarSIJXo7H/SnOg==",
+          "version": "5.27.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.27.1.tgz",
+          "integrity": "sha512-LgogNVkBhCTZU/m8XgEYIWICD6m4dmEDbKXESCbqOXfKZxRKeqpiJXQIErv66sdopRKZPo5l32ymNqibYEH/xg==",
           "dev": true
         },
         "@typescript-eslint/typescript-estree": {
-          "version": "5.29.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.29.0.tgz",
-          "integrity": "sha512-mQvSUJ/JjGBdvo+1LwC+GY2XmSYjK1nAaVw2emp/E61wEVYEyibRHCqm1I1vEKbXCpUKuW4G7u9ZCaZhJbLoNQ==",
+          "version": "5.27.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.27.1.tgz",
+          "integrity": "sha512-DnZvvq3TAJ5ke+hk0LklvxwYsnXpRdqUY5gaVS0D4raKtbznPz71UJGnPTHEFo0GDxqLOLdMkkmVZjSpET1hFw==",
           "dev": true,
           "requires": {
-            "@typescript-eslint/types": "5.29.0",
-            "@typescript-eslint/visitor-keys": "5.29.0",
+            "@typescript-eslint/types": "5.27.1",
+            "@typescript-eslint/visitor-keys": "5.27.1",
             "debug": "^4.3.4",
             "globby": "^11.1.0",
             "is-glob": "^4.0.3",
@@ -36603,12 +38083,12 @@
           }
         },
         "@typescript-eslint/visitor-keys": {
-          "version": "5.29.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.29.0.tgz",
-          "integrity": "sha512-Hpb/mCWsjILvikMQoZIE3voc9wtQcS0A9FUw3h8bhr9UxBdtI/tw1ZDZUOXHXLOVMedKCH5NxyzATwnU78bWCQ==",
+          "version": "5.27.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.27.1.tgz",
+          "integrity": "sha512-xYs6ffo01nhdJgPieyk7HAOpjhTsx7r/oB9LWEhwAXgwn33tkr+W8DI2ChboqhZlC4q3TC6geDYPoiX8ROqyOQ==",
           "dev": true,
           "requires": {
-            "@typescript-eslint/types": "5.29.0",
+            "@typescript-eslint/types": "5.27.1",
             "eslint-visitor-keys": "^3.3.0"
           }
         },
@@ -36630,40 +38110,40 @@
       }
     },
     "@typescript-eslint/scope-manager": {
-      "version": "5.29.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.29.0.tgz",
-      "integrity": "sha512-etbXUT0FygFi2ihcxDZjz21LtC+Eps9V2xVx09zFoN44RRHPrkMflidGMI+2dUs821zR1tDS6Oc9IXxIjOUZwA==",
+      "version": "5.27.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.27.1.tgz",
+      "integrity": "sha512-fQEOSa/QroWE6fAEg+bJxtRZJTH8NTskggybogHt4H9Da8zd4cJji76gA5SBlR0MgtwF7rebxTbDKB49YUCpAg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.29.0",
-        "@typescript-eslint/visitor-keys": "5.29.0"
+        "@typescript-eslint/types": "5.27.1",
+        "@typescript-eslint/visitor-keys": "5.27.1"
       }
     },
     "@typescript-eslint/type-utils": {
-      "version": "5.29.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.29.0.tgz",
-      "integrity": "sha512-JK6bAaaiJozbox3K220VRfCzLa9n0ib/J+FHIwnaV3Enw/TO267qe0pM1b1QrrEuy6xun374XEAsRlA86JJnyg==",
+      "version": "5.27.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.27.1.tgz",
+      "integrity": "sha512-+UC1vVUWaDHRnC2cQrCJ4QtVjpjjCgjNFpg8b03nERmkHv9JV9X5M19D7UFMd+/G7T/sgFwX2pGmWK38rqyvXw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/utils": "5.29.0",
+        "@typescript-eslint/utils": "5.27.1",
         "debug": "^4.3.4",
         "tsutils": "^3.21.0"
       }
     },
     "@typescript-eslint/types": {
-      "version": "5.29.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.29.0.tgz",
-      "integrity": "sha512-X99VbqvAXOMdVyfFmksMy3u8p8yoRGITgU1joBJPzeYa0rhdf5ok9S56/itRoUSh99fiDoMtarSIJXo7H/SnOg==",
+      "version": "5.27.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.27.1.tgz",
+      "integrity": "sha512-LgogNVkBhCTZU/m8XgEYIWICD6m4dmEDbKXESCbqOXfKZxRKeqpiJXQIErv66sdopRKZPo5l32ymNqibYEH/xg==",
       "dev": true
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "5.29.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.29.0.tgz",
-      "integrity": "sha512-mQvSUJ/JjGBdvo+1LwC+GY2XmSYjK1nAaVw2emp/E61wEVYEyibRHCqm1I1vEKbXCpUKuW4G7u9ZCaZhJbLoNQ==",
+      "version": "5.27.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.27.1.tgz",
+      "integrity": "sha512-DnZvvq3TAJ5ke+hk0LklvxwYsnXpRdqUY5gaVS0D4raKtbznPz71UJGnPTHEFo0GDxqLOLdMkkmVZjSpET1hFw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.29.0",
-        "@typescript-eslint/visitor-keys": "5.29.0",
+        "@typescript-eslint/types": "5.27.1",
+        "@typescript-eslint/visitor-keys": "5.27.1",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -36683,26 +38163,26 @@
       }
     },
     "@typescript-eslint/utils": {
-      "version": "5.29.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.29.0.tgz",
-      "integrity": "sha512-3Eos6uP1nyLOBayc/VUdKZikV90HahXE5Dx9L5YlSd/7ylQPXhLk1BYb29SDgnBnTp+jmSZUU0QxUiyHgW4p7A==",
+      "version": "5.27.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.27.1.tgz",
+      "integrity": "sha512-mZ9WEn1ZLDaVrhRaYgzbkXBkTPghPFsup8zDbbsYTxC5OmqrFE7skkKS/sraVsLP3TcT3Ki5CSyEFBRkLH/H/w==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.9",
-        "@typescript-eslint/scope-manager": "5.29.0",
-        "@typescript-eslint/types": "5.29.0",
-        "@typescript-eslint/typescript-estree": "5.29.0",
+        "@typescript-eslint/scope-manager": "5.27.1",
+        "@typescript-eslint/types": "5.27.1",
+        "@typescript-eslint/typescript-estree": "5.27.1",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^3.0.0"
       }
     },
     "@typescript-eslint/visitor-keys": {
-      "version": "5.29.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.29.0.tgz",
-      "integrity": "sha512-Hpb/mCWsjILvikMQoZIE3voc9wtQcS0A9FUw3h8bhr9UxBdtI/tw1ZDZUOXHXLOVMedKCH5NxyzATwnU78bWCQ==",
+      "version": "5.27.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.27.1.tgz",
+      "integrity": "sha512-xYs6ffo01nhdJgPieyk7HAOpjhTsx7r/oB9LWEhwAXgwn33tkr+W8DI2ChboqhZlC4q3TC6geDYPoiX8ROqyOQ==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.29.0",
+        "@typescript-eslint/types": "5.27.1",
         "eslint-visitor-keys": "^3.3.0"
       },
       "dependencies": {
@@ -37187,12 +38667,6 @@
         "delegates": "^1.0.0",
         "readable-stream": "^3.6.0"
       }
-    },
-    "arg": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-      "dev": true
     },
     "argparse": {
       "version": "1.0.10",
@@ -39006,17 +40480,6 @@
         "q": "^1.5.1"
       }
     },
-    "conventional-changelog-conventionalcommits": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-5.0.0.tgz",
-      "integrity": "sha512-lCDbA+ZqVFQGUj7h9QBKoIpLhl8iihkO0nCTyRNzuXtcd7ubODpYB04IFy31JloiJgG0Uovu8ot8oxRzn7Nwtw==",
-      "dev": true,
-      "requires": {
-        "compare-func": "^2.0.0",
-        "lodash": "^4.17.15",
-        "q": "^1.5.1"
-      }
-    },
     "conventional-changelog-writer": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-5.0.1.tgz",
@@ -39238,16 +40701,6 @@
         "yaml": "^1.10.0"
       }
     },
-    "cosmiconfig-typescript-loader": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-2.0.1.tgz",
-      "integrity": "sha512-B9s6sX/omXq7I6gC6+YgLmrBFMJhPWew7ty/X5Tuwtd2zOSgWaUdXjkuVwbe3qqcdETo60+1nSVMekq//LIXVA==",
-      "dev": true,
-      "requires": {
-        "cosmiconfig": "^7",
-        "ts-node": "^10.8.0"
-      }
-    },
     "coveralls": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.1.1.tgz",
@@ -39260,12 +40713,6 @@
         "minimist": "^1.2.5",
         "request": "^2.88.2"
       }
-    },
-    "create-require": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-      "dev": true
     },
     "cross-fetch": {
       "version": "3.1.5",
@@ -39432,12 +40879,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/d3-voronoi/-/d3-voronoi-1.1.2.tgz",
       "integrity": "sha1-Fodmfo8TotFYyAwUgMWinLDYlzw="
-    },
-    "dargs": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/dargs/-/dargs-7.0.0.tgz",
-      "integrity": "sha512-2iy1EkLdlBzQGvbweYRFxmFath8+K7+AKB0TlhHWkNuH+TmovaMH/Wp7V7R4u7f4SnX3OgLsU9t1NI9ioDnUpg==",
-      "dev": true
     },
     "dashdash": {
       "version": "1.14.1",
@@ -39823,16 +41264,10 @@
         }
       }
     },
-    "diff": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-      "dev": true
-    },
     "diff-sequences": {
-      "version": "28.1.1",
-      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-28.1.1.tgz",
-      "integrity": "sha512-FU0iFaH/E23a+a718l8Qa/19bF9p06kgE0KipMOMadwa3SjnaElKzPaUC0vnibs6/B/9ni97s61mcejk8W1fQw==",
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-27.5.1.tgz",
+      "integrity": "sha512-k1gCAXAsNgLwEL+Y8Wvl+M6oEFj5bgazfZULpS5CneoPPXRaCCW7dm+q21Ky2VEE5X+VeRDBVg1Pcvvsr4TtNQ==",
       "dev": true
     },
     "dir-glob": {
@@ -40310,9 +41745,9 @@
       }
     },
     "eslint": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.18.0.tgz",
-      "integrity": "sha512-As1EfFMVk7Xc6/CvhssHUjsAQSkpfXvUGMFC3ce8JDe6WvqCgRrLOBQbVpsBFr1X1V+RACOadnzVvcUS5ni2bA==",
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.17.0.tgz",
+      "integrity": "sha512-gq0m0BTJfci60Fz4nczYxNAlED+sMcihltndR8t9t1evnU/azx53x3t2UHXC/uRjcbvRw/XctpaNygSTcQD+Iw==",
       "dev": true,
       "requires": {
         "@eslint/eslintrc": "^1.3.0",
@@ -40528,9 +41963,9 @@
       }
     },
     "eslint-plugin-react-hooks": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz",
-      "integrity": "sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.5.0.tgz",
+      "integrity": "sha512-8k1gRt7D7h03kd+SAAlzXkQwWK22BnK6GKZG+FJA6BAGy22CFvl8kCIXKpVux0cCxMWDQUPqSok0LKaZ0aOcCw==",
       "dev": true,
       "requires": {}
     },
@@ -40828,6 +42263,119 @@
         "jest-matcher-utils": "^28.1.1",
         "jest-message-util": "^28.1.1",
         "jest-util": "^28.1.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "diff-sequences": {
+          "version": "28.1.1",
+          "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-28.1.1.tgz",
+          "integrity": "sha512-FU0iFaH/E23a+a718l8Qa/19bF9p06kgE0KipMOMadwa3SjnaElKzPaUC0vnibs6/B/9ni97s61mcejk8W1fQw==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "jest-diff": {
+          "version": "28.1.1",
+          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-28.1.1.tgz",
+          "integrity": "sha512-/MUUxeR2fHbqHoMMiffe/Afm+U8U4olFRJ0hiVG2lZatPJcnGxx292ustVu7bULhjV65IYMxRdploAKLbcrsyg==",
+          "dev": true,
+          "requires": {
+            "chalk": "^4.0.0",
+            "diff-sequences": "^28.1.1",
+            "jest-get-type": "^28.0.2",
+            "pretty-format": "^28.1.1"
+          }
+        },
+        "jest-get-type": {
+          "version": "28.0.2",
+          "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-28.0.2.tgz",
+          "integrity": "sha512-ioj2w9/DxSYHfOm5lJKCdcAmPJzQXmbM/Url3rhlghrPvT3tt+7a/+oXc9azkKmLvoiXjtV83bEWqi+vs5nlPA==",
+          "dev": true
+        },
+        "jest-matcher-utils": {
+          "version": "28.1.1",
+          "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-28.1.1.tgz",
+          "integrity": "sha512-NPJPRWrbmR2nAJ+1nmnfcKKzSwgfaciCCrYZzVnNoxVoyusYWIjkBMNvu0RHJe7dNj4hH3uZOPZsQA+xAYWqsw==",
+          "dev": true,
+          "requires": {
+            "chalk": "^4.0.0",
+            "jest-diff": "^28.1.1",
+            "jest-get-type": "^28.0.2",
+            "pretty-format": "^28.1.1"
+          }
+        },
+        "pretty-format": {
+          "version": "28.1.1",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-28.1.1.tgz",
+          "integrity": "sha512-wwJbVTGFHeucr5Jw2bQ9P+VYHyLdAqedFLEkdQUVaBF/eiidDwH5OpilINq4mEfhbCjLnirt6HTTDhv1HaTIQw==",
+          "dev": true,
+          "requires": {
+            "@jest/schemas": "^28.0.2",
+            "ansi-regex": "^5.0.1",
+            "ansi-styles": "^5.0.0",
+            "react-is": "^18.0.0"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "5.2.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+              "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+              "dev": true
+            }
+          }
+        },
+        "react-is": {
+          "version": "18.1.0",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.1.0.tgz",
+          "integrity": "sha512-Fl7FuabXsJnV5Q1qIOQwx/sagGF18kogb4gpfcG4gjLBWO0WDiiz1ko/ExayuxE7InyQkBLkxRFG5oxY6Uu3Kg==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
       }
     },
     "express": {
@@ -41564,1388 +43112,18 @@
       }
     },
     "geostyler-openlayers-parser": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/geostyler-openlayers-parser/-/geostyler-openlayers-parser-2.5.0.tgz",
-      "integrity": "sha512-Uum/lDci8oqhBA/c0RZbD91aXP4ycjlsAp4ZoVAPDHT6Og0XyF5Tze8wg0Ux44CerE6W+m2DfWkOTAP+iaakzQ==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/geostyler-openlayers-parser/-/geostyler-openlayers-parser-3.0.2.tgz",
+      "integrity": "sha512-HiEjaobWR/UU/1NoSyobV85OIdoX7gxQaaTVQaFIyo7+8zN+RWRMf99chmY9PSasX8b5khN1LJfVL1ySUKwcsQ==",
       "requires": {
-        "@terrestris/ol-util": "^4.0.1",
-        "geostyler-style": "^4.0.0",
-        "lodash": "^4.17.15"
-      },
-      "dependencies": {
-        "@terrestris/ol-util": {
-          "version": "4.1.3",
-          "resolved": "https://registry.npmjs.org/@terrestris/ol-util/-/ol-util-4.1.3.tgz",
-          "integrity": "sha512-vTS7rXxOcvTpXQzRGR6DVldEYcbFjADQ9/ArSKeq9yCmmY9wb3dkeGKw+rN/dltu6oZbaswjsUsBQe060kiMOQ==",
-          "requires": {
-            "@terrestris/base-util": "^1.0.0",
-            "@turf/turf": "^5.1.6",
-            "lodash": "^4.17.20",
-            "proj4": "^2.7.0",
-            "shpjs": "^3.6.3"
-          }
-        },
-        "@turf/along": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/along/-/along-5.1.5.tgz",
-          "integrity": "sha512-N7BN1xvj6VWMe3UpjQDdVI0j0oY/EZ0bWgOgBXc4DlJ411uEsKCh6iBv0b2MSxQ3YUXEez3oc5FcgO9eVSs7iQ==",
-          "requires": {
-            "@turf/bearing": "^5.1.5",
-            "@turf/destination": "^5.1.5",
-            "@turf/distance": "^5.1.5",
-            "@turf/helpers": "^5.1.5"
-          }
-        },
-        "@turf/area": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/area/-/area-5.1.5.tgz",
-          "integrity": "sha512-lz16gqtvoz+j1jD9y3zj0Z5JnGNd3YfS0h+DQY1EcZymvi75Frm9i5YbEyth0RfxYZeOVufY7YIS3LXbJlI57g==",
-          "requires": {
-            "@turf/helpers": "^5.1.5",
-            "@turf/meta": "^5.1.5"
-          }
-        },
-        "@turf/bbox": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/bbox/-/bbox-5.1.5.tgz",
-          "integrity": "sha512-sYQU4fqsOYYJoD8UndC1n2hy8hV/lGIAmMLKWuzwmPUWqWOuSKWUcoRWDi9mGB0GvQQe/ow2IxZr8UaVaGz3sQ==",
-          "requires": {
-            "@turf/helpers": "^5.1.5",
-            "@turf/meta": "^5.1.5"
-          }
-        },
-        "@turf/bbox-clip": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/bbox-clip/-/bbox-clip-5.1.5.tgz",
-          "integrity": "sha512-KP64aoTvjcXxWHeM/Hs25vOQUBJgyJi7DlRVEoZofFJiR1kPnmDQrK7Xj+60lAk5cxuqzFnaPPxUk9Q+3v4p1Q==",
-          "requires": {
-            "@turf/helpers": "^5.1.5",
-            "@turf/invariant": "^5.1.5",
-            "lineclip": "^1.1.5"
-          }
-        },
-        "@turf/bbox-polygon": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/bbox-polygon/-/bbox-polygon-5.1.5.tgz",
-          "integrity": "sha512-PKVPF5LABFWZJud8KzzfesLGm5ihiwLbVa54HJjYySe6yqU/cr5q/qcN9TWptynOFhNktG1dr0KXVG0I2FZmfw==",
-          "requires": {
-            "@turf/helpers": "^5.1.5"
-          }
-        },
-        "@turf/bearing": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/bearing/-/bearing-5.1.5.tgz",
-          "integrity": "sha512-PrvZuJjnXGseB8hUatIjsrK3tgD3wttyRnVYXTbSfXYJZzaOfHDMplgO4lxXQp7diraZhGhCdSlbMvRRXItbUQ==",
-          "requires": {
-            "@turf/helpers": "^5.1.5",
-            "@turf/invariant": "^5.1.5"
-          }
-        },
-        "@turf/bezier-spline": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/bezier-spline/-/bezier-spline-5.1.5.tgz",
-          "integrity": "sha512-Y9NoComaGgFFFe9TWWE/cEMg2+EnBfU1R3112ec2wlx21ygDmFGXs4boOS71WM4ySwm/dbS3wxnbVxs4j68sKw==",
-          "requires": {
-            "@turf/helpers": "^5.1.5",
-            "@turf/invariant": "^5.1.5"
-          }
-        },
-        "@turf/boolean-clockwise": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/boolean-clockwise/-/boolean-clockwise-5.1.5.tgz",
-          "integrity": "sha512-FqbmEEOJ4rU4/2t7FKx0HUWmjFEVqR+NJrFP7ymGSjja2SQ7Q91nnBihGuT+yuHHl6ElMjQ3ttsB/eTmyCycxA==",
-          "requires": {
-            "@turf/helpers": "^5.1.5",
-            "@turf/invariant": "^5.1.5"
-          }
-        },
-        "@turf/boolean-contains": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/boolean-contains/-/boolean-contains-5.1.5.tgz",
-          "integrity": "sha512-x2HeEieeE9vBQrTdCuj4swnAXlpKbj9ChxMdDTV479c0m2gVmfea83ocmkj3w+9cvAaS63L8WqFyNVSmkwqljQ==",
-          "requires": {
-            "@turf/bbox": "^5.1.5",
-            "@turf/boolean-point-in-polygon": "^5.1.5",
-            "@turf/boolean-point-on-line": "^5.1.5",
-            "@turf/helpers": "^5.1.5",
-            "@turf/invariant": "^5.1.5"
-          }
-        },
-        "@turf/boolean-crosses": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/boolean-crosses/-/boolean-crosses-5.1.5.tgz",
-          "integrity": "sha512-odljvS7INr9k/8yXeyXQVry7GqEaChOmXawP0+SoTfGO3hgptiik59TLU/Yjn/SLFjE2Ul54Ga1jKFSL7vvH0Q==",
-          "requires": {
-            "@turf/boolean-point-in-polygon": "^5.1.5",
-            "@turf/helpers": "^5.1.5",
-            "@turf/invariant": "^5.1.5",
-            "@turf/line-intersect": "^5.1.5",
-            "@turf/polygon-to-line": "^5.1.5"
-          }
-        },
-        "@turf/boolean-disjoint": {
-          "version": "5.1.6",
-          "resolved": "https://registry.npmjs.org/@turf/boolean-disjoint/-/boolean-disjoint-5.1.6.tgz",
-          "integrity": "sha512-KHvUS6SBNYHBCLIJEJrg04pF5Oy+Fqn8V5G9U+9pti5vI9tyX7Ln2g7RSB7iJ1Cxsz8QAi6OukhXjEF2/8ZpGg==",
-          "requires": {
-            "@turf/boolean-point-in-polygon": "^5.1.5",
-            "@turf/helpers": "^5.1.5",
-            "@turf/line-intersect": "^5.1.5",
-            "@turf/meta": "^5.1.5",
-            "@turf/polygon-to-line": "^5.1.5"
-          }
-        },
-        "@turf/boolean-equal": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/boolean-equal/-/boolean-equal-5.1.5.tgz",
-          "integrity": "sha512-QEMbhDPV+J8PlRkMlVg6m5oSLaYUpOx2VUhDDekQ73FlpnhFBKRIlidhvHtS6CYnEw8d+/zA3h8Z18B4W4mq9Q==",
-          "requires": {
-            "@turf/clean-coords": "^5.1.5",
-            "@turf/helpers": "^5.1.5",
-            "@turf/invariant": "^5.1.5",
-            "geojson-equality": "0.1.6"
-          }
-        },
-        "@turf/boolean-overlap": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/boolean-overlap/-/boolean-overlap-5.1.5.tgz",
-          "integrity": "sha512-lizojgU559KME0G705YAgWVa0B3/tsWNobMzOEWDx/1rABWTojCY4uxw2rFxpOsP++s8JJHrGWXRLh1PbdAvRQ==",
-          "requires": {
-            "@turf/helpers": "^5.1.5",
-            "@turf/invariant": "^5.1.5",
-            "@turf/line-intersect": "^5.1.5",
-            "@turf/line-overlap": "^5.1.5",
-            "@turf/meta": "^5.1.5",
-            "geojson-equality": "0.1.6"
-          }
-        },
-        "@turf/boolean-parallel": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/boolean-parallel/-/boolean-parallel-5.1.5.tgz",
-          "integrity": "sha512-eeuGgDhnas3nJ22A/DD8aiH0kg9dSzbQChIMAqYRPGg3pWNK41aGAbeh5z0GO5N/EVFX1+ga5a0vsPmiRgQB5g==",
-          "requires": {
-            "@turf/clean-coords": "^5.1.5",
-            "@turf/helpers": "^5.1.5",
-            "@turf/line-segment": "^5.1.5",
-            "@turf/rhumb-bearing": "^5.1.5"
-          },
-          "dependencies": {
-            "@turf/rhumb-bearing": {
-              "version": "5.1.5",
-              "resolved": "https://registry.npmjs.org/@turf/rhumb-bearing/-/rhumb-bearing-5.1.5.tgz",
-              "integrity": "sha512-zXTl2khjwf7mx2D1uPo5vgpGgP4sM2VrKDbJNKyulPu4TO4ELt8x7FsKyCBlRTzzQf284t/xnNcZOfUbkkd70g==",
-              "requires": {
-                "@turf/helpers": "^5.1.5",
-                "@turf/invariant": "^5.1.5"
-              }
-            }
-          }
-        },
-        "@turf/boolean-point-in-polygon": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/boolean-point-in-polygon/-/boolean-point-in-polygon-5.1.5.tgz",
-          "integrity": "sha512-y+gbAhLmsAZH9uYhv+C68pu06mxsGIm3o7l0hzVkc/PXYdbkr+vKe7n7PfSN3xpVA3qoDLKLpCGOqeW8/ThaJA==",
-          "requires": {
-            "@turf/helpers": "^5.1.5",
-            "@turf/invariant": "^5.1.5"
-          }
-        },
-        "@turf/boolean-point-on-line": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/boolean-point-on-line/-/boolean-point-on-line-5.1.5.tgz",
-          "integrity": "sha512-Zf4d28mckV2tYfLWf2iqxQ8eeLZqi2HGimM26mptf1OCEIwc1wfkKgLRRJXMu94Crvd/pJxjRAjoYGcGliP6Vg==",
-          "requires": {
-            "@turf/helpers": "^5.1.5",
-            "@turf/invariant": "^5.1.5"
-          }
-        },
-        "@turf/boolean-within": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/boolean-within/-/boolean-within-5.1.5.tgz",
-          "integrity": "sha512-CNAtrvm4HiUwV/vhpGhvJzfhV9CN7VhPC5y4tTfQicK82fYY6ifPz0iaNpUOmshU6+TAot/fsVQVgDJ4t7HXcA==",
-          "requires": {
-            "@turf/bbox": "^5.1.5",
-            "@turf/boolean-point-in-polygon": "^5.1.5",
-            "@turf/boolean-point-on-line": "^5.1.5",
-            "@turf/helpers": "^5.1.5",
-            "@turf/invariant": "^5.1.5"
-          }
-        },
-        "@turf/buffer": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/buffer/-/buffer-5.1.5.tgz",
-          "integrity": "sha512-U3LU0HF/JNFUNabpB5ArpNG6yPla7yR5XPrZvzZRH48vvbr/N0rkSRI0tJFRWTz7ntugVm9X0OD9Y382NTJRhA==",
-          "requires": {
-            "@turf/bbox": "^5.1.5",
-            "@turf/center": "^5.1.5",
-            "@turf/helpers": "^5.1.5",
-            "@turf/meta": "^5.1.5",
-            "@turf/projection": "^5.1.5",
-            "d3-geo": "1.7.1",
-            "turf-jsts": "*"
-          },
-          "dependencies": {
-            "@turf/projection": {
-              "version": "5.1.5",
-              "resolved": "https://registry.npmjs.org/@turf/projection/-/projection-5.1.5.tgz",
-              "integrity": "sha512-TWKJDFeEKQhI4Ce1+2PuOSDggn4cnMibqyUoCpIW+4KxUC1R88SE3/SYomqzwxMn00O09glHSycPkGD5JzHd8A==",
-              "requires": {
-                "@turf/clone": "^5.1.5",
-                "@turf/helpers": "^5.1.5",
-                "@turf/meta": "^5.1.5"
-              }
-            }
-          }
-        },
-        "@turf/center": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/center/-/center-5.1.5.tgz",
-          "integrity": "sha512-Dy1TvAv2oHKFddZcWqlVsanxurfcZV1Mmb1E+7H7GRKI+fXZTfRjwCdbiZCbO/tPwxt8jWQHWdLHn8E9lecc3A==",
-          "requires": {
-            "@turf/bbox": "^5.1.5",
-            "@turf/helpers": "^5.1.5"
-          }
-        },
-        "@turf/center-mean": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/center-mean/-/center-mean-5.1.5.tgz",
-          "integrity": "sha512-XdkBXzFUuyCqu5EPlBwgkv8FLA8pIGBnt7xy5cxxhxKOYLMrKqwMPPHPA84TjeQpNti0gH0CVuOk2r1f/Pp8iQ==",
-          "requires": {
-            "@turf/bbox": "^5.1.5",
-            "@turf/helpers": "^5.1.5",
-            "@turf/meta": "^5.1.5"
-          }
-        },
-        "@turf/center-median": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/center-median/-/center-median-5.1.5.tgz",
-          "integrity": "sha512-M+O6bSNsIDKZ4utk/YzSOIg6W0isjLVWud+TCLWyrDCWTSERlSJlhOaVE1y7cObhG8nYBHvmszqZyoAY6nufQw==",
-          "requires": {
-            "@turf/center-mean": "^5.1.5",
-            "@turf/centroid": "^5.1.5",
-            "@turf/distance": "^5.1.5",
-            "@turf/helpers": "^5.1.5",
-            "@turf/meta": "^5.1.5"
-          }
-        },
-        "@turf/center-of-mass": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/center-of-mass/-/center-of-mass-5.1.5.tgz",
-          "integrity": "sha512-UvI7q6GgW3afCVIDOyTRuLT54v9Xwv65Xudxh4FIT6w7HNU4KUBtTGnx0NuhODZcgvZgWVWVakhmIcHQTMjYYA==",
-          "requires": {
-            "@turf/centroid": "^5.1.5",
-            "@turf/convex": "^5.1.5",
-            "@turf/helpers": "^5.1.5",
-            "@turf/invariant": "^5.1.5",
-            "@turf/meta": "^5.1.5"
-          }
-        },
-        "@turf/centroid": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/centroid/-/centroid-5.1.5.tgz",
-          "integrity": "sha512-0m9ZAZJB4YXLDxF2fWGqlE/g9Y68cebeWaRNOMN+e6Bti1fz0JKQuaEqJV+J8xOmODPHSMbZZ1SqSDVRgVHP2Q==",
-          "requires": {
-            "@turf/helpers": "^5.1.5",
-            "@turf/meta": "^5.1.5"
-          }
-        },
-        "@turf/circle": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/circle/-/circle-5.1.5.tgz",
-          "integrity": "sha512-CNaEtvp38Q+TSFJHdzdl5iYNjBFZRluRTFikIuEcennSeMJD60nP0dMubP58TR/QQn541eNDUyED90V4KuOjyQ==",
-          "requires": {
-            "@turf/destination": "^5.1.5",
-            "@turf/helpers": "^5.1.5"
-          }
-        },
-        "@turf/clean-coords": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/clean-coords/-/clean-coords-5.1.5.tgz",
-          "integrity": "sha512-xd/iSM0McVUxbu81KCKDqirCsYkKk3EAwpDjYI8vIQ+eKf/MLSdteRcm3PB7wo2y6JcYp4dMGv2cr9IP7V+dXQ==",
-          "requires": {
-            "@turf/helpers": "^5.1.5",
-            "@turf/invariant": "^5.1.5"
-          }
-        },
-        "@turf/clone": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/clone/-/clone-5.1.5.tgz",
-          "integrity": "sha512-//pITsQ8xUdcQ9pVb4JqXiSqG4dos5Q9N4sYFoWghX21tfOV2dhc5TGqYOhnHrQS7RiKQL1vQ48kIK34gQ5oRg==",
-          "requires": {
-            "@turf/helpers": "^5.1.5"
-          }
-        },
-        "@turf/clusters": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/clusters/-/clusters-5.1.5.tgz",
-          "integrity": "sha512-+rQe+g66xfbIXz58tveXQCDdE9hzqRJtDVSw5xth92TvCcL4J60ZKN8mHNUSn1ZZvpUHtVPe4dYcbtk5bW8fXQ==",
-          "requires": {
-            "@turf/helpers": "^5.1.5",
-            "@turf/meta": "^5.1.5"
-          }
-        },
-        "@turf/clusters-dbscan": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/clusters-dbscan/-/clusters-dbscan-5.1.5.tgz",
-          "integrity": "sha512-X3qLLHJkwMuv+xdWQ08NtOc6BgeqCKKSAltyyAZ7iImE65f0C+sW024DfHSbTMsZVXBFst2Q6RQY8RVUf3QBeQ==",
-          "requires": {
-            "@turf/clone": "^5.1.5",
-            "@turf/distance": "^5.1.5",
-            "@turf/helpers": "^5.1.5",
-            "@turf/invariant": "^5.1.5",
-            "@turf/meta": "^5.1.5",
-            "density-clustering": "1.3.0"
-          }
-        },
-        "@turf/clusters-kmeans": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/clusters-kmeans/-/clusters-kmeans-5.1.5.tgz",
-          "integrity": "sha512-W6raiv9+fRgmJxCvKrpSacbLXzh7beZUk0A1pjF82Fv3CFTrXAJbgAyIbdlmgXezYSXhOT5NMUugnbkUy2oBZw==",
-          "requires": {
-            "@turf/clone": "^5.1.5",
-            "@turf/helpers": "^5.1.5",
-            "@turf/invariant": "^5.1.5",
-            "@turf/meta": "^5.1.5",
-            "skmeans": "0.9.7"
-          }
-        },
-        "@turf/collect": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/collect/-/collect-5.1.5.tgz",
-          "integrity": "sha512-voFWu6EGPcNuIbAp43yvGf2Ip4/q8TTeWhOSJ2yDEHgOfbAwrNUwUJCclEjcUVsnc7ypKNrFn3/8bmR9tI0NQg==",
-          "requires": {
-            "@turf/bbox": "^5.1.5",
-            "@turf/boolean-point-in-polygon": "^5.1.5",
-            "@turf/helpers": "^5.1.5",
-            "rbush": "^2.0.1"
-          }
-        },
-        "@turf/combine": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/combine/-/combine-5.1.5.tgz",
-          "integrity": "sha512-/RqmfCvduHquINVyNmzKOcZtZjfaEHMhghgmj8MYnzepN3ro+E2QXoaQGGrQ7nChAvGgWPAvN8EveVSc1MvzPg==",
-          "requires": {
-            "@turf/helpers": "^5.1.5",
-            "@turf/meta": "^5.1.5"
-          }
-        },
-        "@turf/concave": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/concave/-/concave-5.1.5.tgz",
-          "integrity": "sha512-NvR5vmAunmgjEPjNzmvjLRvPcj7C6WuqCf+vu/aqyc4h2c1B/x399bDsSM64iFT+PYesFuoS1ZhJHWivXG8Y5g==",
-          "requires": {
-            "@turf/clone": "^5.1.5",
-            "@turf/distance": "^5.1.5",
-            "@turf/helpers": "^5.1.5",
-            "@turf/invariant": "^5.1.5",
-            "@turf/meta": "^5.1.5",
-            "@turf/tin": "^5.1.5",
-            "topojson-client": "3.x",
-            "topojson-server": "3.x"
-          }
-        },
-        "@turf/convex": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/convex/-/convex-5.1.5.tgz",
-          "integrity": "sha512-ZEk4kIAoYR/mjO3C8rMe2StgmwhdwmbxVvNxg3udeahe2m0ZzbfkRC4HiJAaBgfR4TLJUAEewynESReTPwASBQ==",
-          "requires": {
-            "@turf/helpers": "^5.1.5",
-            "@turf/meta": "^5.1.5",
-            "concaveman": "*"
-          }
-        },
-        "@turf/destination": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/destination/-/destination-5.1.5.tgz",
-          "integrity": "sha512-EWwZnd4wxUO9d8UWzJt88jQlFf6W/6SE1930MMzzIR9o+RfqhrS/BL1eUDrg5I5drsymf6PZsK0j/V0q6jqkFQ==",
-          "requires": {
-            "@turf/helpers": "^5.1.5",
-            "@turf/invariant": "^5.1.5"
-          }
-        },
-        "@turf/difference": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/difference/-/difference-5.1.5.tgz",
-          "integrity": "sha512-hIjiUHS8WiDfnmADQrhh6QcXWc3zNtjIpPQ5g/2NZ3k1mjnOdmGBVObkSJG4WEUNqyj3PKlsZ8W9xnSu+lLF1Q==",
-          "requires": {
-            "@turf/area": "^5.1.5",
-            "@turf/helpers": "^5.1.5",
-            "@turf/invariant": "^5.1.5",
-            "@turf/meta": "^5.1.5",
-            "turf-jsts": "*"
-          }
-        },
-        "@turf/dissolve": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/dissolve/-/dissolve-5.1.5.tgz",
-          "integrity": "sha512-YcQgyp7pvhyZHCmbqqItVH6vHs43R9N0jzP/LnAG03oMiY4wves/BO1du6VDDbnJSXeRKf1afmY9tRGKYrm9ag==",
-          "requires": {
-            "@turf/boolean-overlap": "^5.1.5",
-            "@turf/clone": "^5.1.5",
-            "@turf/helpers": "^5.1.5",
-            "@turf/invariant": "^5.1.5",
-            "@turf/line-intersect": "^5.1.5",
-            "@turf/meta": "^5.1.5",
-            "@turf/union": "^5.1.5",
-            "geojson-rbush": "2.1.0",
-            "get-closest": "*"
-          }
-        },
-        "@turf/distance": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/distance/-/distance-5.1.5.tgz",
-          "integrity": "sha512-sYCAgYZ2MjNKMtx17EijHlK9qHwpA0MuuQWbR4P30LTCl52UlG/reBfV899wKyF3HuDL9ux78IbILwOfeQ4zgA==",
-          "requires": {
-            "@turf/helpers": "^5.1.5",
-            "@turf/invariant": "^5.1.5"
-          }
-        },
-        "@turf/ellipse": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/ellipse/-/ellipse-5.1.5.tgz",
-          "integrity": "sha512-oVTzEyDOi3d9isgB7Ah+YiOoUKB1eHMtMDXVl1oT+vC/T+6KR2aq+HjjbF11A0cjuh3VhjSWUZaS+2TYY0pu0w==",
-          "requires": {
-            "@turf/helpers": "^5.1.5",
-            "@turf/invariant": "^5.1.5",
-            "@turf/rhumb-destination": "^5.1.5",
-            "@turf/transform-rotate": "^5.1.5"
-          }
-        },
-        "@turf/envelope": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/envelope/-/envelope-5.1.5.tgz",
-          "integrity": "sha512-Mxl5A2euAxq3RZVN65/MVyaO91kzGU8MJXfegPdep6SN4bONDadEp0olwW5qSRf2U3cJ8Jppl089X6AeifD3IA==",
-          "requires": {
-            "@turf/bbox": "^5.1.5",
-            "@turf/bbox-polygon": "^5.1.5",
-            "@turf/helpers": "^5.1.5"
-          }
-        },
-        "@turf/explode": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/explode/-/explode-5.1.5.tgz",
-          "integrity": "sha512-v/hC9DB9RKRW9/ZjnKoQelIp08JNa5wew0889465s//tfgY8+JEGkSGMag2L2NnVARWmzI/vlLgMK36qwkyDIA==",
-          "requires": {
-            "@turf/helpers": "^5.1.5",
-            "@turf/meta": "^5.1.5"
-          }
-        },
-        "@turf/flatten": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/flatten/-/flatten-5.1.5.tgz",
-          "integrity": "sha512-aagHz5tjHmOtb8eMb5fd10+HJwdlhkhsPql1vRXQNnpv0Q9xL/4SsbvXZ6lPqkRAjiZuy087mvaz+ERml76/jg==",
-          "requires": {
-            "@turf/helpers": "^5.1.5",
-            "@turf/meta": "^5.1.5"
-          }
-        },
-        "@turf/flip": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/flip/-/flip-5.1.5.tgz",
-          "integrity": "sha512-7+IYM3QQAkV4co3wjEmM726/OkXqUCCHWWyIqrI9hiK+LR628qkoqP1hk6rQ4vZJrAYuvSlK+FZnr24OtgY0cw==",
-          "requires": {
-            "@turf/clone": "^5.1.5",
-            "@turf/helpers": "^5.1.5",
-            "@turf/meta": "^5.1.5"
-          }
-        },
-        "@turf/great-circle": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/great-circle/-/great-circle-5.1.5.tgz",
-          "integrity": "sha512-k6FWwlt+YCQoD5VS1NybQjriNL7apYHO+tm2HbIFQ85blPUX4IyLppHIFevfD/k+K2bJqhFCze8JNVMBwdrzVw==",
-          "requires": {
-            "@turf/helpers": "^5.1.5",
-            "@turf/invariant": "^5.1.5"
-          }
-        },
-        "@turf/helpers": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-5.1.5.tgz",
-          "integrity": "sha512-/lF+JR+qNDHZ8bF9d+Cp58nxtZWJ3sqFe6n3u3Vpj+/0cqkjk4nXKYBSY0azm+GIYB5mWKxUXvuP/m0ZnKj1bw=="
-        },
-        "@turf/hex-grid": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/hex-grid/-/hex-grid-5.1.5.tgz",
-          "integrity": "sha512-rwDL+DlUyxDNL1aVHIKKCmrt1131ZULF3irExYIO/um6/SwRzsBw+522/RcxD/mg/Shtrpozb6bz8aJJ/3RXHA==",
-          "requires": {
-            "@turf/distance": "^5.1.5",
-            "@turf/helpers": "^5.1.5",
-            "@turf/intersect": "^5.1.5",
-            "@turf/invariant": "^5.1.5"
-          }
-        },
-        "@turf/interpolate": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/interpolate/-/interpolate-5.1.5.tgz",
-          "integrity": "sha512-LfmvtIUWc3NVkqPkX6j3CAIjF7y1LAZqfDd+2Ii+0fN7XOOGMWcb1uiTTAb8zDQjhTsygcUYgaz6mMYDCWYKPg==",
-          "requires": {
-            "@turf/bbox": "^5.1.5",
-            "@turf/centroid": "^5.1.5",
-            "@turf/clone": "^5.1.5",
-            "@turf/distance": "^5.1.5",
-            "@turf/helpers": "^5.1.5",
-            "@turf/hex-grid": "^5.1.5",
-            "@turf/invariant": "^5.1.5",
-            "@turf/meta": "^5.1.5",
-            "@turf/point-grid": "^5.1.5",
-            "@turf/square-grid": "^5.1.5",
-            "@turf/triangle-grid": "^5.1.5"
-          }
-        },
-        "@turf/intersect": {
-          "version": "5.1.6",
-          "resolved": "https://registry.npmjs.org/@turf/intersect/-/intersect-5.1.6.tgz",
-          "integrity": "sha512-KXyNv/GXdoGAOy03qZF53rgtXC2tNhF/4jLwTKiVRrBQH6kcEpipGStdJ+QkYIlarQPa8f7I9UlVAB19et4MfQ==",
-          "requires": {
-            "@turf/clean-coords": "^5.1.5",
-            "@turf/helpers": "^5.1.5",
-            "@turf/invariant": "^5.1.5",
-            "@turf/truncate": "^5.1.5",
-            "turf-jsts": "*"
-          }
-        },
-        "@turf/invariant": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-5.1.5.tgz",
-          "integrity": "sha512-4elbC8GVQ8XxrnWLWpFFXTK3qnzIYzIVtSkJrY9eefA8WNZzwcwT3WGFY3xte4BB48o5oEjihjoJharWRis78w==",
-          "requires": {
-            "@turf/helpers": "^5.1.5"
-          }
-        },
-        "@turf/isobands": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/isobands/-/isobands-5.1.5.tgz",
-          "integrity": "sha512-0n3NPfDYQyqjOch00I4hVCCqjKn9Sm+a8qlWOKbkuhmGa9dCDzsu2bZL0ahT+LjwlS4c8/owQXqe6KE2GWqT1Q==",
-          "requires": {
-            "@turf/area": "^5.1.5",
-            "@turf/bbox": "^5.1.5",
-            "@turf/boolean-point-in-polygon": "^5.1.5",
-            "@turf/explode": "^5.1.5",
-            "@turf/helpers": "^5.1.5",
-            "@turf/invariant": "^5.1.5",
-            "@turf/meta": "^5.1.5"
-          }
-        },
-        "@turf/isolines": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/isolines/-/isolines-5.1.5.tgz",
-          "integrity": "sha512-Ehn5pJmiq4hAn2+2jPB2rLt3iF8DDp8zciw9z2pAt5IGVRU/K+x3z4aYG5ra5vbFB/E4G3aHr/X4QPIb9LCJtA==",
-          "requires": {
-            "@turf/bbox": "^5.1.5",
-            "@turf/helpers": "^5.1.5",
-            "@turf/invariant": "^5.1.5",
-            "@turf/meta": "^5.1.5"
-          }
-        },
-        "@turf/kinks": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/kinks/-/kinks-5.1.5.tgz",
-          "integrity": "sha512-G38sC8/+MYqQpVocT3XahhV42cqEAVJAZwUND9YOfKJZfjUn7FKmWhPURs5py95me48UuI0C0jLLAMzBkUc2nQ==",
-          "requires": {
-            "@turf/helpers": "^5.1.5"
-          }
-        },
-        "@turf/length": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/length/-/length-5.1.5.tgz",
-          "integrity": "sha512-0ryx68h512wCoNfwyksLdabxEfwkGNTPg61/QiY+QfGFUOUNhHbP+QimViFpwF5hyX7qmroaSHVclLUqyLGRbg==",
-          "requires": {
-            "@turf/distance": "^5.1.5",
-            "@turf/helpers": "^5.1.5",
-            "@turf/meta": "^5.1.5"
-          }
-        },
-        "@turf/line-arc": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/line-arc/-/line-arc-5.1.5.tgz",
-          "integrity": "sha512-Kz5RX/qRIHVrGNqF3BRlD3ACuuCr0G5lpaVyPjNvN+vA7Q4bEDyWIYeqm3DdTn7X2MXitpTNgr2uvX4WoUy4yA==",
-          "requires": {
-            "@turf/circle": "^5.1.5",
-            "@turf/destination": "^5.1.5",
-            "@turf/helpers": "^5.1.5"
-          }
-        },
-        "@turf/line-chunk": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/line-chunk/-/line-chunk-5.1.5.tgz",
-          "integrity": "sha512-mKvTUMahnb3EsYUMI8tQmygsliQkgQ1FZAY915zoTrm+WV246loa+84+h7i5d8W2O8gGJWuY7jQTpM7toTeL5w==",
-          "requires": {
-            "@turf/helpers": "^5.1.5",
-            "@turf/length": "^5.1.5",
-            "@turf/line-slice-along": "^5.1.5",
-            "@turf/meta": "^5.1.5"
-          }
-        },
-        "@turf/line-intersect": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/line-intersect/-/line-intersect-5.1.5.tgz",
-          "integrity": "sha512-9DajJbHhJauLI2qVMnqZ7SeFsinFroVICOSUheODk7j5teuwNABuZ2Z6WmKATzEsPkEJ1iVykqB+F9vGMVKB6g==",
-          "requires": {
-            "@turf/helpers": "^5.1.5",
-            "@turf/invariant": "^5.1.5",
-            "@turf/line-segment": "^5.1.5",
-            "@turf/meta": "^5.1.5",
-            "geojson-rbush": "2.1.0"
-          }
-        },
-        "@turf/line-offset": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/line-offset/-/line-offset-5.1.5.tgz",
-          "integrity": "sha512-VccGDgFfBSiCTqrHdQgxD7Rs9lnJmDOJ5gqQRculKPsCNUyRFMYIZud7l2dTs83g66evfOwkZCrTxtSoBY3Jxg==",
-          "requires": {
-            "@turf/helpers": "^5.1.5",
-            "@turf/invariant": "^5.1.5",
-            "@turf/meta": "^5.1.5"
-          }
-        },
-        "@turf/line-overlap": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/line-overlap/-/line-overlap-5.1.5.tgz",
-          "integrity": "sha512-hMz3XARXEbfGwLF9WXyErqQjzhZYMKvGQwlPGOoth+2o9Uga9mfWfevduJvozJAE1MKxtFttMjIXMzcShW3O8A==",
-          "requires": {
-            "@turf/boolean-point-on-line": "^5.1.5",
-            "@turf/helpers": "^5.1.5",
-            "@turf/invariant": "^5.1.5",
-            "@turf/line-segment": "^5.1.5",
-            "@turf/meta": "^5.1.5",
-            "@turf/nearest-point-on-line": "^5.1.5",
-            "geojson-rbush": "2.1.0"
-          }
-        },
-        "@turf/line-segment": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/line-segment/-/line-segment-5.1.5.tgz",
-          "integrity": "sha512-wIrRtWuLuLXhnSkqdVG1SDayTU0/CmZf+a+BBhEf0vFIsAedJnrY3a2cbCEvtfuk6ZsAbhOi7/kYiaR/F+rEzg==",
-          "requires": {
-            "@turf/helpers": "^5.1.5",
-            "@turf/invariant": "^5.1.5",
-            "@turf/meta": "^5.1.5"
-          }
-        },
-        "@turf/line-slice": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/line-slice/-/line-slice-5.1.5.tgz",
-          "integrity": "sha512-Fo+CuD+fj6T702BofHO+rgiXUgzCk0iO2JqMPtttMtgzfKkVTUOQoauMNS1LNNaG/7n/TfKGh5gRCEDRNaNwYA==",
-          "requires": {
-            "@turf/helpers": "^5.1.5",
-            "@turf/invariant": "^5.1.5",
-            "@turf/nearest-point-on-line": "^5.1.5"
-          }
-        },
-        "@turf/line-slice-along": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/line-slice-along/-/line-slice-along-5.1.5.tgz",
-          "integrity": "sha512-yKvSDtULztLtlPIMowm9l8pS6XLAEpCPmrARZA0sIWFX8XrcSzISBaXZbiMMzg3nxQJMXfGIgWDk10B7+J8Tqw==",
-          "requires": {
-            "@turf/bearing": "^5.1.5",
-            "@turf/destination": "^5.1.5",
-            "@turf/distance": "^5.1.5",
-            "@turf/helpers": "^5.1.5"
-          }
-        },
-        "@turf/line-split": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/line-split/-/line-split-5.1.5.tgz",
-          "integrity": "sha512-gtUUBwZL3hcSu5MpqHTl68hgAJBNHcr1APDj8E5o6iX5xFX+wvl4ohQXyMs5HOATCI8Iy83wLuggcY6maNw7LQ==",
-          "requires": {
-            "@turf/bbox": "^5.1.5",
-            "@turf/helpers": "^5.1.5",
-            "@turf/invariant": "^5.1.5",
-            "@turf/line-intersect": "^5.1.5",
-            "@turf/line-segment": "^5.1.5",
-            "@turf/meta": "^5.1.5",
-            "@turf/nearest-point-on-line": "^5.1.5",
-            "@turf/square": "^5.1.5",
-            "@turf/truncate": "^5.1.5",
-            "geojson-rbush": "2.1.0"
-          }
-        },
-        "@turf/line-to-polygon": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/line-to-polygon/-/line-to-polygon-5.1.5.tgz",
-          "integrity": "sha512-hGiDAPd6j986kZZLDgEAkVD7O6DmIqHQliBedspoKperPJOUJJzdzSnF6OAWSsxY+j8fWtQnIo5TTqdO/KfamA==",
-          "requires": {
-            "@turf/bbox": "^5.1.5",
-            "@turf/helpers": "^5.1.5",
-            "@turf/invariant": "^5.1.5"
-          }
-        },
-        "@turf/mask": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/mask/-/mask-5.1.5.tgz",
-          "integrity": "sha512-2eOuxA3ammZAGsjlsy/H7IpeJxjl3hrgkcKM6kTKRJGft4QyKwCxqQP7RN5j0zIYvAurgs9JOLe/dpd5sE5HXQ==",
-          "requires": {
-            "@turf/bbox": "^5.1.5",
-            "@turf/helpers": "^5.1.5",
-            "@turf/meta": "^5.1.5",
-            "@turf/union": "^5.1.5",
-            "rbush": "^2.0.1"
-          }
-        },
-        "@turf/meta": {
-          "version": "5.1.6",
-          "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-5.1.6.tgz",
-          "integrity": "sha512-lv+6LCgoc3LVitQZ4TScN/8a/fcctq8bIoxBTMJVq4aU8xoHeY1851Dq8MCU37EzbH33utkx8/jENaQP+aeElg==",
-          "requires": {
-            "@turf/helpers": "^5.1.5"
-          }
-        },
-        "@turf/midpoint": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/midpoint/-/midpoint-5.1.5.tgz",
-          "integrity": "sha512-0pDQAKHyK/zxlvUx3XNxwvqftf4sV32QxnHfqSs4AXaODUGUbPhzAD7aXgDScBeUOVLwpAzFRQfitUvUMTGC6A==",
-          "requires": {
-            "@turf/bearing": "^5.1.5",
-            "@turf/destination": "^5.1.5",
-            "@turf/distance": "^5.1.5",
-            "@turf/helpers": "^5.1.5"
-          }
-        },
-        "@turf/nearest-point": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/nearest-point/-/nearest-point-5.1.5.tgz",
-          "integrity": "sha512-tZQXI7OE7keNKK4OvYOJ5gervCEuu2pJ6psu59QW9yhe2Di3Gl+HAdLvVa6RZ8s5Fndr3u0JWKsmxve3fCxc9g==",
-          "requires": {
-            "@turf/clone": "^5.1.5",
-            "@turf/distance": "^5.1.5",
-            "@turf/helpers": "^5.1.5",
-            "@turf/meta": "^5.1.5"
-          }
-        },
-        "@turf/nearest-point-on-line": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/nearest-point-on-line/-/nearest-point-on-line-5.1.5.tgz",
-          "integrity": "sha512-qT7BLTwToo8cq0oNoz921oLlRPJamyRg/rZgll+kNBadyDPmJI4W66riHcpM9RQcAJ6TPvDveIIBeGJH7iG88w==",
-          "requires": {
-            "@turf/bearing": "^5.1.5",
-            "@turf/destination": "^5.1.5",
-            "@turf/distance": "^5.1.5",
-            "@turf/helpers": "^5.1.5",
-            "@turf/invariant": "^5.1.5",
-            "@turf/line-intersect": "^5.1.5",
-            "@turf/meta": "^5.1.5"
-          }
-        },
-        "@turf/nearest-point-to-line": {
-          "version": "5.1.6",
-          "resolved": "https://registry.npmjs.org/@turf/nearest-point-to-line/-/nearest-point-to-line-5.1.6.tgz",
-          "integrity": "sha512-ZSvDIEiHhifn/vNwLXZI/E8xmEz5yBPqfUR7BVHRZrB1cP7jLhKZvkbidjG//uW8Fr1Ulc+PFOXczLspIcx/lw==",
-          "requires": {
-            "@turf/helpers": "6.x",
-            "@turf/invariant": "6.x",
-            "@turf/meta": "6.x",
-            "@turf/point-to-line-distance": "^5.1.5",
-            "object-assign": "*"
-          },
-          "dependencies": {
-            "@turf/helpers": {
-              "version": "6.5.0",
-              "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.5.0.tgz",
-              "integrity": "sha512-VbI1dV5bLFzohYYdgqwikdMVpe7pJ9X3E+dlr425wa2/sMJqYDhTO++ec38/pcPvPE6oD9WEEeU3Xu3gza+VPw=="
-            },
-            "@turf/invariant": {
-              "version": "6.5.0",
-              "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-6.5.0.tgz",
-              "integrity": "sha512-Wv8PRNCtPD31UVbdJE/KVAWKe7l6US+lJItRR/HOEW3eh+U/JwRCSUl/KZ7bmjM/C+zLNoreM2TU6OoLACs4eg==",
-              "requires": {
-                "@turf/helpers": "^6.5.0"
-              }
-            },
-            "@turf/meta": {
-              "version": "6.5.0",
-              "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-6.5.0.tgz",
-              "integrity": "sha512-RrArvtsV0vdsCBegoBtOalgdSOfkBrTJ07VkpiCnq/491W67hnMWmDu7e6Ztw0C3WldRYTXkg3SumfdzZxLBHA==",
-              "requires": {
-                "@turf/helpers": "^6.5.0"
-              }
-            }
-          }
-        },
-        "@turf/planepoint": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/planepoint/-/planepoint-5.1.5.tgz",
-          "integrity": "sha512-+Tp+SQ0Db2tqwLbxfXJPysT9IxcOHSMIin2dJb/j3Qn5+g0LRus6rczZl6dWNAIjqBPMawj/V/dZhMu6Q9O9wA==",
-          "requires": {
-            "@turf/helpers": "^5.1.5",
-            "@turf/invariant": "^5.1.5"
-          }
-        },
-        "@turf/point-grid": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/point-grid/-/point-grid-5.1.5.tgz",
-          "integrity": "sha512-4ibozguP9YJ297Q7i9e8/ypGSycvt1re2jrPXTxeuZ4/L/NE5B1nOBLG+tw121nMjD+S+v2RWOtqD+FZ3Ga+ew==",
-          "requires": {
-            "@turf/boolean-within": "^5.1.5",
-            "@turf/distance": "^5.1.5",
-            "@turf/helpers": "^5.1.5",
-            "@turf/invariant": "^5.1.5"
-          }
-        },
-        "@turf/point-on-feature": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/point-on-feature/-/point-on-feature-5.1.5.tgz",
-          "integrity": "sha512-NTcpe5xZjybRh0aTL+7td1cm0s49GGbAt5u8Cdec4W9ix2PsehRcLUbmQIQsODN2kiVyUSpnhECIpsyN5MjX7A==",
-          "requires": {
-            "@turf/boolean-point-in-polygon": "^5.1.5",
-            "@turf/center": "^5.1.5",
-            "@turf/explode": "^5.1.5",
-            "@turf/helpers": "^5.1.5",
-            "@turf/nearest-point": "^5.1.5"
-          }
-        },
-        "@turf/point-to-line-distance": {
-          "version": "5.1.6",
-          "resolved": "https://registry.npmjs.org/@turf/point-to-line-distance/-/point-to-line-distance-5.1.6.tgz",
-          "integrity": "sha512-PE3hiTeeDEi4ZLPtI8XAzFYW9nHo1EVsZGm/4ZVV8jo39d3X1oLVHxY3e1PkCmWwRapXy4QLqvnTQ7nU4wspNw==",
-          "requires": {
-            "@turf/bearing": "6.x",
-            "@turf/distance": "6.x",
-            "@turf/helpers": "6.x",
-            "@turf/invariant": "6.x",
-            "@turf/meta": "6.x",
-            "@turf/projection": "6.x",
-            "@turf/rhumb-bearing": "6.x",
-            "@turf/rhumb-distance": "6.x"
-          },
-          "dependencies": {
-            "@turf/bearing": {
-              "version": "6.5.0",
-              "resolved": "https://registry.npmjs.org/@turf/bearing/-/bearing-6.5.0.tgz",
-              "integrity": "sha512-dxINYhIEMzgDOztyMZc20I7ssYVNEpSv04VbMo5YPQsqa80KO3TFvbuCahMsCAW5z8Tncc8dwBlEFrmRjJG33A==",
-              "requires": {
-                "@turf/helpers": "^6.5.0",
-                "@turf/invariant": "^6.5.0"
-              }
-            },
-            "@turf/distance": {
-              "version": "6.5.0",
-              "resolved": "https://registry.npmjs.org/@turf/distance/-/distance-6.5.0.tgz",
-              "integrity": "sha512-xzykSLfoURec5qvQJcfifw/1mJa+5UwByZZ5TZ8iaqjGYN0vomhV9aiSLeYdUGtYRESZ+DYC/OzY+4RclZYgMg==",
-              "requires": {
-                "@turf/helpers": "^6.5.0",
-                "@turf/invariant": "^6.5.0"
-              }
-            },
-            "@turf/helpers": {
-              "version": "6.5.0",
-              "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.5.0.tgz",
-              "integrity": "sha512-VbI1dV5bLFzohYYdgqwikdMVpe7pJ9X3E+dlr425wa2/sMJqYDhTO++ec38/pcPvPE6oD9WEEeU3Xu3gza+VPw=="
-            },
-            "@turf/invariant": {
-              "version": "6.5.0",
-              "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-6.5.0.tgz",
-              "integrity": "sha512-Wv8PRNCtPD31UVbdJE/KVAWKe7l6US+lJItRR/HOEW3eh+U/JwRCSUl/KZ7bmjM/C+zLNoreM2TU6OoLACs4eg==",
-              "requires": {
-                "@turf/helpers": "^6.5.0"
-              }
-            },
-            "@turf/meta": {
-              "version": "6.5.0",
-              "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-6.5.0.tgz",
-              "integrity": "sha512-RrArvtsV0vdsCBegoBtOalgdSOfkBrTJ07VkpiCnq/491W67hnMWmDu7e6Ztw0C3WldRYTXkg3SumfdzZxLBHA==",
-              "requires": {
-                "@turf/helpers": "^6.5.0"
-              }
-            }
-          }
-        },
-        "@turf/points-within-polygon": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/points-within-polygon/-/points-within-polygon-5.1.5.tgz",
-          "integrity": "sha512-nexe2AHVOY8wEBvs+CYSOp10NyOCkyZ1gkhIfsx0mzU8LPYBxD9ctjlKveheKh4AAldLcFupd/gSCBTKF1JS7A==",
-          "requires": {
-            "@turf/boolean-point-in-polygon": "^5.1.5",
-            "@turf/helpers": "^5.1.5",
-            "@turf/meta": "^5.1.5"
-          }
-        },
-        "@turf/polygon-tangents": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/polygon-tangents/-/polygon-tangents-5.1.5.tgz",
-          "integrity": "sha512-uoZfKvFhl6rf0+CDWucru9fZ4mJB5Nsg37TS/7emrzjoVxXyOdxc/s1HFCjcKflMue7MjU/gT6AitJyrvdztDg==",
-          "requires": {
-            "@turf/helpers": "^5.1.5",
-            "@turf/invariant": "^5.1.5"
-          }
-        },
-        "@turf/polygon-to-line": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/polygon-to-line/-/polygon-to-line-5.1.5.tgz",
-          "integrity": "sha512-kVo0owPqyccy5+qZGvaxGvMsYkgueKE2OOgX2UV/HyrXF3uI3TomK1txjApqeFsLvwuSANxesvVbYLrYiIwvGw==",
-          "requires": {
-            "@turf/helpers": "^5.1.5",
-            "@turf/invariant": "^5.1.5"
-          }
-        },
-        "@turf/polygonize": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/polygonize/-/polygonize-5.1.5.tgz",
-          "integrity": "sha512-qzhtuzoOhldqZHm+ZPsWAs9nDpnkcDfsr+I0twmBF+wjAmo0HKiy9++sRQ4kEePpdwbMpF07D/NdZqYdmOJkGQ==",
-          "requires": {
-            "@turf/boolean-point-in-polygon": "^5.1.5",
-            "@turf/envelope": "^5.1.5",
-            "@turf/helpers": "^5.1.5",
-            "@turf/invariant": "^5.1.5",
-            "@turf/meta": "^5.1.5"
-          }
-        },
-        "@turf/random": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/random/-/random-5.1.5.tgz",
-          "integrity": "sha512-oitpBwEb6YXqoUkIAOVMK+vrTPxUi2rqITmtTa/FBHr6J8TDwMWq6bufE3Gmgjxsss50O2ITJunOksxrouWGDQ==",
-          "requires": {
-            "@turf/helpers": "^5.1.5"
-          }
-        },
-        "@turf/rewind": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/rewind/-/rewind-5.1.5.tgz",
-          "integrity": "sha512-Gdem7JXNu+G4hMllQHXRFRihJl3+pNl7qY+l4qhQFxq+hiU1cQoVFnyoleIqWKIrdK/i2YubaSwc3SCM7N5mMw==",
-          "requires": {
-            "@turf/boolean-clockwise": "^5.1.5",
-            "@turf/clone": "^5.1.5",
-            "@turf/helpers": "^5.1.5",
-            "@turf/invariant": "^5.1.5",
-            "@turf/meta": "^5.1.5"
-          }
-        },
-        "@turf/rhumb-destination": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/rhumb-destination/-/rhumb-destination-5.1.5.tgz",
-          "integrity": "sha512-FdDUCSRfRAfsRmUaWjc76Wk32QYFJ6ckmSt6Ls6nEczO6eg/RgH1atF8CIYwR5ifl0Sk1rQzKiOSbpCyvVwQtw==",
-          "requires": {
-            "@turf/helpers": "^5.1.5",
-            "@turf/invariant": "^5.1.5"
-          }
-        },
-        "@turf/sample": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/sample/-/sample-5.1.5.tgz",
-          "integrity": "sha512-EJE8yx+5x7rXejTzwBdOKpvT4tOCS0jwYJfycyTVDuLUSh2rETeYdjy7EeJbofnxm9CRPXqWQMPWIBKWxNTjow==",
-          "requires": {
-            "@turf/helpers": "^5.1.5"
-          }
-        },
-        "@turf/sector": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/sector/-/sector-5.1.5.tgz",
-          "integrity": "sha512-dnWVifL3xWTqPPs8mfbbV9muDimNJtxRk4ogrkOLEDQ9ZZ1ALQMtQdYrg7kI3iC+L+LscV37tl+E8bayWyX8YA==",
-          "requires": {
-            "@turf/circle": "^5.1.5",
-            "@turf/helpers": "^5.1.5",
-            "@turf/invariant": "^5.1.5",
-            "@turf/line-arc": "^5.1.5",
-            "@turf/meta": "^5.1.5"
-          }
-        },
-        "@turf/shortest-path": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/shortest-path/-/shortest-path-5.1.5.tgz",
-          "integrity": "sha512-ZGC8kSBj02GKWiI56Z5FNdrZ+fS0xyeOUNrPJWzudAlrv9wKGaRuWoIVRLGBu0j0OuO1HCwggic2c6WV/AhP0A==",
-          "requires": {
-            "@turf/bbox": "^5.1.5",
-            "@turf/bbox-polygon": "^5.1.5",
-            "@turf/boolean-point-in-polygon": "^5.1.5",
-            "@turf/clean-coords": "^5.1.5",
-            "@turf/distance": "^5.1.5",
-            "@turf/helpers": "^5.1.5",
-            "@turf/invariant": "^5.1.5",
-            "@turf/meta": "^5.1.5",
-            "@turf/transform-scale": "^5.1.5"
-          }
-        },
-        "@turf/simplify": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/simplify/-/simplify-5.1.5.tgz",
-          "integrity": "sha512-IuBXEYdGSxbDOK3v949ajaPvs6NhjhTCTbKA6mSGuVbwGS7gzAuRiPSG4K/MvCVuQy3PKpkPcUGD+Uvt2Ov2PQ==",
-          "requires": {
-            "@turf/clean-coords": "^5.1.5",
-            "@turf/clone": "^5.1.5",
-            "@turf/helpers": "^5.1.5",
-            "@turf/meta": "^5.1.5"
-          }
-        },
-        "@turf/square": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/square/-/square-5.1.5.tgz",
-          "integrity": "sha512-GgP2le9ksoW6vsVef5wFkjmWQiLPTJvcjGXqmoGWT4oMwDpvTJVQ91RBLs8qQbI4KACCQevz94N69klk3ah30Q==",
-          "requires": {
-            "@turf/distance": "^5.1.5",
-            "@turf/helpers": "^5.1.5"
-          }
-        },
-        "@turf/square-grid": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/square-grid/-/square-grid-5.1.5.tgz",
-          "integrity": "sha512-/pusEL4FmOwNWLcZfIXUyqUe0fOdkfaLO4wLhDlg/ZL1jWr/wZjhVlMU0tQ27kVN6dJTvlzNc9e0JWNw6yt2eQ==",
-          "requires": {
-            "@turf/boolean-contains": "^5.1.5",
-            "@turf/boolean-overlap": "^5.1.5",
-            "@turf/distance": "^5.1.5",
-            "@turf/helpers": "^5.1.5",
-            "@turf/intersect": "^5.1.5",
-            "@turf/invariant": "^5.1.5"
-          }
-        },
-        "@turf/standard-deviational-ellipse": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/standard-deviational-ellipse/-/standard-deviational-ellipse-5.1.5.tgz",
-          "integrity": "sha512-GOaxGKeeJAXV1H3Zz2fjQ5XeSbMKz1OkFRlTDBUipiAawe/9qTCF55L87I2ZPnO80B5BaaIT+AN2n0lMcAklzA==",
-          "requires": {
-            "@turf/center-mean": "^5.1.5",
-            "@turf/ellipse": "^5.1.5",
-            "@turf/helpers": "^5.1.5",
-            "@turf/invariant": "^5.1.5",
-            "@turf/meta": "^5.1.5",
-            "@turf/points-within-polygon": "^5.1.5"
-          }
-        },
-        "@turf/tag": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/tag/-/tag-5.1.5.tgz",
-          "integrity": "sha512-XI3QFpva6tEsRnzFe1tJGdAAWlzjnXZPfJ9EKShTxEW8ZgPzm92b2odjiSAt2KuQusK82ltNfdw5Frlna5xGYQ==",
-          "requires": {
-            "@turf/boolean-point-in-polygon": "^5.1.5",
-            "@turf/clone": "^5.1.5",
-            "@turf/helpers": "^5.1.5",
-            "@turf/meta": "^5.1.5"
-          }
-        },
-        "@turf/tesselate": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/tesselate/-/tesselate-5.1.5.tgz",
-          "integrity": "sha512-Rs/jAij26bcU4OzvFXkWDase1G3kSwyuuKZPFU0t7OmJu7eQJOR12WOZLGcVxd5oBlklo4xPE4EBQUqpQUsQgg==",
-          "requires": {
-            "@turf/helpers": "^5.1.5",
-            "earcut": "^2.0.0"
-          }
-        },
-        "@turf/tin": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/tin/-/tin-5.1.5.tgz",
-          "integrity": "sha512-lDyCTYKoThBIKmkBxBMupqEpFbvTDAYuZIs8qrWnmux2vntSb8OFGi7ZbGPC6apS2hdVwZZae3YB88Tp+Fg+xw==",
-          "requires": {
-            "@turf/helpers": "^5.1.5"
-          }
-        },
-        "@turf/transform-rotate": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/transform-rotate/-/transform-rotate-5.1.5.tgz",
-          "integrity": "sha512-3QKckeHKPXu5O5vEuT+nkszGDI6aknDD06ePb00+6H2oA7MZj7nj+fVQIJLs41MRb76IyKr4n5NvuKZU6idESA==",
-          "requires": {
-            "@turf/centroid": "^5.1.5",
-            "@turf/clone": "^5.1.5",
-            "@turf/helpers": "^5.1.5",
-            "@turf/invariant": "^5.1.5",
-            "@turf/meta": "^5.1.5",
-            "@turf/rhumb-bearing": "^5.1.5",
-            "@turf/rhumb-destination": "^5.1.5",
-            "@turf/rhumb-distance": "^5.1.5"
-          },
-          "dependencies": {
-            "@turf/rhumb-bearing": {
-              "version": "5.1.5",
-              "resolved": "https://registry.npmjs.org/@turf/rhumb-bearing/-/rhumb-bearing-5.1.5.tgz",
-              "integrity": "sha512-zXTl2khjwf7mx2D1uPo5vgpGgP4sM2VrKDbJNKyulPu4TO4ELt8x7FsKyCBlRTzzQf284t/xnNcZOfUbkkd70g==",
-              "requires": {
-                "@turf/helpers": "^5.1.5",
-                "@turf/invariant": "^5.1.5"
-              }
-            },
-            "@turf/rhumb-distance": {
-              "version": "5.1.5",
-              "resolved": "https://registry.npmjs.org/@turf/rhumb-distance/-/rhumb-distance-5.1.5.tgz",
-              "integrity": "sha512-AGA/ky5/BJJZtzQqafy2GvJfcUXSzCCrPFp8sDRPSKBoUN4gMBHN15ijDWYYLFoWFFj0urcauVx7chQlHZ/Qfw==",
-              "requires": {
-                "@turf/helpers": "^5.1.5",
-                "@turf/invariant": "^5.1.5"
-              }
-            }
-          }
-        },
-        "@turf/transform-scale": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/transform-scale/-/transform-scale-5.1.5.tgz",
-          "integrity": "sha512-t1fCZX29ONA7DJiqCKA4YZy0+hCzhppWNOZhglBUv9vKHsWCFYZDUKfFInciaypUInsZyvm8eKxxixBVPdPGsw==",
-          "requires": {
-            "@turf/bbox": "^5.1.5",
-            "@turf/center": "^5.1.5",
-            "@turf/centroid": "^5.1.5",
-            "@turf/clone": "^5.1.5",
-            "@turf/helpers": "^5.1.5",
-            "@turf/invariant": "^5.1.5",
-            "@turf/meta": "^5.1.5",
-            "@turf/rhumb-bearing": "^5.1.5",
-            "@turf/rhumb-destination": "^5.1.5",
-            "@turf/rhumb-distance": "^5.1.5"
-          },
-          "dependencies": {
-            "@turf/rhumb-bearing": {
-              "version": "5.1.5",
-              "resolved": "https://registry.npmjs.org/@turf/rhumb-bearing/-/rhumb-bearing-5.1.5.tgz",
-              "integrity": "sha512-zXTl2khjwf7mx2D1uPo5vgpGgP4sM2VrKDbJNKyulPu4TO4ELt8x7FsKyCBlRTzzQf284t/xnNcZOfUbkkd70g==",
-              "requires": {
-                "@turf/helpers": "^5.1.5",
-                "@turf/invariant": "^5.1.5"
-              }
-            },
-            "@turf/rhumb-distance": {
-              "version": "5.1.5",
-              "resolved": "https://registry.npmjs.org/@turf/rhumb-distance/-/rhumb-distance-5.1.5.tgz",
-              "integrity": "sha512-AGA/ky5/BJJZtzQqafy2GvJfcUXSzCCrPFp8sDRPSKBoUN4gMBHN15ijDWYYLFoWFFj0urcauVx7chQlHZ/Qfw==",
-              "requires": {
-                "@turf/helpers": "^5.1.5",
-                "@turf/invariant": "^5.1.5"
-              }
-            }
-          }
-        },
-        "@turf/transform-translate": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/transform-translate/-/transform-translate-5.1.5.tgz",
-          "integrity": "sha512-GdLFp7I7198oRQt311B8EjiqHupndeMSQ3Zclzki5L/niUrb1ptOIpo+mxSidSy03m+1Q5ylWlENroI1WBcQ3Q==",
-          "requires": {
-            "@turf/clone": "^5.1.5",
-            "@turf/helpers": "^5.1.5",
-            "@turf/invariant": "^5.1.5",
-            "@turf/meta": "^5.1.5",
-            "@turf/rhumb-destination": "^5.1.5"
-          }
-        },
-        "@turf/triangle-grid": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/triangle-grid/-/triangle-grid-5.1.5.tgz",
-          "integrity": "sha512-jmCRcynI80xsVqd+0rv0YxP6mvZn4BAaJv8dwthg2T3WfHB9OD+rNUMohMuUY8HmI0zRT3s/Ypdy2Cdri9u/tw==",
-          "requires": {
-            "@turf/distance": "^5.1.5",
-            "@turf/helpers": "^5.1.5",
-            "@turf/intersect": "^5.1.5",
-            "@turf/invariant": "^5.1.5"
-          }
-        },
-        "@turf/truncate": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/truncate/-/truncate-5.1.5.tgz",
-          "integrity": "sha512-WjWGsRE6o1vUqULGb/O7O1eK6B4Eu6R/RBZWnF0rH0Os6WVel6tHktkeJdlKwz9WElIEO12wDIu6uKd54t7DDQ==",
-          "requires": {
-            "@turf/helpers": "^5.1.5",
-            "@turf/meta": "^5.1.5"
-          }
-        },
-        "@turf/turf": {
-          "version": "5.1.6",
-          "resolved": "https://registry.npmjs.org/@turf/turf/-/turf-5.1.6.tgz",
-          "integrity": "sha512-NIjkt5jAbOrom+56ELw9ERZF6qsdf1xAIHyC9/PkDMIOQAxe7FVe2HaqbQ+x88F0q5FaSX4dtpIEf08md6h5/A==",
-          "requires": {
-            "@turf/along": "5.1.x",
-            "@turf/area": "5.1.x",
-            "@turf/bbox": "5.1.x",
-            "@turf/bbox-clip": "5.1.x",
-            "@turf/bbox-polygon": "5.1.x",
-            "@turf/bearing": "5.1.x",
-            "@turf/bezier-spline": "5.1.x",
-            "@turf/boolean-clockwise": "5.1.x",
-            "@turf/boolean-contains": "5.1.x",
-            "@turf/boolean-crosses": "5.1.x",
-            "@turf/boolean-disjoint": "5.1.x",
-            "@turf/boolean-equal": "5.1.x",
-            "@turf/boolean-overlap": "5.1.x",
-            "@turf/boolean-parallel": "5.1.x",
-            "@turf/boolean-point-in-polygon": "5.1.x",
-            "@turf/boolean-point-on-line": "5.1.x",
-            "@turf/boolean-within": "5.1.x",
-            "@turf/buffer": "5.1.x",
-            "@turf/center": "5.1.x",
-            "@turf/center-mean": "5.1.x",
-            "@turf/center-median": "5.1.x",
-            "@turf/center-of-mass": "5.1.x",
-            "@turf/centroid": "5.1.x",
-            "@turf/circle": "5.1.x",
-            "@turf/clean-coords": "5.1.x",
-            "@turf/clone": "5.1.x",
-            "@turf/clusters": "5.1.x",
-            "@turf/clusters-dbscan": "5.1.x",
-            "@turf/clusters-kmeans": "5.1.x",
-            "@turf/collect": "5.1.x",
-            "@turf/combine": "5.1.x",
-            "@turf/concave": "5.1.x",
-            "@turf/convex": "5.1.x",
-            "@turf/destination": "5.1.x",
-            "@turf/difference": "5.1.x",
-            "@turf/dissolve": "5.1.x",
-            "@turf/distance": "5.1.x",
-            "@turf/ellipse": "5.1.x",
-            "@turf/envelope": "5.1.x",
-            "@turf/explode": "5.1.x",
-            "@turf/flatten": "5.1.x",
-            "@turf/flip": "5.1.x",
-            "@turf/great-circle": "5.1.x",
-            "@turf/helpers": "5.1.x",
-            "@turf/hex-grid": "5.1.x",
-            "@turf/interpolate": "5.1.x",
-            "@turf/intersect": "5.1.x",
-            "@turf/invariant": "5.1.x",
-            "@turf/isobands": "5.1.x",
-            "@turf/isolines": "5.1.x",
-            "@turf/kinks": "5.1.x",
-            "@turf/length": "5.1.x",
-            "@turf/line-arc": "5.1.x",
-            "@turf/line-chunk": "5.1.x",
-            "@turf/line-intersect": "5.1.x",
-            "@turf/line-offset": "5.1.x",
-            "@turf/line-overlap": "5.1.x",
-            "@turf/line-segment": "5.1.x",
-            "@turf/line-slice": "5.1.x",
-            "@turf/line-slice-along": "5.1.x",
-            "@turf/line-split": "5.1.x",
-            "@turf/line-to-polygon": "5.1.x",
-            "@turf/mask": "5.1.x",
-            "@turf/meta": "5.1.x",
-            "@turf/midpoint": "5.1.x",
-            "@turf/nearest-point": "5.1.x",
-            "@turf/nearest-point-on-line": "5.1.x",
-            "@turf/nearest-point-to-line": "5.1.x",
-            "@turf/planepoint": "5.1.x",
-            "@turf/point-grid": "5.1.x",
-            "@turf/point-on-feature": "5.1.x",
-            "@turf/point-to-line-distance": "5.1.x",
-            "@turf/points-within-polygon": "5.1.x",
-            "@turf/polygon-tangents": "5.1.x",
-            "@turf/polygon-to-line": "5.1.x",
-            "@turf/polygonize": "5.1.x",
-            "@turf/projection": "5.1.x",
-            "@turf/random": "5.1.x",
-            "@turf/rewind": "5.1.x",
-            "@turf/rhumb-bearing": "5.1.x",
-            "@turf/rhumb-destination": "5.1.x",
-            "@turf/rhumb-distance": "5.1.x",
-            "@turf/sample": "5.1.x",
-            "@turf/sector": "5.1.x",
-            "@turf/shortest-path": "5.1.x",
-            "@turf/simplify": "5.1.x",
-            "@turf/square": "5.1.x",
-            "@turf/square-grid": "5.1.x",
-            "@turf/standard-deviational-ellipse": "5.1.x",
-            "@turf/tag": "5.1.x",
-            "@turf/tesselate": "5.1.x",
-            "@turf/tin": "5.1.x",
-            "@turf/transform-rotate": "5.1.x",
-            "@turf/transform-scale": "5.1.x",
-            "@turf/transform-translate": "5.1.x",
-            "@turf/triangle-grid": "5.1.x",
-            "@turf/truncate": "5.1.x",
-            "@turf/union": "5.1.x",
-            "@turf/unkink-polygon": "5.1.x",
-            "@turf/voronoi": "5.1.x"
-          },
-          "dependencies": {
-            "@turf/projection": {
-              "version": "5.1.5",
-              "resolved": "https://registry.npmjs.org/@turf/projection/-/projection-5.1.5.tgz",
-              "integrity": "sha512-TWKJDFeEKQhI4Ce1+2PuOSDggn4cnMibqyUoCpIW+4KxUC1R88SE3/SYomqzwxMn00O09glHSycPkGD5JzHd8A==",
-              "requires": {
-                "@turf/clone": "^5.1.5",
-                "@turf/helpers": "^5.1.5",
-                "@turf/meta": "^5.1.5"
-              }
-            },
-            "@turf/rhumb-bearing": {
-              "version": "5.1.5",
-              "resolved": "https://registry.npmjs.org/@turf/rhumb-bearing/-/rhumb-bearing-5.1.5.tgz",
-              "integrity": "sha512-zXTl2khjwf7mx2D1uPo5vgpGgP4sM2VrKDbJNKyulPu4TO4ELt8x7FsKyCBlRTzzQf284t/xnNcZOfUbkkd70g==",
-              "requires": {
-                "@turf/helpers": "^5.1.5",
-                "@turf/invariant": "^5.1.5"
-              }
-            },
-            "@turf/rhumb-distance": {
-              "version": "5.1.5",
-              "resolved": "https://registry.npmjs.org/@turf/rhumb-distance/-/rhumb-distance-5.1.5.tgz",
-              "integrity": "sha512-AGA/ky5/BJJZtzQqafy2GvJfcUXSzCCrPFp8sDRPSKBoUN4gMBHN15ijDWYYLFoWFFj0urcauVx7chQlHZ/Qfw==",
-              "requires": {
-                "@turf/helpers": "^5.1.5",
-                "@turf/invariant": "^5.1.5"
-              }
-            }
-          }
-        },
-        "@turf/union": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/union/-/union-5.1.5.tgz",
-          "integrity": "sha512-wBy1ixxC68PpsTeEDebk/EfnbI1Za5dCyY7xFY9NMzrtVEOy0l0lQ5syOsaqY4Ire+dbsDM66p2GGxmefoyIEA==",
-          "requires": {
-            "@turf/helpers": "^5.1.5",
-            "turf-jsts": "*"
-          }
-        },
-        "@turf/unkink-polygon": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/unkink-polygon/-/unkink-polygon-5.1.5.tgz",
-          "integrity": "sha512-lzSrgsfSuyxIc4pkE2qyM2dsHxR992e6oItoZAT8G58A2Ef4qc5gRocmXPWZakGx41fQobegSo7wlo4I49wyHg==",
-          "requires": {
-            "@turf/area": "^5.1.5",
-            "@turf/boolean-point-in-polygon": "^5.1.5",
-            "@turf/helpers": "^5.1.5",
-            "@turf/meta": "^5.1.5",
-            "rbush": "^2.0.1"
-          }
-        },
-        "@turf/voronoi": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/voronoi/-/voronoi-5.1.5.tgz",
-          "integrity": "sha512-Ad0HZAyYjOpMIZfDGV+Q+30M9PQHIirTyn32kWyTjEI1O6uhL5NOYjzSha4Sr77xOls3hGzKOj+JET7eDtOvsg==",
-          "requires": {
-            "@turf/helpers": "^5.1.5",
-            "@turf/invariant": "^5.1.5",
-            "d3-voronoi": "1.1.2"
-          }
-        },
-        "geojson-rbush": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/geojson-rbush/-/geojson-rbush-2.1.0.tgz",
-          "integrity": "sha512-9HvLGhmAJBYkYYDdPlCrlfkKGwNW3PapiS0xPekdJLobkZE4rjtduKJXsO7+kUr97SsUlz4VtMcPuSIbjjJaQg==",
-          "requires": {
-            "@turf/helpers": "*",
-            "@turf/meta": "*",
-            "rbush": "*"
-          }
-        },
-        "jszip": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/jszip/-/jszip-2.6.1.tgz",
-          "integrity": "sha512-C4Z++nYQv+CudUkCWUdz+yKVhQiFJjuWSmRJ5Sg3d3/OzcJ6U4ooUYlmE3+rJXrVk89KWQaiJ9mPp/VLQ4D66g==",
-          "requires": {
-            "pako": "~1.0.2"
-          }
-        },
-        "lru-cache": {
-          "version": "2.7.3",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
-          "integrity": "sha512-WpibWJ60c3AgAz8a2iYErDrcT2C7OmKnsWhIcHOjkUHFjkXncJhtLxNSqUmxRxRunpb5I8Vprd7aNSd2NtksJQ=="
-        },
-        "pako": {
-          "version": "1.0.11",
-          "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
-          "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
-        },
-        "shpjs": {
-          "version": "3.6.3",
-          "resolved": "https://registry.npmjs.org/shpjs/-/shpjs-3.6.3.tgz",
-          "integrity": "sha512-wcR2S3WL/7RnEIm+YO+H/mZR9z9FCV46op+SZt+W5PtPs26Omb9U93f+EPI1DOpNKBuAIrWjHWh0SxlnBahJkg==",
-          "requires": {
-            "jszip": "^2.4.0",
-            "lie": "^3.0.1",
-            "lru-cache": "^2.7.0",
-            "parsedbf": "^1.1.0",
-            "proj4": "^2.1.4"
-          }
-        }
+        "geostyler-style": "^5.0.2",
+        "lodash": "^4.17.21"
       }
     },
     "geostyler-style": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/geostyler-style/-/geostyler-style-4.0.3.tgz",
-      "integrity": "sha512-51esHVZz86HFoSvKRA/Kfqd2Mytek88zgHSSt8ZZg30o4dqyZuQluxwIjqkSLp5hdvmA0nwCAyqxHy6aMyJ5lQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/geostyler-style/-/geostyler-style-5.1.0.tgz",
+      "integrity": "sha512-AJzQBomzuTGr01uRYvu7bocJTBB6vrgBdxsIoSHDATbnNF07XnAtsrbkjXlMsKaRnbqE2MGLhQqBmBx6C2Gubg==",
       "requires": {
         "@types/lodash": "^4.14.168",
         "lodash": "^4.17.21"

--- a/package.json
+++ b/package.json
@@ -126,6 +126,7 @@
     "canvas": "^2.9.0",
     "chokidar": "^3.5.3",
     "copy-to-clipboard": "^3.3.1",
+    "copy-webpack-plugin": "^11.0.0",
     "coveralls": "^3.1.1",
     "css-loader": "^6.6.0",
     "enzyme": "^3.11.0",

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "@types/react": "^17.0",
     "@types/react-dom": "^18.0.2",
     "@types/react-rnd": "^8.0.0",
+    "geostyler-openlayers-parser": "^3.0.2",
     "lodash": "^4.17.21",
     "moment": "^2.29.2",
     "proj4": "^2.7.5",

--- a/package.json
+++ b/package.json
@@ -86,7 +86,6 @@
     "@types/react": "^17.0",
     "@types/react-dom": "^18.0.2",
     "@types/react-rnd": "^8.0.0",
-    "geostyler-openlayers-parser": "^3.0.2",
     "lodash": "^4.17.21",
     "moment": "^2.29.2",
     "proj4": "^2.7.5",

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "@ag-grid-community/core": "^27.1.0",
     "@ag-grid-community/react": "^27.1.0",
     "@ant-design/icons": "^4.7.0",
+    "@camptocamp/inkmap": "^1.2.0",
     "@fortawesome/fontawesome-svg-core": "^6.1.1",
     "@fortawesome/free-brands-svg-icons": "^6.1.1",
     "@fortawesome/free-regular-svg-icons": "^6.1.1",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "@fortawesome/free-solid-svg-icons": "^6.1.1",
     "@fortawesome/react-fontawesome": "^0.1.18",
     "@terrestris/base-util": "^1.0.1",
-    "@terrestris/ol-util": "^6.0.1",
+    "@terrestris/ol-util": "^7.0.0",
     "@types/geojson": "^7946.0.8",
     "@types/lodash": "^4.14.179",
     "@types/moment": "^2.13.0",

--- a/src/Button/PrintButton/InkmapTypes.ts
+++ b/src/Button/PrintButton/InkmapTypes.ts
@@ -1,0 +1,78 @@
+export type WmsLayer = {
+  type: 'WMS';
+  url: string;
+  opacity?: number;
+  attribution?: string;
+  layer: string;
+  tiled?: boolean;
+};
+
+export type WmtsLayer = {
+  type: 'WMTS';
+  url: string;
+  opacity?: number;
+  attribution?: string;
+  layer?: string;
+  projection?: string;
+  matrixSet?: string;
+  tileGrid?: any;
+  format?: string;
+  requestEncoding?: string;
+};
+
+export type GeoJsonLayer = {
+  type: 'GeoJSON';
+  attribution?: string;
+  style: any;
+  geojson: any;
+};
+
+export type WfsLayer = {
+  type: 'WFS';
+  url: string;
+  attribution?: string;
+  layer?: string;
+  projection?: string;
+};
+
+export type OsmLayer = {
+  type: 'XYZ';
+  url: string;
+  opacity?: number;
+  attribution?: string;
+  layer?: string;
+  tiled?: boolean;
+  projection?: string;
+  matrixSet?: string;
+  tileGrid?: any;
+  style?: any;
+  format?: string;
+  requestEncoding?: string;
+  geojson?: any;
+};
+
+export type InkmapLayer = WmsLayer | WmtsLayer | GeoJsonLayer | WfsLayer | OsmLayer;
+
+export type ScaleBarSpec = {
+  position: 'bottom-left' | 'bottom-right';
+  units: string;
+};
+
+export type InkmapProjectionDefinition = {
+  name: string;
+  bbox: [number, number, number, number];
+  proj4: string;
+};
+
+export type InkmapPrintSpec = {
+  layers: InkmapLayer[];
+  size: [number, number] | [number, number, string];
+  center: [number, number];
+  dpi: number;
+  scale: number;
+  scaleBar: boolean | ScaleBarSpec;
+  northArrow: boolean | string;
+  projection: string;
+  projectionDefinitions?: InkmapProjectionDefinition[];
+  attributions: boolean | 'top-left' | 'bottom-left' | 'bottom-right' | 'top-right';
+};

--- a/src/Button/PrintButton/PrintButton.example.md
+++ b/src/Button/PrintButton/PrintButton.example.md
@@ -1,0 +1,58 @@
+This demonstrates the use of the PrintButton.
+
+```jsx
+import {useEffect, useState} from 'react';
+
+import OlMap from 'ol/Map';
+import OlView from 'ol/View';
+import OlLayerTile from 'ol/layer/Tile';
+import OlSourceOsm from 'ol/source/OSM';
+import { fromLonLat } from 'ol/proj';
+
+import MapContext from '@terrestris/react-geo/Context/MapContext/MapContext'
+import MapComponent from '@terrestris/react-geo/Map/MapComponent/MapComponent';
+import PrintButton from '@terrestris/react-geo/Button/PrintButton/PrintButton';
+
+const PrintButtonExample = () => {
+  const [map, setMap] = useState();
+
+  useEffect(() => {
+    const newMap = new OlMap({
+      layers: [
+        new OlLayerTile({
+          name: 'OSM',
+          source: new OlSourceOsm()
+        })
+      ],
+      view: new OlView({
+        center: fromLonLat([8, 50]),
+        zoom: 4
+      })
+    });
+
+    setMap(newMap);
+  }, []);
+
+  if (!map) {
+    return null;
+  }
+
+  return (
+    <div>
+      <MapContext.Provider value={map}>
+        <MapComponent
+          map={map}
+          style={{
+            height: '400px'
+          }}
+        />
+        <PrintButton>
+          Print map
+        </PrintButton>
+      </MapContext.Provider>
+    </div>
+  );
+}
+
+<PrintButtonExample />
+```

--- a/src/Button/PrintButton/PrintButton.example.md
+++ b/src/Button/PrintButton/PrintButton.example.md
@@ -7,6 +7,7 @@ import OlMap from 'ol/Map';
 import OlView from 'ol/View';
 import OlLayerTile from 'ol/layer/Tile';
 import OlSourceOsm from 'ol/source/OSM';
+import OlSourceTileWMS from 'ol/source/TileWMS';
 import { fromLonLat } from 'ol/proj';
 
 import MapContext from '@terrestris/react-geo/Context/MapContext/MapContext'
@@ -21,6 +22,15 @@ const PrintButtonExample = () => {
       layers: [
         new OlLayerTile({
           source: new OlSourceOsm()
+        }),
+        new OlLayerTile({
+          name: 'True Color Composite',
+          opacity: 0.5,
+          source: new OlSourceTileWMS({
+            url: 'https://geoserver.mundialis.de/geoserver/wms',
+            params: {'LAYERS': '1_040302', 'TILED': true},
+            serverType: 'geoserver'
+          })
         })
       ],
       view: new OlView({

--- a/src/Button/PrintButton/PrintButton.example.md
+++ b/src/Button/PrintButton/PrintButton.example.md
@@ -1,10 +1,15 @@
 This demonstrates the use of the PrintButton.
 
 ```jsx
-import {useEffect, useState} from 'react';
+import {useEffect, useState, useMemo} from 'react';
 
-import { fromLonLat, get as getProjection } from 'ol/proj';
+import {Circle as CircleStyle, Fill, Stroke, Style} from 'ol/style';
+import {fromLonLat, get as getProjection} from 'ol/proj';
 import {getTopLeft, getWidth} from 'ol/extent';
+import {OSM, Vector as VectorSource} from 'ol/source';
+import {Vector as VectorLayer} from 'ol/layer';
+import Feature from 'ol/Feature';
+import GeoJSON from 'ol/format/GeoJSON';
 import OlLayerTile from 'ol/layer/Tile';
 import OlMap from 'ol/Map';
 import OlSourceOsm from 'ol/source/OSM';
@@ -13,22 +18,116 @@ import OlView from 'ol/View';
 import WMTS from 'ol/source/WMTS';
 import WMTSTileGrid from 'ol/tilegrid/WMTS';
 
-import MapContext from '@terrestris/react-geo/Context/MapContext/MapContext'
 import MapComponent from '@terrestris/react-geo/Map/MapComponent/MapComponent';
+import MapContext from '@terrestris/react-geo/Context/MapContext/MapContext'
 import PrintButton from '@terrestris/react-geo/Button/PrintButton/PrintButton';
 
-const PrintButtonExample = () => {  
+import { Progress } from 'antd';
+
+const PrintButtonExample = () => {
   const [map, setMap] = useState();
+  const [progress, setProgress] = useState(0);
+  const [status, setStatus] = useState('pending');
+
+  const geojson = useMemo(() => ({
+    'type': 'FeatureCollection',
+    'crs': {
+      'type': 'name',
+      'properties': {
+        'name': 'EPSG:3857',
+      },
+    },
+    'features': [
+      {
+        'type': 'Feature',
+        'geometry': {
+          'type': 'LineString',
+          'coordinates': [
+            [4e6, 2e6],
+            [8e6, 4e6],
+          ],
+        },
+      },
+      {
+        'type': 'Feature',
+        'geometry': {
+          'type': 'LineString',
+          'coordinates': [
+            [4e6, 2e6],
+            [8e6, -2e6],
+          ],
+        },
+      },
+      {
+        'type': 'Feature',
+        'geometry': {
+          'type': 'Polygon',
+          'coordinates': [
+            [
+              [2e6, 5e6],
+              [2e6, 6e6],
+              [2e6, 7e6],
+              [0e6, 5e6]
+            ],
+          ],
+        },
+      },
+    ]}
+  ));
+
+  const image = new CircleStyle({
+    radius: 5,
+    fill: null,
+    stroke: new Stroke({color: 'red', width: 1}),
+  });
+
+  const styles = {
+    'Point': new Style({
+      image: image,
+    }),
+    'LineString': new Style({
+      stroke: new Stroke({
+        color: 'green',
+        width: 1,
+      }),
+    }),
+    'Polygon': new Style({
+      stroke: new Stroke({
+        color: 'blue',
+        lineDash: [4],
+        width: 3,
+      }),
+      fill: new Fill({
+        color: 'rgba(0, 0, 255, 0.1)',
+      }),
+    }),
+    'Circle': new Style({
+      stroke: new Stroke({
+        color: 'red',
+        width: 2,
+      }),
+      fill: new Fill({
+        color: 'rgba(255,0,0,0.2)',
+      })
+    })
+  };
+
+  const styleFunction = function (feature) {
+    return styles[feature.getGeometry().getType()];
+  };
 
   useEffect(() => {
     const projection = getProjection('EPSG:3857');
     const projectionExtent = projection.getExtent();
 
+    const vectorSource = new VectorSource({
+      features: new GeoJSON().readFeatures(geojson),
+    });
+
     const newMap = new OlMap({
       layers: [
         new OlLayerTile({
           source: new OlSourceOsm(),
-          opacity: 0.5
         }),
         new OlLayerTile({
           name: 'True Color Composite',
@@ -40,7 +139,7 @@ const PrintButtonExample = () => {
           })
         }),
         new OlLayerTile({
-          opacity: 0.7,
+          opacity: 0.6,
           source: new WMTS({
             attributions:
               'Tiles © <a href="https://mrdata.usgs.gov/geology/state/"' +
@@ -76,8 +175,25 @@ const PrintButtonExample = () => {
               matrixIds: [0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18]
             }),
             style: 'default',
-            wrapX: true,
-          }),
+            wrapX: true
+          })
+        }),
+        new VectorLayer({
+          source: vectorSource,
+          style: [
+            new Style({
+              stroke: new Stroke({
+                color: '#0000FF', // 'blue', todo: parser does not support named colors
+                lineDash: [4],
+                width: 3
+              })
+            }),
+            new Style({
+              fill: new Fill({
+                color: 'rgba(0, 0, 255, 0.1)'
+              })
+            })
+          ]
         })
       ],
       view: new OlView({
@@ -102,10 +218,13 @@ const PrintButtonExample = () => {
             height: '400px'
           }}
         />
-        <PrintButton>
+        <PrintButton
+          onProgressChange={setProgress}
+        >
           Print map
         </PrintButton>
       </MapContext.Provider>
+      <Progress percent={progress} />
     </div>
   );
 }

--- a/src/Button/PrintButton/PrintButton.example.md
+++ b/src/Button/PrintButton/PrintButton.example.md
@@ -20,7 +20,6 @@ const PrintButtonExample = () => {
     const newMap = new OlMap({
       layers: [
         new OlLayerTile({
-          name: 'OSM',
           source: new OlSourceOsm()
         })
       ],

--- a/src/Button/PrintButton/PrintButton.example.md
+++ b/src/Button/PrintButton/PrintButton.example.md
@@ -3,25 +3,32 @@ This demonstrates the use of the PrintButton.
 ```jsx
 import {useEffect, useState} from 'react';
 
-import OlMap from 'ol/Map';
-import OlView from 'ol/View';
+import { fromLonLat, get as getProjection } from 'ol/proj';
+import {getTopLeft, getWidth} from 'ol/extent';
 import OlLayerTile from 'ol/layer/Tile';
+import OlMap from 'ol/Map';
 import OlSourceOsm from 'ol/source/OSM';
 import OlSourceTileWMS from 'ol/source/TileWMS';
-import { fromLonLat } from 'ol/proj';
+import OlView from 'ol/View';
+import WMTS from 'ol/source/WMTS';
+import WMTSTileGrid from 'ol/tilegrid/WMTS';
 
 import MapContext from '@terrestris/react-geo/Context/MapContext/MapContext'
 import MapComponent from '@terrestris/react-geo/Map/MapComponent/MapComponent';
 import PrintButton from '@terrestris/react-geo/Button/PrintButton/PrintButton';
 
-const PrintButtonExample = () => {
+const PrintButtonExample = () => {  
   const [map, setMap] = useState();
 
   useEffect(() => {
+    const projection = getProjection('EPSG:3857');
+    const projectionExtent = projection.getExtent();
+
     const newMap = new OlMap({
       layers: [
         new OlLayerTile({
-          source: new OlSourceOsm()
+          source: new OlSourceOsm(),
+          opacity: 0.5
         }),
         new OlLayerTile({
           name: 'True Color Composite',
@@ -31,6 +38,46 @@ const PrintButtonExample = () => {
             params: {'LAYERS': '1_040302', 'TILED': true},
             serverType: 'geoserver'
           })
+        }),
+        new OlLayerTile({
+          opacity: 0.7,
+          source: new WMTS({
+            attributions:
+              'Tiles © <a href="https://mrdata.usgs.gov/geology/state/"' +
+              ' target="_blank">USGS</a>',
+            url: 'https://mrdata.usgs.gov/mapcache/wmts',
+            layer: 'sgmc2',
+            matrixSet: 'GoogleMapsCompatible',
+            format: 'image/png',
+            projection: projection,
+            tileGrid: new WMTSTileGrid({
+              origin: getTopLeft(projectionExtent),
+              resolutions: [
+                156543.03392804097,
+                78271.51696402048,
+                39135.75848201024,
+                19567.87924100512,
+                9783.93962050256,
+                4891.96981025128,
+                2445.98490512564,
+                1222.99245256282,
+                611.49622628141,
+                305.748113140705,
+                152.8740565703525,
+                76.43702828517625,
+                38.21851414258813,
+                19.109257071294063,
+                9.554628535647032,
+                4.777314267823516,
+                2.388657133911758,
+                1.194328566955879,
+                0.5971642834779395
+              ],
+              matrixIds: [0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18]
+            }),
+            style: 'default',
+            wrapX: true,
+          }),
         })
       ],
       view: new OlView({

--- a/src/Button/PrintButton/PrintButton.spec.tsx
+++ b/src/Button/PrintButton/PrintButton.spec.tsx
@@ -1,0 +1,79 @@
+import { screen,  within } from '@testing-library/react';
+import * as React from 'react';
+import userEvent from '@testing-library/user-event';
+
+import OlView from 'ol/View';
+import OlMap from 'ol/Map';
+import OlPoint from 'ol/geom/Point';
+import OlFeature from 'ol/Feature';
+
+import { clickMap, mockForEachFeatureAtPixel, renderInMapContext } from '../../Util/rtlTestUtils';
+import { DigitizeUtil } from '../../Util/DigitizeUtil';
+import PrintButton from './PrintButton';
+
+describe('<PrintButton />', () => {
+
+  const coord = [829729, 6708850];
+  let map: OlMap;
+  let feature: OlFeature<OlPoint>;
+
+  beforeEach(() => {
+    feature = new OlFeature<OlPoint>({
+      geometry: new OlPoint(coord),
+      someProp: 'test'
+    });
+
+    map = new OlMap({
+      view: new OlView({
+        center: coord,
+        zoom: 10
+      }),
+      controls: [],
+      layers: []
+    });
+
+    DigitizeUtil.getDigitizeLayer(map)
+      .getSource().addFeature(feature);
+  });
+
+  describe('#Basics', () => {
+
+    it('is defined', () => {
+      expect(PrintButton).not.toBeUndefined();
+    });
+
+    it('can be rendered', () => {
+      const { container } = renderInMapContext(map, <PrintButton />);
+
+      const button = within(container).getByRole('button');
+      expect(button).toBeVisible();
+    });
+  });
+
+  describe('#Copying', () => {
+    it('copies the feature', async () => {
+      const mock = mockForEachFeatureAtPixel(map, [200, 200], feature);
+
+      const layer = DigitizeUtil.getDigitizeLayer(map);
+
+      renderInMapContext(map, <PrintButton />);
+
+      const button = screen.getByRole('button');
+      await userEvent.click(button);
+
+      expect(layer.getSource().getFeatures()).toHaveLength(1);
+
+      clickMap(map, 200, 200);
+
+      expect(layer.getSource().getFeatures()).toHaveLength(2);
+
+      const [feat1, feat2] = layer.getSource().getFeatures();
+
+      expect(feat2.get('someProp')).toEqual('test');
+
+      expect(feat1.getGeometry().getType()).toEqual(feat2.getGeometry().getType());
+
+      mock.mockRestore();
+    });
+  });
+});

--- a/src/Button/PrintButton/PrintButton.spec.tsx
+++ b/src/Button/PrintButton/PrintButton.spec.tsx
@@ -21,7 +21,7 @@ describe('<PrintButton />', () => {
 
   beforeEach(() => {
     feature = new OlFeature<OlPoint>({
-      geometry: new OlPoint(coord),
+      geometry: new OlPoint(coordinates),
       someProp: 'test'
     });
 

--- a/src/Button/PrintButton/PrintButton.spec.tsx
+++ b/src/Button/PrintButton/PrintButton.spec.tsx
@@ -1,30 +1,21 @@
-import { screen,  within } from '@testing-library/react';
 import * as React from 'react';
+import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
-import OlView from 'ol/View';
+import PrintButton from './PrintButton';
+import { renderInMapContext } from '../../Util/rtlTestUtils';
+
 import OlMap from 'ol/Map';
-import OlPoint from 'ol/geom/Point';
-import OlFeature from 'ol/Feature';
+import OlView from 'ol/View';
 import OlLayerTile from 'ol/layer/Tile';
 import OlSourceOsm from 'ol/source/OSM';
-
-import { clickMap, mockForEachFeatureAtPixel, renderInMapContext } from '../../Util/rtlTestUtils';
-import { DigitizeUtil } from '../../Util/DigitizeUtil';
-import PrintButton from './PrintButton';
 
 describe('<PrintButton />', () => {
 
   const coordinates = [829729, 6708850];
   let map: OlMap;
-  let feature: OlFeature<OlPoint>;
 
   beforeEach(() => {
-    feature = new OlFeature<OlPoint>({
-      geometry: new OlPoint(coordinates),
-      someProp: 'test'
-    });
-
     map = new OlMap({
       layers: [
         new OlLayerTile({
@@ -36,9 +27,6 @@ describe('<PrintButton />', () => {
         zoom: 10
       })
     });
-
-    DigitizeUtil.getDigitizeLayer(map)
-      .getSource().addFeature(feature);
   });
 
   describe('#Basics', () => {
@@ -49,36 +37,17 @@ describe('<PrintButton />', () => {
 
     it('can be rendered', () => {
       const { container } = renderInMapContext(map, <PrintButton />);
-
-      const button = within(container).getByRole('button');
-      expect(button).toBeVisible();
+      expect(container).toBeVisible();
     });
   });
 
-  describe('#Copying', () => {
-    it('copies the feature', async () => {
-      const mock = mockForEachFeatureAtPixel(map, [200, 200], feature);
+  describe('#Printing', () => {
 
-      const layer = DigitizeUtil.getDigitizeLayer(map);
-
-      renderInMapContext(map, <PrintButton />);
-
-      const button = screen.getByRole('button');
+    it('prints a png image', async () => {
+      renderInMapContext(map, <PrintButton>Print test</PrintButton>);
+      const button = screen.getByText('Print test');
       await userEvent.click(button);
-
-      expect(layer.getSource().getFeatures()).toHaveLength(1);
-
-      clickMap(map, 200, 200);
-
-      expect(layer.getSource().getFeatures()).toHaveLength(2);
-
-      const [feat1, feat2] = layer.getSource().getFeatures();
-
-      expect(feat2.get('someProp')).toEqual('test');
-
-      expect(feat1.getGeometry().getType()).toEqual(feat2.getGeometry().getType());
-
-      mock.mockRestore();
     });
+
   });
 });

--- a/src/Button/PrintButton/PrintButton.spec.tsx
+++ b/src/Button/PrintButton/PrintButton.spec.tsx
@@ -6,6 +6,8 @@ import OlView from 'ol/View';
 import OlMap from 'ol/Map';
 import OlPoint from 'ol/geom/Point';
 import OlFeature from 'ol/Feature';
+import OlLayerTile from 'ol/layer/Tile';
+import OlSourceOsm from 'ol/source/OSM';
 
 import { clickMap, mockForEachFeatureAtPixel, renderInMapContext } from '../../Util/rtlTestUtils';
 import { DigitizeUtil } from '../../Util/DigitizeUtil';
@@ -13,7 +15,7 @@ import PrintButton from './PrintButton';
 
 describe('<PrintButton />', () => {
 
-  const coord = [829729, 6708850];
+  const coordinates = [829729, 6708850];
   let map: OlMap;
   let feature: OlFeature<OlPoint>;
 
@@ -24,12 +26,15 @@ describe('<PrintButton />', () => {
     });
 
     map = new OlMap({
+      layers: [
+        new OlLayerTile({
+          source: new OlSourceOsm()
+        })
+      ],
       view: new OlView({
-        center: coord,
+        center: coordinates,
         zoom: 10
-      }),
-      controls: [],
-      layers: []
+      })
     });
 
     DigitizeUtil.getDigitizeLayer(map)

--- a/src/Button/PrintButton/PrintButton.tsx
+++ b/src/Button/PrintButton/PrintButton.tsx
@@ -10,12 +10,55 @@ import {
 } from '@camptocamp/inkmap';
 import { Progress } from 'antd';
 import SimpleButton from '../SimpleButton/SimpleButton';
-// import OlLayer from 'ol/layer/Layer';
+import _isFinite from 'lodash/isFinite';
 
-interface OwnProps {
-}
+import OlLayer from 'ol/layer/Layer';
+import {toLonLat} from 'ol/proj';
+import OlMap from 'ol/Map';
+import OSM from 'ol/source/OSM';
+import WMTS from 'ol/source/WMTS';
+import TileWMS from 'ol/source/TileWMS';
+import ImageWMS from 'ol/source/ImageWMS';
+import VectorSource from 'ol/source/Vector';
+
+import MapUtil from '@terrestris/ol-util/dist/MapUtil/MapUtil';
+
+interface OwnProps {}
 
 export type PrintButtonProps = OwnProps;
+
+export type InkmapLayer = {
+  type: 'XYZ' | 'WMTS' | 'WMS' | 'WFS' | 'GeoJSON';
+  url: string;
+  opacity: number;
+  attribution: string;
+  layer?: string;
+  tiled?: boolean;
+}
+
+export type ScaleBarSpec = {
+  position: 'bottom-left' | 'bottom-right';
+  units: string;
+};
+
+export type InkmapProjectionDefinition = {
+  name: string;
+  bbox: [number, number, number, number];
+  proj4: string;
+};
+
+export type InkmapPrintSpec = {
+  layers: InkmapLayer[];
+  size: Array<string|number>; // todo: [number, number] | [number, number, string]
+  center: [number, number];
+  dpi: number;
+  scale: number;
+  scaleBar: boolean | ScaleBarSpec;
+  northArrow: boolean | string;
+  projection: string;
+  projectionDefinitions?: InkmapProjectionDefinition[];
+  attributions: boolean | 'top-left' | 'bottom-left' | 'bottom-right' | 'top-right';
+};
 
 const PrintButton: React.FC<PrintButtonProps> = ({
   ...passThroughProps
@@ -29,26 +72,120 @@ const PrintButton: React.FC<PrintButtonProps> = ({
 
   console.log('status', status);
 
-  const onPrintClick = async (event: any) => {
-    setLoading(true);
-    // todo: get layer from map and map to configuration object
-    // const layerSources = map?.getAllLayers().map((l: OlLayer) => l.getSource());
-    const printConfig = {
-      ... baseConfig
-      // layers: layerSources
+  const mapOlLayerToInkmap = (olLayer: OlLayer): InkmapLayer | null => {
+    const source = olLayer.getSource();
+    if (source instanceof TileWMS) {
+      return {
+       type: 'WMS',
+       url: source.getUrls()?.[0] ?? '',
+       opacity: olLayer.getOpacity(), // todo: fix opacity
+       attribution: source.getAttributions()?.toString() ?? '', // todo: ...
+       layer: source.getParams()?.LAYERS,
+       tiled: true
+      };
+    } else if (source instanceof ImageWMS) {
+      return {
+        type: 'WMS',
+        url: source.getUrl() ?? '',
+        opacity: olLayer.getOpacity(),
+        attribution: source.getAttributions()?.toString() ?? '', // todo: ...
+        layer: 'bla test q123',
+        tiled: false
+       };
+    } else if (source instanceof WMTS) {
+      return {
+        type: 'WMS',
+        url: source.getUrls()?.[0] ?? '',
+        opacity: olLayer.getOpacity(),
+        attribution: source.getAttributions()?.toString() ?? '', // todo: ...
+        layer: 'bla test q123',
+        tiled: true
+        // todo!
+       };
+    } else if (source instanceof OSM) {
+      return {
+        type: 'XYZ',
+        url: 'https://{a-c}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+        opacity: olLayer.getOpacity(),
+        attribution: "© OpenStreetMap (www.openstreetmap.org)",
+        layer: 'bla test q123',
+        tiled: true
+       };
+    } else if (source instanceof VectorSource) {
+      // todo
+      return null;
+    } else {
+      return null;
+    }
+
+  };
+
+  const generatePrintConfig = (map: OlMap): InkmapPrintSpec => {
+    const unit = map.getView().getProjection().getUnits();
+    const resolution = map.getView().getResolution();
+    const projection =  map.getView().getProjection().getCode();
+
+    const scale = MapUtil.getScaleForResolution(resolution as number, unit);
+    const center = map?.getView().getCenter();
+    if (!unit || !center || !_isFinite(resolution)) {
+      throw new Error('Can not determine unit / resolution from map');
+    }
+    const centerLonLat = toLonLat(center, projection) as [number, number];
+
+    const layers: InkmapLayer[] = map.getAllLayers()
+      .map(mapOlLayerToInkmap)
+      .filter(l => l !== null) as InkmapLayer[]; // todo: remove cast
+
+    console.log('layers', layers);
+    const config: InkmapPrintSpec = {
+      layers: layers,
+      "size": [
+        400,
+        240,
+        "mm"
+      ],
+      "center": centerLonLat,
+      "dpi": 120,
+      "scale": scale,
+      "scaleBar": {
+        "position": "bottom-left",
+        "units": "metric"
+      },
+      "projection": "EPSG:3857",
+      "northArrow": "top-right",
+      "attributions": "bottom-right"
     };
+
+    return config;
+  }
+
+  const onPrintClick = async (event: any) => {
+    if (!map) {
+      return;
+    }
+    setLoading(true);
+    const printConfig = generatePrintConfig(map);
     const jobId = await queuePrint(printConfig);
 
     getJobStatus(jobId).subscribe((printStatus: any) => {
       // update the job progress
       setProgress(printStatus.progress * 100);
       setStatus(printStatus.status);
-      console.log('printStatus.status', printStatus.status);
 
       // job is finished
       if (printStatus.progress === 1) {
         setLoading(false);
         downloadBlob(printStatus.imageBlob, 'react-geo-image.png');
+      }
+
+      // display errors
+      if (printStatus.sourceLoadErrors.length > 0) {
+        let errorMessage = '';
+        printStatus.sourceLoadErrors.forEach((element: any) => {
+          errorMessage = `${errorMessage} - ${element.url} `;
+        });
+        console.log('errorMessage', errorMessage);
+        // todo: display errors?
       }
     });
   };
@@ -56,36 +193,6 @@ const PrintButton: React.FC<PrintButtonProps> = ({
   if (!map) {
     return null;
   }
-
-  const baseConfig = {
-    "layers": [
-      {
-        "type": "XYZ",
-        "url": "https://{a-c}.tile.openstreetmap.org/{z}/{x}/{y}.png",
-        "layer": "OSM",
-        "tiled": true,
-        "attribution": "© OpenStreetMap (www.openstreetmap.org), Terrestris GmbH"
-      }
-    ],
-    "size": [
-      400,
-      240,
-      "mm"
-    ],
-    "center": [
-      12,
-      56
-    ],
-    "dpi": 120,
-    "scale": 20000000,
-    "scaleBar": {
-      "position": "bottom-left",
-      "units": "metric"
-    },
-    "projection": "EPSG:3857",
-    "northArrow": "top-right",
-    "attributions": "bottom-right"
-  };
 
   return (
     <div>

--- a/src/Button/PrintButton/PrintButton.tsx
+++ b/src/Button/PrintButton/PrintButton.tsx
@@ -11,28 +11,10 @@ import {
 import SimpleButton from '../SimpleButton/SimpleButton';
 import _isFinite from 'lodash/isFinite';
 
-import {toLonLat} from 'ol/proj';
-import ImageWMS from 'ol/source/ImageWMS';
-import OlLayer from 'ol/layer/Layer';
-import OlMap from 'ol/Map';
-import OSM from 'ol/source/OSM';
-import TileWMS from 'ol/source/TileWMS';
-import VectorSource from 'ol/source/Vector';
-import WMTS from 'ol/source/WMTS';
-import GeoJSON from 'ol/format/GeoJSON';
-import VectorLayer from 'ol/layer/Vector';
-
-import OpenLayersParser from 'geostyler-openlayers-parser';
-
-import MapUtil from '@terrestris/ol-util/dist/MapUtil/MapUtil';
 import Logger from '@terrestris/base-util/dist/Logger';
+import MapUtil from '@terrestris/ol-util/dist/MapUtil/MapUtil';
 
 import {
-  WmsLayer,
-  WmtsLayer,
-  OsmLayer,
-  GeoJsonLayer,
-  InkmapLayer,
   InkmapPrintSpec
 } from './InkmapTypes';
 
@@ -56,147 +38,23 @@ const PrintButton: React.FC<PrintButtonProps> = ({
   const [loading, setLoading] = useState<boolean>(false);
   const map = useMap();
 
-  const mapOlLayerToInkmap = async (olLayer: OlLayer): Promise<InkmapLayer | null> => {
-    const source = olLayer.getSource();
-    const opacity = olLayer.getOpacity();
-
-    if (source instanceof TileWMS) {
-      const tileWmsLayer: WmsLayer = {
-        type: 'WMS',
-        url: source.getUrls()?.[0] ?? '',
-        opacity: opacity,
-        attribution: '', // todo: get attributions from source
-        layer: source.getParams()?.LAYERS,
-        tiled: true
-      };
-      return tileWmsLayer;
-    } else if (source instanceof ImageWMS) {
-      const imageWmsLayer: WmsLayer = {
-        type: 'WMS',
-        url: source.getUrl() ?? '',
-        opacity: opacity,
-        attribution: '', // todo: get attributions from source
-        layer: source.getParams()?.LAYERS,
-        tiled: false
-      };
-      return imageWmsLayer;
-    } else if (source instanceof WMTS) {
-      const olTileGrid = source.getTileGrid();
-      const resolutions = olTileGrid?.getResolutions();
-      const matrixIds = resolutions?.map((res, idx) => idx);
-
-      const tileGrid = {
-        resolutions: olTileGrid?.getResolutions(),
-        extent: olTileGrid?.getExtent(),
-        matrixIds: matrixIds
-      };
-
-      const wmtsLayer: WmtsLayer = {
-        type: 'WMTS',
-        requestEncoding: source.getRequestEncoding(),
-        url: source.getUrls()?.[0] ?? '',
-        layer: source.getLayer(),
-        projection: source.getProjection().getCode(),
-        matrixSet: source.getMatrixSet(),
-        tileGrid: tileGrid,
-        format: source.getFormat(),
-        opacity: opacity,
-        attribution: '', // todo: get attributions from source
-      };
-      return wmtsLayer;
-    } else if (source instanceof OSM) {
-      const osmLayer: OsmLayer = {
-        type: 'XYZ',
-        url: 'https://{a-c}.tile.openstreetmap.org/{z}/{x}/{y}.png',
-        opacity: opacity,
-        attribution: '© OpenStreetMap (www.openstreetmap.org)',
-        tiled: true
-      };
-      return osmLayer;
-    } else if (source instanceof VectorSource) {
-      const geojson = new GeoJSON().writeFeaturesObject(source.getFeatures()) as any;
-      const parser = new OpenLayersParser();
-      const config: GeoJsonLayer = {
-        type: 'GeoJSON',
-        geojson: geojson,
-        style: undefined,
-        attribution: ''
-      };
-
-      let olStyle = null;
-
-      if (olLayer instanceof VectorLayer) {
-        olStyle = olLayer.getStyle();
-      }
-
-      // todo: support stylefunction / different styles per feature
-      // const styles = source.getFeatures()?.map(f => f.getStyle());
-
-      if (olStyle) {
-        // todo: gs-ol-parser does not support style with both fill and stroke defined
-        const gsStyle = await parser.readStyle(olStyle);
-        if (gsStyle.errors) {
-          Logger.error('Geostyler errors: ', gsStyle.errors);
-        }
-        if (gsStyle.warnings) {
-          Logger.warn('Geostyler warnings: ', gsStyle.warnings);
-        }
-        if (gsStyle.unsupportedProperties) {
-          Logger.warn('Detected unsupported style properties: ', gsStyle.unsupportedProperties);
-        }
-        config.style = gsStyle.output;
-      }
-      return config;
-    }
-    return null;
-  };
-
-  const generatePrintConfig = async (olMap: OlMap): Promise<InkmapPrintSpec | null> => {
-    const unit = olMap.getView().getProjection().getUnits();
-    const resolution = olMap.getView().getResolution();
-    const projection =  olMap.getView().getProjection().getCode();
-
-    const scale = MapUtil.getScaleForResolution(resolution as number, unit);
-    const center = olMap?.getView().getCenter();
-    if (!unit || !center || !_isFinite(resolution)) {
-      throw new Error('Can not determine unit / resolution from map');
-    }
-    const centerLonLat = toLonLat(center, projection) as [number, number];
-
-    const layerPromises = olMap.getAllLayers()
-      .map(mapOlLayerToInkmap);
-
-    return Promise.all(layerPromises)
-      .then((responses) => {
-        const layers: InkmapLayer[] = responses.filter(l => l !== null) as InkmapLayer[];
-        const config: InkmapPrintSpec = {
-          layers: layers,
-          size: size,
-          center: centerLonLat,
-          dpi: dpi,
-          scale: scale,
-          scaleBar: { // todo: make configurable
-            position: 'bottom-left',
-            units: 'metric'
-          },
-          projection: projection,
-          northArrow: 'top-right', // todo: make configurable
-          attributions: 'bottom-right' // todo: make configurable
-        };
-        return Promise.resolve(config);
-      })
-      .catch((error: any) => {
-        Logger.error(error);
-        return Promise.reject();
-      });
-  };
-
   const onPrintClick = async (event: any) => {
     if (!map) {
       return;
     }
     setLoading(true);
-    const printConfig = await generatePrintConfig(map);
+    const printConfigByMap = await MapUtil.generatePrintConfig(map);
+    const printConfig = {
+      ...printConfigByMap,
+      size: size,
+      dpi: dpi,
+      scaleBar: { // todo: make configurable
+        position: 'bottom-left',
+        units: 'metric'
+      },
+      northArrow: 'top-right', // todo: make configurable
+      attributions: 'bottom-right' // todo: make configurable
+    };
     const jobId = await queuePrint(printConfig);
 
     getJobStatus(jobId).subscribe((printStatus: any) => {

--- a/src/Button/PrintButton/PrintButton.tsx
+++ b/src/Button/PrintButton/PrintButton.tsx
@@ -1,0 +1,80 @@
+import React, {
+  useState
+} from 'react';
+
+import { useMap } from '../../Hook/useMap';
+import { print, downloadBlob } from '@camptocamp/inkmap';
+import SimpleButton from '../SimpleButton/SimpleButton';
+
+interface OwnProps {
+}
+
+export type PrintButtonProps = OwnProps;
+
+const PrintButton: React.FC<PrintButtonProps> = ({
+  ...passThroughProps
+}) => {
+
+  const [loading, setLoading] = useState<boolean>(false);
+
+  const map = useMap();
+
+  const onPrintClick = (event: any) => {
+    setLoading(true);
+    // todo: get layer from map and map to configuration object
+    // const layers = map?.getAllLayers().map((l: OlLayerTile<OlSourceOsm>) => ({
+    //   type: 'WMS',
+    //   url: l.getSource()?.getUrls()[0]
+    // }));
+    const printConfig = {
+      ... baseConfig,
+      // layers: layers
+    };
+    print(printConfig)
+      .then(downloadBlob)
+      .then(setLoading(false));
+  };
+
+  if (!map) {
+    return null;
+  }
+
+  const baseConfig = {
+    "layers": [
+      {
+        "type": "XYZ",
+        "url": "https://{a-c}.tile.openstreetmap.org/{z}/{x}/{y}.png",
+        "layer": "OSM",
+        "tiled": true,
+        "attribution": "© OpenStreetMap (www.openstreetmap.org), Terrestris GmbH"
+      }
+    ],
+    "size": [
+      400,
+      240,
+      "mm"
+    ],
+    "center": [
+      12,
+      56
+    ],
+    "dpi": 120,
+    "scale": 20000000,
+    "scaleBar": {
+      "position": "bottom-left",
+      "units": "metric"
+    },
+    "projection": "EPSG:3857",
+    "northArrow": "top-right",
+    "attributions": "bottom-right"
+  };
+
+  return <SimpleButton
+    loading={loading}
+    onClick={onPrintClick}
+    {...passThroughProps}
+  />;
+
+};
+
+export default PrintButton;

--- a/src/Field/WfsSearch/WfsSearch.tsx
+++ b/src/Field/WfsSearch/WfsSearch.tsx
@@ -327,13 +327,13 @@ export class WfsSearch extends React.Component<WfsSearchProps, WfsSearchState> {
     } = this.props;
 
     const searchOpts = {
-      featureNS,
-      featurePrefix,
+      featureNS: featureNS ?? '',
+      featurePrefix: featurePrefix ?? '',
       featureTypes,
-      geometryName,
-      maxFeatures,
+      geometryName: geometryName ?? '',
+      maxFeatures: maxFeatures ?? 0,
       outputFormat,
-      propertyNames,
+      propertyNames: propertyNames ?? [],
       srsName,
       wfsFormatOptions,
       searchAttributes,

--- a/src/Field/WfsSearchInput/WfsSearchInput.tsx
+++ b/src/Field/WfsSearchInput/WfsSearchInput.tsx
@@ -296,13 +296,13 @@ export class WfsSearchInput extends React.Component<WfsSearchInputProps, WfsSear
     } = this.props;
 
     const searchOpts = {
-      featureNS,
-      featurePrefix,
+      featureNS: featureNS ?? '',
+      featurePrefix: featurePrefix ?? '',
       featureTypes,
-      geometryName,
-      maxFeatures,
+      geometryName: geometryName ?? '',
+      maxFeatures: maxFeatures ?? 0,
       outputFormat,
-      propertyNames,
+      propertyNames: propertyNames ?? [],
       srsName,
       wfsFormatOptions,
       searchAttributes,

--- a/src/LayerTree/LayerTree.tsx
+++ b/src/LayerTree/LayerTree.tsx
@@ -24,6 +24,7 @@ import _isFunction from 'lodash/isFunction';
 import _isEqual from 'lodash/isEqual';
 
 import MapUtil from '@terrestris/ol-util/dist/MapUtil/MapUtil';
+import Logger from '@terrestris/base-util/dist/Logger';
 
 import LayerTreeNode, { LayerTreeNodeProps } from './LayerTreeNode/LayerTreeNode';
 
@@ -451,6 +452,10 @@ class LayerTree extends React.Component<LayerTreeProps, LayerTreeState> {
     const eventKey = e.node.props.eventKey;
     if (eventKey) {
       const layer = MapUtil.getLayerByOlUid(this.props.map, eventKey);
+      if (!layer) {
+        Logger.error('layer is not defined');
+        return;
+      }
       this.setLayerVisibility(layer, checked);
     }
   }
@@ -512,9 +517,17 @@ class LayerTree extends React.Component<LayerTreeProps, LayerTreeState> {
       return;
     }
     const dragLayer = MapUtil.getLayerByOlUid(this.props.map, e.dragNode.props.eventKey);
+    if (!dragLayer) {
+      Logger.error('dragLayer is not defined');
+      return;
+    }
     const dragInfo = MapUtil.getLayerPositionInfo(dragLayer, this.props.map);
     const dragCollection = dragInfo.groupLayer.getLayers();
     const dropLayer = MapUtil.getLayerByOlUid(this.props.map, e.node.props.eventKey);
+    if (!dropLayer) {
+      Logger.error('dropLayer is not defined');
+      return;
+    }
     const dropPos = e.node.props.pos.split('-');
     const location = e.dropPosition - Number(dropPos[dropPos.length - 1]);
 

--- a/src/custom.d.ts
+++ b/src/custom.d.ts
@@ -4,3 +4,4 @@ declare module 'ol/format';
 declare module 'ol/layer';
 declare module 'ol/source';
 declare module 'ol/geom';
+declare module '@camptocamp/inkmap';

--- a/webpack.common.config.js
+++ b/webpack.common.config.js
@@ -1,6 +1,7 @@
 const path = require('path');
 const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
 const TsconfigPathsPlugin = require('tsconfig-paths-webpack-plugin');
+const CopyWebpackPlugin = require('copy-webpack-plugin');
 
 module.exports = {
   devServer: {
@@ -60,6 +61,14 @@ module.exports = {
   plugins: [
     new ForkTsCheckerWebpackPlugin({
       async: false
+    }),
+    new CopyWebpackPlugin({
+      patterns: [
+        {
+          from: 'node_modules/@camptocamp/inkmap/dist/inkmap-worker.js',
+          to: 'build'
+        }
+      ]
     })
   ]
   // Uncomment the following lines if you're working with a linked


### PR DESCRIPTION
## Description

<!-- Please give a short description of the changes you propose. Please use prose and try not to be too technical, if possible. Make sure to mention people that you think should know about the PR. -->

Introduces a client-side print component using [@camptocamp/inkmap](https://github.com/camptocamp/inkmap) which prints the map provided by the MapContext.

Currently supports:
- WMS layers
- WMTS layers
- GeoJSON vector layers
- OSM layers

Todos / open issues:
- support wfs layers
- support styles on feature level (if possible)
- fix issues with geostyler-openlayers-parser:
   - if both fill and stroke are defined, stroke will be silently removed
   - support for named colors
- add legend support (on the way)
- pass configuration options for scale bar, north arrow etc. to inkmap

![print2](https://user-images.githubusercontent.com/5795523/173516953-b1fe6ea4-7d6c-4eb3-abf8-58c370949a79.gif)

@terrestris/devs Please review

## Related issues or pull requests

<!-- Please list issues or pull requests that the changes you propose are related to. It does not matter if they are still open and/or unmerged, any link is appreciated. -->

## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [ ] Bugfix
- [x] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the
  [BSD-2-Clause](https://github.com/terrestris/react-geo/blob/main/LICENSE).
- [x] I have followed the [guidelines for contributing](https://github.com/terrestris/react-geo/blob/main/CONTRIBUTING.md).
- [x] The proposed change fits to the content of the [Code of Conduct](https://github.com/terrestris/react-geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally).
- [x] I have added a screenshot/screencast to illustrate the visual output of my update.
