### PR TITLE
fix: use actual image size when printing legends

### DIFF
--- a/src/Button/PrintButton/PrintButton.example.md
+++ b/src/Button/PrintButton/PrintButton.example.md
@@ -129,7 +129,7 @@ const PrintButtonExample = () => {
       source: new OlSourceOsm(),
     });
     osm.set('name', 'OpenStreetMap');
-    osm.set('legendUrl', '/assets/legend2.png');
+    osm.set('legendUrl', '/assets/legend1.png');
 
     const stamen = new OlLayerTile({
       source: new OlSourceStamen({


### PR DESCRIPTION
## Description

Determines legend image dimensions before putting them in the PDF.

Temporary solution until https://github.com/camptocamp/inkmap/pull/49 is available.

## Related issues or pull requests

https://github.com/camptocamp/inkmap/pull/49

## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the
  [BSD-2-Clause](https://github.com/terrestris/react-geo/blob/main/LICENSE).
- [x] I have followed the [guidelines for contributing](https://github.com/terrestris/react-geo/blob/main/CONTRIBUTING.md).
- [x] The proposed change fits to the content of the [Code of Conduct](https://github.com/terrestris/react-geo/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally).
- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
