### PR TITLE
feat: add antd passThroughProps to SearchResultsPanel

### DIFF
--- a/src/Panel/SearchResultsPanel/SearchResultsPanel.tsx
+++ b/src/Panel/SearchResultsPanel/SearchResultsPanel.tsx
@@ -6,6 +6,7 @@ import OlMap from 'ol/Map';
 
 import {
   Collapse,
+  CollapseProps,
   List
 } from 'antd';
 
@@ -17,7 +18,7 @@ import BaseLayer from 'ol/layer/Base';
 const Panel = Collapse.Panel;
 const ListItem = List.Item;
 
-interface SearchResultsPanelProps {
+interface SearchResultsPanelProps extends Partial<CollapseProps>{
   features: {
     [title: string]: OlFeature[];
   };
@@ -31,7 +32,8 @@ const SearchResultsPanel = (props: SearchResultsPanelProps) => {
   const {
     features,
     numTotal,
-    searchTerms
+    searchTerms,
+    ...passThroughProps
   } = props;
 
   useEffect(() => {
@@ -45,7 +47,7 @@ const SearchResultsPanel = (props: SearchResultsPanelProps) => {
   useEffect(() => {
     return () => {
       map.removeLayer(highlightLayer as BaseLayer);
-    }
+    };
   }, [highlightLayer]);
 
   const highlightSearchTerms = (text: string) => {
@@ -135,6 +137,7 @@ const SearchResultsPanel = (props: SearchResultsPanelProps) => {
     <div className="search-result-div">
       <Collapse
         defaultActiveKey={Object.keys(features)[0]}
+        {...passThroughProps}
       >
         {
           Object.keys(features).map((title: string) => {


### PR DESCRIPTION
## Description

<!-- Please give a short description of the changes you propose. Please use prose and try not to be too technical, if possible. Make sure to mention people that you think should know about the PR. -->

This extends the props type of `<SearchResultsPanel>` to pass through antd properties. Through this, it is possible to configure antd `<Collapse>` and e.g. set all panels to be expanded by default.

## Related issues or pull requests

<!-- Please list issues or pull requests that the changes you propose are related to. It does not matter if they are still open and/or unmerged, any link is appreciated. -->

## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [ ] Bugfix
- [x] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the
  [BSD-2-Clause](https://github.com/terrestris/react-geo/blob/main/LICENSE).
- [x] I have followed the [guidelines for contributing](https://github.com/terrestris/react-geo/blob/main/CONTRIBUTING.md).
- [x] The proposed change fits to the content of the [Code of Conduct](https://github.com/terrestris/react-geo/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally).
- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
