### PR TITLE
fix: use broader peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -158,10 +158,10 @@
     "whatwg-fetch": "^3.6.2"
   },
   "peerDependencies": {
-    "@types/react": "^17.0",
+    "@types/react": ">=17",
     "antd": "^4.17",
     "ol": "^6.9",
-    "react": "^17.0"
+    "react": ">=17"
   },
   "engines": {
     "node": ">=14",


### PR DESCRIPTION
## Description

Newer npm version complain if there is a peerDependency mismatch. This way react-geo is more compatible.

## Related issues or pull requests

<!-- Please list issues or pull requests that the changes you propose are related to. It does not matter if they are still open and/or unmerged, any link is appreciated. -->

## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [ ] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the
  [BSD-2-Clause](https://github.com/terrestris/react-geo/blob/main/LICENSE).
- [x] I have followed the [guidelines for contributing](https://github.com/terrestris/react-geo/blob/main/CONTRIBUTING.md).
- [x] The proposed change fits to the content of the [Code of Conduct](https://github.com/terrestris/react-geo/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally).
- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
