### PR TITLE
Prepare ol update

### DIFF
--- a/src/Button/DrawButton/DrawButton.tsx
+++ b/src/Button/DrawButton/DrawButton.tsx
@@ -140,13 +140,15 @@ const DrawButton: React.FC<DrawButtonProps> = ({
     }
 
     let geometryFunction;
-    let type = drawType;
+    let type: 'Point' | 'Circle' | 'LineString' | 'Polygon';
 
     if (drawType === 'Rectangle') {
       geometryFunction = createBox();
       type = 'Circle';
     } else if (drawType === 'Text') {
       type = 'Point';
+    } else {
+      type = drawType;
     }
 
     const newInteraction = new OlInteractionDraw({

--- a/src/Button/MeasureButton/MeasureButton.tsx
+++ b/src/Button/MeasureButton/MeasureButton.tsx
@@ -16,8 +16,6 @@ import OlInteractionDraw, { DrawEvent } from 'ol/interaction/Draw';
 import { unByKey } from 'ol/Observable';
 import OlOverlay from 'ol/Overlay';
 import OlMapBrowserEvent from 'ol/MapBrowserEvent';
-import OlGeometryType from 'ol/geom/GeometryType';
-import OlOverlayPositioning from 'ol/OverlayPositioning';
 import OlFeature from 'ol/Feature';
 import OlGeometry from 'ol/geom/Geometry';
 import OlGeomPolygon from 'ol/geom/Polygon';
@@ -391,7 +389,7 @@ class MeasureButton extends React.Component<MeasureButtonProps> {
     }
 
     const maxPoints = measureType === 'angle' ? 2 : undefined;
-    const drawType = measureType === 'polygon' ? OlGeometryType.MULTI_POLYGON : OlGeometryType.MULTI_LINE_STRING;
+    const drawType = measureType === 'polygon' ? 'MultiPolygon' : 'MultiLineString';
 
     const drawInteraction = new OlInteractionDraw({
       source: this._measureLayer.getSource() || undefined,
@@ -618,7 +616,7 @@ class MeasureButton extends React.Component<MeasureButtonProps> {
         const tooltip = new OlOverlay({
           element: div,
           offset: [0, -15],
-          positioning: OlOverlayPositioning.BOTTOM_CENTER
+          positioning: 'bottom-center'
         });
         map.addOverlay(tooltip);
 
@@ -652,7 +650,7 @@ class MeasureButton extends React.Component<MeasureButtonProps> {
     this._measureTooltip = new OlOverlay({
       element: this._measureTooltipElement,
       offset: [0, -15],
-      positioning: OlOverlayPositioning.BOTTOM_CENTER
+      positioning: 'bottom-center'
     });
 
     map.addOverlay(this._measureTooltip);
@@ -677,7 +675,7 @@ class MeasureButton extends React.Component<MeasureButtonProps> {
     this._helpTooltip = new OlOverlay({
       element: this._helpTooltipElement,
       offset: [15, 0],
-      positioning: OlOverlayPositioning.CENTER_LEFT
+      positioning: 'center-left'
     });
 
     map.addOverlay(this._helpTooltip);

--- a/src/Util/ClickAwayListener/ClickAwayListener.tsx
+++ b/src/Util/ClickAwayListener/ClickAwayListener.tsx
@@ -23,7 +23,7 @@ const ClickAwayListener = (props: ClickAwayProps) => {
   useEffect(() => {
     return () => {
       window.removeEventListener('click', handleClickAway);
-    }
+    };
   }, []);
 
   return (


### PR DESCRIPTION
## Description

<!-- Please give a short description of the changes you propose. Please use prose and try not to be too technical, if possible. Make sure to mention people that you think should know about the PR. -->

This prepares the update to ol >= 6.15 by fixing some outdated typings.

Unfortunately the update can't take place right now as our `inkmap` dependency isn't compatible with the newest ol version yet.

Please review @terrestris/devs.

## Related issues or pull requests

<!-- Please list issues or pull requests that the changes you propose are related to. It does not matter if they are still open and/or unmerged, any link is appreciated. -->

--

## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [ ] Bugfix
- [ ] Feature
- [x] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the
  [BSD-2-Clause](https://github.com/terrestris/react-geo/blob/main/LICENSE).
- [x] I have followed the [guidelines for contributing](https://github.com/terrestris/react-geo/blob/main/CONTRIBUTING.md).
- [x] The proposed change fits to the content of the [Code of Conduct](https://github.com/terrestris/react-geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally).
- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
