### PR TITLE
Allow additional fetch opts for GFI per query layer

### DIFF
--- a/src/CoordinateInfo/CoordinateInfo.tsx
+++ b/src/CoordinateInfo/CoordinateInfo.tsx
@@ -8,6 +8,7 @@ import OlFeature from 'ol/Feature';
 import { Coordinate as OlCoordinate } from 'ol/coordinate';
 import OlGeometry from 'ol/geom/Geometry';
 import OlBaseLayer from 'ol/layer/Base';
+import { getUid } from 'ol';
 
 import _isString from 'lodash/isString';
 
@@ -50,6 +51,13 @@ export interface CoordinateInfoProps {
    * The ol map.
    */
   map: OlMap;
+  /**
+   * Optional request options to apply (separated by each query layer, identified
+   * its internal ol id).
+   */
+  fetchOpts: {
+    [uid: string]: RequestInit
+  };
 }
 
 export interface CoordinateInfoState {
@@ -81,7 +89,8 @@ export class CoordinateInfo extends React.Component<CoordinateInfoProps, Coordin
       return (
         <div/>
       );
-    }
+    },
+    fetchOpts: {}
   };
 
   /**
@@ -122,7 +131,8 @@ export class CoordinateInfo extends React.Component<CoordinateInfoProps, Coordin
       map,
       featureCount,
       drillDown,
-      hitTolerance
+      hitTolerance,
+      fetchOpts
     } = this.props;
 
     const mapView = map.getView();
@@ -145,7 +155,7 @@ export class CoordinateInfo extends React.Component<CoordinateInfoProps, Coordin
         }
       );
 
-      promises.push(fetch(featureInfoUrl));
+      promises.push(fetch(featureInfoUrl, fetchOpts[getUid(layer)]));
 
       return !drillDown;
     }, {

--- a/src/CoordinateInfo/CoordinateInfo.tsx
+++ b/src/CoordinateInfo/CoordinateInfo.tsx
@@ -53,7 +53,7 @@ export interface CoordinateInfoProps {
   map: OlMap;
   /**
    * Optional request options to apply (separated by each query layer, identified
-   * its internal ol id).
+   * by its internal ol id).
    */
   fetchOpts: {
     [uid: string]: RequestInit


### PR DESCRIPTION
## Description

<!-- Please give a short description of the changes you propose. Please use prose and try not to be too technical, if possible. Make sure to mention people that you think should know about the PR. -->

This introduces the prop `fetchOpts` for the `CoordinateInfo` component to set additional request options that will be applied to the GetFeatureInfo request. The options can be set for each `queryLayer` separately and will be identified by the internal layer id.

Please review @terrestris/devs.

## Related issues or pull requests

<!-- Please list issues or pull requests that the changes you propose are related to. It does not matter if they are still open and/or unmerged, any link is appreciated. -->

--

## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [ ] Bugfix
- [x] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the
  [BSD-2-Clause](https://github.com/terrestris/react-geo/blob/main/LICENSE).
- [x] I have followed the [guidelines for contributing](https://github.com/terrestris/react-geo/blob/main/CONTRIBUTING.md).
- [x] The proposed change fits to the content of the [Code of Conduct](https://github.com/terrestris/react-geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally).
- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
