### PR TITLE
Improvements to WFSSearchInput

### DIFF
--- a/src/Field/WfsSearchInput/WfsSearchInput.tsx
+++ b/src/Field/WfsSearchInput/WfsSearchInput.tsx
@@ -9,6 +9,8 @@ import LoadingOutlined from '@ant-design/icons/LoadingOutlined';
 import CloseCircleOutlined from '@ant-design/icons/CloseCircleOutlined';
 
 import OlMap from 'ol/Map';
+import OlFormatGML32 from 'ol/format/GML32';
+import OlFormatGeoJson from 'ol/format/GeoJSON';
 
 import _debounce from 'lodash/debounce';
 
@@ -326,7 +328,18 @@ export class WfsSearchInput extends React.Component<WfsSearchInputProps, WfsSear
             body: new XMLSerializer().serializeToString(request),
             ...additionalFetchOptions
           });
-          this.onFetchSuccess(await response.json());
+          let data;
+          if (outputFormat === 'application/json' ) {
+            data = response.json();
+          } else {
+            const xml = response.text();
+            // TODO: Add support for other GML formats
+            const gmlParser = new OlFormatGML32();
+            const geojsonParser = new OlFormatGeoJson();
+            const features = gmlParser.readFeatures(xml);
+            data = geojsonParser.writeFeaturesObject(features);
+          }
+          this.onFetchSuccess(data);
         } catch (e) {
           this.onFetchError(e);
         }

--- a/src/Field/WfsSearchInput/WfsSearchInput.tsx
+++ b/src/Field/WfsSearchInput/WfsSearchInput.tsx
@@ -114,7 +114,7 @@ interface OwnProps {
    */
   featureTypes: string[];
   /**
-   * Maximum number of features to fetch.
+   * Maximum number of features to fetch. Default value is 1000.
    */
   maxFeatures?: number;
   /**
@@ -286,7 +286,7 @@ export class WfsSearchInput extends React.Component<WfsSearchInputProps, WfsSear
       featurePrefix,
       featureTypes,
       geometryName,
-      maxFeatures,
+      maxFeatures = 1000,
       outputFormat,
       propertyNames,
       srsName,
@@ -300,7 +300,7 @@ export class WfsSearchInput extends React.Component<WfsSearchInputProps, WfsSear
       featurePrefix: featurePrefix ?? '',
       featureTypes,
       geometryName: geometryName ?? '',
-      maxFeatures: maxFeatures ?? 0,
+      maxFeatures,
       outputFormat,
       propertyNames: propertyNames ?? [],
       srsName,


### PR DESCRIPTION
## Description

This adds a Bugfix as the default `maxFeatures` was `0` if not defined. New default is 1000.
It also adds the possibility to parse GML32 responses.

## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [x] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the
  [BSD-2-Clause](https://github.com/terrestris/react-geo/blob/main/LICENSE).
- [x] I have followed the [guidelines for contributing](https://github.com/terrestris/react-geo/blob/main/CONTRIBUTING.md).
- [x] The proposed change fits to the content of the [Code of Conduct](https://github.com/terrestris/react-geo/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally).
- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
