### PR TITLE
Add support for a custom list item prefix in the `SearchResultsPanel`

### DIFF
--- a/src/Panel/SearchResultsPanel/SearchResultsPanel.spec.tsx
+++ b/src/Panel/SearchResultsPanel/SearchResultsPanel.spec.tsx
@@ -1,10 +1,14 @@
 import * as React from 'react';
-import { within } from '@testing-library/react';
+import { within, screen } from '@testing-library/react';
 
 import OlView from 'ol/View';
 import OlMap from 'ol/Map';
 import OlPoint from 'ol/geom/Point';
 import OlFeature from 'ol/Feature';
+
+import {
+  GlobalOutlined
+} from '@ant-design/icons';
 
 import { renderInMapContext } from '../../Util/rtlTestUtils';
 
@@ -83,6 +87,23 @@ describe('<SearchResultsPanel />', () => {
       const actionItems = within(container).getAllByText(actionContent);
       expect(actionItems).toHaveLength(searchResults.length);
     });
+  });
+
+  it('renders a list prefix if given', () => {
+    const { container } = renderInMapContext(map, <SearchResultsPanel
+      numTotal={searchResults.length}
+      searchResults={searchResults}
+      searchTerms={[]}
+      listPrefixRenderer={() => <GlobalOutlined />}
+    />);
+
+    // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+    const listPrefixItems = container.querySelectorAll('.result-prefix');
+    expect(listPrefixItems.length).toEqual(1);
+
+    // eslint-disable-next-line testing-library/no-node-access
+    const listPrefixItem = listPrefixItems.item(0).querySelectorAll('.anticon-global');
+    expect(listPrefixItem).toBeDefined();
   });
 
 });

--- a/src/Panel/SearchResultsPanel/SearchResultsPanel.tsx
+++ b/src/Panel/SearchResultsPanel/SearchResultsPanel.tsx
@@ -30,6 +30,8 @@ interface SearchResultsPanelProps extends Partial<CollapseProps>{
   searchTerms: string[];
   /** Creator function that creates actions for each item */
   actionsCreator?: (item: any) => undefined | ReactNode[];
+  /** A renderer function returning a prefix component for each list item */
+  listPrefixRenderer?: (item: any) => undefined | JSX.Element;
 }
 
 const SearchResultsPanel = (props: SearchResultsPanelProps) => {
@@ -40,6 +42,7 @@ const SearchResultsPanel = (props: SearchResultsPanelProps) => {
     numTotal,
     searchTerms,
     actionsCreator = () => undefined,
+    listPrefixRenderer = () => undefined,
     ...passThroughProps
   } = props;
 
@@ -131,6 +134,13 @@ const SearchResultsPanel = (props: SearchResultsPanelProps) => {
               })}
               actions={actionsCreator(item)}
             >
+              <div
+                className="result-prefix"
+              >
+                {
+                  listPrefixRenderer(item)
+                }
+              </div>
               <div
                 className="result-text"
                 dangerouslySetInnerHTML={{ __html: item.text }}


### PR DESCRIPTION
## Description

<!-- Please give a short description of the changes you propose. Please use prose and try not to be too technical, if possible. Make sure to mention people that you think should know about the PR. -->

This adds support for a custom list item prefix component in the `SearchResultsPanel`.

Please review @terrestris/devs.

## Related issues or pull requests

<!-- Please list issues or pull requests that the changes you propose are related to. It does not matter if they are still open and/or unmerged, any link is appreciated. -->

--

## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [ ] Bugfix
- [x] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the
  [BSD-2-Clause](https://github.com/terrestris/react-geo/blob/main/LICENSE).
- [x] I have followed the [guidelines for contributing](https://github.com/terrestris/react-geo/blob/main/CONTRIBUTING.md).
- [x] The proposed change fits to the content of the [Code of Conduct](https://github.com/terrestris/react-geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally).
- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
