### PR TITLE
Enhance the accessibility of icons in AddWmsLayerEntry

### DIFF
--- a/src/Container/AddWmsPanel/AddWmsLayerEntry/AddWmsLayerEntry.spec.tsx
+++ b/src/Container/AddWmsPanel/AddWmsLayerEntry/AddWmsLayerEntry.spec.tsx
@@ -1,4 +1,7 @@
-import { getElementError, queryAllByAttribute, queryByAttribute, render, screen } from '@testing-library/react';
+import {
+  render,
+  screen
+} from '@testing-library/react';
 import * as React from 'react';
 
 import OlLayerTile from 'ol/layer/Tile';
@@ -19,6 +22,8 @@ describe('<AddWmsLayerEntry />', () => {
     })
   });
   testLayer.set('title', testLayerTitle);
+  const labelIconAttribution = 'Icon indicating that attribution information for layer is available';
+  const labelIconQueryable = 'Icon indicating that the layer is queryable';
 
   it('is defined', () => {
     expect(AddWmsLayerEntry).not.toBeUndefined();
@@ -32,36 +37,43 @@ describe('<AddWmsLayerEntry />', () => {
   it('adds queryable icon if prop wmsLayer has queryable set to true', () => {
     testLayer.set('queryable', true);
 
-    const { container } = render(<AddWmsLayerEntry wmsLayer={testLayer} />);
-    const icon = container.getElementsByClassName('queryable-info');
-    const iconClassList = Object.keys(icon.item(0).classList).map(k => icon.item(0).classList[k]);
-    expect(iconClassList).toContain('fa-info');
+    render(<AddWmsLayerEntry wmsLayer={testLayer} />);
+    let icon;
+    expect(() => {
+      icon = screen.getByLabelText(labelIconQueryable);
+    }).not.toThrowError();
+    expect(icon).toHaveClass('fa-info');
+
     testLayer.set('queryable', false);
   });
 
   it('doesn\'t add queryable icon if prop wmsLayer has queryable set to false', () => {
-    const { container } = render(<AddWmsLayerEntry wmsLayer={testLayer} />);
-    const icon = container.getElementsByClassName('queryable-info');
-    expect(icon.length).toEqual(0);
+    render(<AddWmsLayerEntry wmsLayer={testLayer} />);
+    expect(() => {
+      screen.getByLabelText(labelIconQueryable);
+    }).toThrowError();
   });
 
   it('adds copyright icon if prop wmsLayer has filled wmsAttribution', () => {
     const wmsAttribution = 'Test - attribution';
-    testLayer.getSource().setAttributions(wmsAttribution);
+    testLayer.getSource()?.setAttributions(wmsAttribution);
 
-    const { container } = render(<AddWmsLayerEntry wmsLayer={testLayer} />);
-    const icon = container.getElementsByClassName('attribution-info');
-    const iconClassList = Object.keys(icon.item(0).classList).map(k => icon.item(0).classList[k]);
-    expect(iconClassList).toContain('fa-copyright');
+    render(<AddWmsLayerEntry wmsLayer={testLayer} />);
+    let icon;
+    expect(() => {
+      icon = screen.getByLabelText(labelIconAttribution);
+    }).not.toThrowError();
+    expect(icon).toHaveClass('fa-copyright');
 
-    testLayer.getSource().setAttributions(null);
+    testLayer.getSource()?.setAttributions(undefined);
   });
 
-  it('doesn\'t add copyright icon if prop wmsLayer no has filled attribution', () => {
-    const { container } = render(<AddWmsLayerEntry wmsLayer={testLayer} />);
-
-    const attributionIcon = container.getElementsByClassName('attribution-info');
-    expect(attributionIcon.length).toEqual(0);
+  it('doesn\'t add copyright icon if prop wmsLayer has no attribution', () => {
+    render(<AddWmsLayerEntry wmsLayer={testLayer} />);
+    let icon;
+    expect(() => {
+      icon = screen.getByLabelText(labelIconAttribution);
+    }).toThrowError();
   });
 
   it('includes abstract in description text if abstract property is set for layer', () => {

--- a/src/Container/AddWmsPanel/AddWmsLayerEntry/AddWmsLayerEntry.tsx
+++ b/src/Container/AddWmsPanel/AddWmsLayerEntry/AddWmsLayerEntry.tsx
@@ -22,6 +22,20 @@ interface AddWmsLayerEntryProps {
    */
   layerQueryableText: string;
   /**
+   * ARIA label for the icon which indicates that the layer has copyright / attribution
+   * information. This label increases the accessibility of the generated HTML. If not
+   * set explicitly, a generic English label will be added. Make sure to translate this
+   * to the page language if needed.
+   */
+  ariaLabelCopyright: string;
+  /**
+   * ARIA label for the icon which indicates that the layer is queryable. This label
+   * increases the accessibility of the generated HTML. If not set explicitly, a generic
+   * English label will be added. Make sure to translate this to the page language if
+   * needed.
+   */
+  ariaLabelQueryable: string;
+  /**
    * Object containing layer information
    */
   wmsLayer: WmsLayer;
@@ -46,6 +60,8 @@ export class AddWmsLayerEntry extends React.Component<AddWmsLayerEntryProps, Add
    */
   static defaultProps = {
     layerQueryableText: 'Layer is queryable',
+    ariaLabelCopyright: 'Icon indicating that attribution information for layer is available',
+    ariaLabelQueryable: 'Icon indicating that the layer is queryable',
     layerTextTemplateFn: (wmsLayer: WmsLayer) => {
       const title = wmsLayer.get('title');
       const abstract = wmsLayer.get('abstract');
@@ -76,7 +92,9 @@ export class AddWmsLayerEntry extends React.Component<AddWmsLayerEntryProps, Add
     const {
       wmsLayer,
       layerTextTemplateFn,
-      layerQueryableText
+      layerQueryableText,
+      ariaLabelCopyright,
+      ariaLabelQueryable
     } = this.props;
 
     const {
@@ -96,6 +114,7 @@ export class AddWmsLayerEntry extends React.Component<AddWmsLayerEntryProps, Add
               <FontAwesomeIcon
                 className="add-wms-add-info-icon attribution-info"
                 icon={faCopyright}
+                aria-label={ariaLabelCopyright}
               />
             )
               : null
@@ -106,6 +125,7 @@ export class AddWmsLayerEntry extends React.Component<AddWmsLayerEntryProps, Add
                 <FontAwesomeIcon
                   className="add-wms-add-info-icon queryable-info"
                   icon={faInfo}
+                  aria-label={ariaLabelQueryable}
                 />
               </Tooltip>
             )

--- a/src/Field/CoordinateReferenceSystemCombo/CoordinateReferenceSystemCombo.example.md
+++ b/src/Field/CoordinateReferenceSystemCombo/CoordinateReferenceSystemCombo.example.md
@@ -17,7 +17,8 @@ import {
 } from 'ol/proj';
 import { applyTransform } from 'ol/extent';
 
-import CoordinateReferenceSystemCombo from '@terrestris/react-geo/Field/CoordinateReferenceSystemCombo/CoordinateReferenceSystemCombo';
+import CoordinateReferenceSystemCombo from
+  '@terrestris/react-geo/Field/CoordinateReferenceSystemCombo/CoordinateReferenceSystemCombo';
 
 const predefinedCrsDefinitions = [{
   code: '25832',
@@ -27,12 +28,14 @@ const predefinedCrsDefinitions = [{
 }, {
   code: '31466',
   value: 'DHDN / 3-degree Gauss-Kruger zone 2',
-  proj4def: '+proj=tmerc +lat_0=0 +lon_0=6 +k=1 +x_0=2500000 +y_0=0 +ellps=bessel +towgs84=598.1,73.7,418.2,0.202,0.045,-2.455,6.7 +units=m +no_defs',
+  proj4def: '+proj=tmerc +lat_0=0 +lon_0=6 +k=1 +x_0=2500000 +y_0=0 +ellps=bessel ' +
+    '+towgs84=598.1,73.7,418.2,0.202,0.045,-2.455,6.7 +units=m +no_defs',
   bbox: [53.81, 5.86, 49.11, 7.5]
 }, {
   code: '31467',
   value: 'DHDN / 3-degree Gauss-Kruger zone 3',
-  proj4def: '+proj=tmerc +lat_0=0 +lon_0=9 +k=1 +x_0=3500000 +y_0=0 +ellps=bessel +towgs84=598.1,73.7,418.2,0.202,0.045,-2.455,6.7 +units=m +no_defs',
+  proj4def: '+proj=tmerc +lat_0=0 +lon_0=9 +k=1 +x_0=3500000 +y_0=0 +ellps=bessel ' +
+    '+towgs84=598.1,73.7,418.2,0.202,0.045,-2.455,6.7 +units=m +no_defs',
   bbox: [55.09, 7.5, 47.27, 10.51]
 }, {
   code: '4326',

--- a/src/LayerTree/LayerTree.example.md
+++ b/src/LayerTree/LayerTree.example.md
@@ -78,7 +78,8 @@ class LayerTreeExample extends React.Component {
           }}
         />
 
-        <span>{'Please note that the layers have resolution restrictions, please zoom in and out to see how the trees react to this.'}</span>
+        <span>{'Please note that the layers have resolution restrictions, please ' +
+        ' zoom in and out to see how the trees react to this.'}</span>
         <div className="example-block">
           <span>{'Autoconfigured with topmost LayerGroup of passed map:'}</span>
 


### PR DESCRIPTION
## Description

This PR makes the icons of `AddWmsLayerEntry`  more accessible by adding an `aria-label` to inline `<svg role="img>…</svg>`; this article suggests that this is a correct approach: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/img_role#svg_and_roleimg

Additionally a bunch of eslint warnings in examples and tests are fixed.

The tests now make use of [`getByLabelText`](https://testing-library.com/docs/queries/bylabeltext/), I'd love to hear your opinions on this.

## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [ ] Bugfix
- [x] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No (this only adds more a11y)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the
  [BSD-2-Clause](https://github.com/terrestris/react-geo/blob/main/LICENSE).
- [x] I have followed the [guidelines for contributing](https://github.com/terrestris/react-geo/blob/main/CONTRIBUTING.md).
- [x] The proposed change fits to the content of the [Code of Conduct](https://github.com/terrestris/react-geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally).
- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
