### PR TITLE
Adds layer style properties to search results panel

### DIFF
--- a/src/Panel/SearchResultsPanel/SearchResultsPanel.tsx
+++ b/src/Panel/SearchResultsPanel/SearchResultsPanel.tsx
@@ -14,6 +14,9 @@ import _isEmpty from 'lodash/isEmpty';
 import './SearchResultsPanel.less';
 import useMap from '../../Hook/useMap';
 import BaseLayer from 'ol/layer/Base';
+import Style from 'ol/style/Style';
+import Stroke from 'ol/style/Stroke';
+import Fill from 'ol/style/Fill';
 
 const Panel = Collapse.Panel;
 const ListItem = List.Item;
@@ -24,6 +27,12 @@ export interface Category {
   features: OlFeature[];
 }
 
+export interface LayerStyle {
+  strokeColor: string;
+  strokeWidth?: number;
+  fillColor?: string;
+}
+
 interface SearchResultsPanelProps extends Partial<CollapseProps>{
   searchResults: Category[];
   numTotal: number;
@@ -32,6 +41,7 @@ interface SearchResultsPanelProps extends Partial<CollapseProps>{
   actionsCreator?: (item: any) => undefined | ReactNode[];
   /** A renderer function returning a prefix component for each list item */
   listPrefixRenderer?: (item: any) => undefined | JSX.Element;
+  layerStyle?: undefined | LayerStyle;
 }
 
 const SearchResultsPanel = (props: SearchResultsPanelProps) => {
@@ -43,6 +53,7 @@ const SearchResultsPanel = (props: SearchResultsPanelProps) => {
     searchTerms,
     actionsCreator = () => undefined,
     listPrefixRenderer = () => undefined,
+    layerStyle,
     ...passThroughProps
   } = props;
 
@@ -50,6 +61,22 @@ const SearchResultsPanel = (props: SearchResultsPanelProps) => {
     const layer = new OlLayerVector({
       source: new OlSourceVector()
     });
+
+    if (layerStyle) {
+      const style = new Style({
+        stroke: new Stroke({
+          color: layerStyle.strokeColor,
+          width: layerStyle.strokeWidth ? layerStyle.strokeWidth : 2
+        }),
+        fill: new Fill({
+          color: layerStyle.fillColor
+            ? layerStyle.fillColor
+            : 'rgba(255,255,255, 0.5)'
+        })
+      });
+      layer.setStyle(style);
+    }
+
     setHighlightLayer(layer);
     map.addLayer(layer);
   }, []);

--- a/src/Panel/SearchResultsPanel/SearchResultsPanel.tsx
+++ b/src/Panel/SearchResultsPanel/SearchResultsPanel.tsx
@@ -14,9 +14,7 @@ import _isEmpty from 'lodash/isEmpty';
 import './SearchResultsPanel.less';
 import useMap from '../../Hook/useMap';
 import BaseLayer from 'ol/layer/Base';
-import Style from 'ol/style/Style';
-import Stroke from 'ol/style/Stroke';
-import Fill from 'ol/style/Fill';
+import OlStyle from 'ol/style/Style';
 
 const Panel = Collapse.Panel;
 const ListItem = List.Item;
@@ -27,12 +25,6 @@ export interface Category {
   features: OlFeature[];
 }
 
-export interface LayerStyle {
-  strokeColor: string;
-  strokeWidth?: number;
-  fillColor?: string;
-}
-
 interface SearchResultsPanelProps extends Partial<CollapseProps>{
   searchResults: Category[];
   numTotal: number;
@@ -41,7 +33,7 @@ interface SearchResultsPanelProps extends Partial<CollapseProps>{
   actionsCreator?: (item: any) => undefined | ReactNode[];
   /** A renderer function returning a prefix component for each list item */
   listPrefixRenderer?: (item: any) => undefined | JSX.Element;
-  layerStyle?: undefined | LayerStyle;
+  layerStyle?: undefined | OlStyle;
 }
 
 const SearchResultsPanel = (props: SearchResultsPanelProps) => {
@@ -63,18 +55,7 @@ const SearchResultsPanel = (props: SearchResultsPanelProps) => {
     });
 
     if (layerStyle) {
-      const style = new Style({
-        stroke: new Stroke({
-          color: layerStyle.strokeColor,
-          width: layerStyle.strokeWidth ? layerStyle.strokeWidth : 2
-        }),
-        fill: new Fill({
-          color: layerStyle.fillColor
-            ? layerStyle.fillColor
-            : 'rgba(255,255,255, 0.5)'
-        })
-      });
-      layer.setStyle(style);
+      layer.setStyle(layerStyle);
     }
 
     setHighlightLayer(layer);


### PR DESCRIPTION
## Description

This PR adds new optional property `layerStyle` to the component `SearchResultPanel`.

Use this property to add a style to the highlighted feature on the highlighting layer. 

Example:
```jsx
<SearchResultsPanel
  […]
  layerStyle={
    new OlStyle({
      stroke: new OlStroke({
        color: 'rgb(255,0,0)',
        width: 2
      }),
      fill: new OlFill({
        color: 'rgba(255,255,255, 0.5)'
      })
    })
  }
  />
```

@terrestris/devs please review.

## Pull request type

- [ ] Bugfix
- [x] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the
  [BSD-2-Clause](https://github.com/terrestris/react-geo/blob/main/LICENSE).
- [x] I have followed the [guidelines for contributing](https://github.com/terrestris/react-geo/blob/main/CONTRIBUTING.md).
- [x] The proposed change fits to the content of the [Code of Conduct](https://github.com/terrestris/react-geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally).
- [x] I have added a screenshot/screencast to illustrate the visual output of my update.
