### PR TITLE
Better a11y, better test, less eslint warnings

### DIFF
--- a/src/LayerSwitcher/LayerSwitcher.spec.tsx
+++ b/src/LayerSwitcher/LayerSwitcher.spec.tsx
@@ -1,4 +1,4 @@
-import { render, within } from '@testing-library/react';
+import { render, within, screen } from '@testing-library/react';
 import * as React from 'react';
 import userEvent from '@testing-library/user-event';
 import TestUtil from '../Util/TestUtil';
@@ -51,20 +51,21 @@ describe('<LayerSwitcher />', () => {
   });
 
   it('adds a custom className', () => {
-    const { container } = render(<LayerSwitcher layers={layers} map={map} className="peter" />);
-    expect(container.children[0]).toHaveClass('peter');
+    render(<LayerSwitcher layers={layers} map={map} className="peter" />);
+    const firstChild = screen.getByRole('form');
+    expect(firstChild).toHaveClass('peter');
   });
 
   it('passes style prop', () => {
-    const { container } = render(<LayerSwitcher layers={layers} map={map} style={{
+    render(<LayerSwitcher layers={layers} map={map} style={{
       backgroundColor: 'yellow',
       position: 'inherit'
     }} />);
-    const child = container.children[0];
-    expect(child).toHaveStyle({
+    const firstChild = screen.getByRole('form');
+    expect(firstChild).toHaveStyle({
       backgroundColor: 'yellow'
     });
-    expect(child).toHaveStyle({
+    expect(firstChild).toHaveStyle({
       position: 'inherit'
     });
   });

--- a/src/LayerSwitcher/LayerSwitcher.tsx
+++ b/src/LayerSwitcher/LayerSwitcher.tsx
@@ -250,6 +250,7 @@ export class LayerSwitcher extends React.Component<LayerSwitcherProps, LayerSwit
 
     return (
       <div
+        role="form"
         className={finalClassName}
         {...passThroughProps}
       >


### PR DESCRIPTION
## Description

This PR suggests to cahnge the LayerSwitcher, to conatin a `role="form"`, which is arguably the best choice (as far as I can tell, I'd love to hear what others think). Additionally, this changes how we test the component, and by that it removes annoying (but perhaps correct) `eslint` warnings.

## Related issues or pull requests

None

## Pull request type

- [ ] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No (only better a11y)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the
  [BSD-2-Clause](https://github.com/terrestris/react-geo/blob/main/LICENSE).
- [x] I have followed the [guidelines for contributing](https://github.com/terrestris/react-geo/blob/main/CONTRIBUTING.md).
- [x] The proposed change fits to the content of the [Code of Conduct](https://github.com/terrestris/react-geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally).
- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
