### PR TITLE
test: add some tests for isWmsLayer

### DIFF
--- a/src/Util/typeUtils.spec.tsx
+++ b/src/Util/typeUtils.spec.tsx
@@ -1,0 +1,130 @@
+import { isWmsLayer } from './typeUtils';
+
+import OlBaseLayer from 'ol/layer/Base';
+import OlLayer from 'ol/layer/Layer';
+import OlImageWMS from 'ol/source/ImageWMS';
+import OlTileWMS from 'ol/source/TileWMS';
+import OlImageLayer from 'ol/layer/Image';
+import OlTileLayer from 'ol/layer/Tile';
+
+import OlVectorLayer from 'ol/layer/Vector';
+import OlHeatmapLayer from 'ol/layer/Heatmap';
+
+import OlSourceVector from 'ol/source/Vector';
+import OlSourceVectorTile from 'ol/source/VectorTile';
+import OlSourceCluster from 'ol/source/Cluster';
+
+const getWmsLikeLayers = () => {
+  return {
+    'ol/layer/Layer': new OlLayer({}),
+    'ol/layer/Image': new OlImageLayer(),
+    'ol/layer/Tile': new OlTileLayer()
+  };
+};
+
+const getWmsSources = () => {
+  return {
+    'ol/source/ImageWMS': new OlImageWMS(),
+    'ol/source/TileWMS': new OlTileWMS()
+  };
+};
+
+const getNonWmsLikeLayers = () => {
+  return {
+    'ol/layer/Vector': new OlVectorLayer(),
+    'ol/layer/Heatmap': new OlHeatmapLayer()
+  };
+};
+
+const getNonWmsSources = () => {
+  return {
+    'ol/source/Vector': new OlSourceVector(),
+    'ol/source/VectorTile': new OlSourceVectorTile({}),
+    'ol/source/Cluster': new OlSourceCluster({})
+  };
+};
+
+
+describe('isWmsLayer', () => {
+
+  it('is defined', () => {
+    expect(isWmsLayer).not.toBeUndefined();
+  });
+
+  it('is a function', () => {
+    expect(isWmsLayer).toBeInstanceOf(Function);
+  });
+
+  it('returns false for an ol base layer', () => {
+    const layer = new OlBaseLayer({});
+    expect(isWmsLayer(layer)).toBe(false);
+  });
+
+  describe('Combinations of wms like layers with wms like sources', () => {
+    const layers = getWmsLikeLayers();
+    const sources = getWmsSources();
+    Object.keys(layers).forEach((layerClass) => {
+      Object.keys(sources).forEach((sourceClass) => {
+        const layer = layers[layerClass];
+        const source = sources[sourceClass];
+        layer.setSource(source);
+
+        it(`returns true for ${layerClass} with ${sourceClass}`, () => {
+          expect(isWmsLayer(layer)).toBe(true);
+        });
+      });
+    });
+  });
+
+  describe('Combinations of some non-wms like layers with some non-wms like sources', () => {
+    const layers = getNonWmsLikeLayers();
+    const sources = getNonWmsSources();
+    Object.keys(layers).forEach((layerClass) => {
+      Object.keys(sources).forEach((sourceClass) => {
+        const layer = layers[layerClass];
+        const source = sources[sourceClass];
+        layer.setSource(source);
+
+        it(`returns false for ${layerClass} with ${sourceClass}`, () => {
+          expect(isWmsLayer(layer)).toBe(false);
+        });
+      });
+    });
+  });
+
+  // these fail, but I fear tghey should pass…
+  // a  ol/layer/Heatmap with ol/source/ImageWMS is not a WMS is it?
+  //
+  // describe('Combinations of some non-wms like layers with wms like sources', () => {
+  //   const layers = getNonWmsLikeLayers();
+  //   const sources = getWmsSources();
+  //   Object.keys(layers).forEach((layerClass) => {
+  //     Object.keys(sources).forEach((sourceClass) => {
+  //       const layer = layers[layerClass];
+  //       const source = sources[sourceClass];
+  //       layer.setSource(source);
+
+  //       it(`returns false for ${layerClass} with ${sourceClass}`, () => {
+  //         expect(isWmsLayer(layer)).toBe(false);
+  //       });
+  //     });
+  //   });
+  // });
+
+  describe('Combinations of some wms like layers with non-wms like sources', () => {
+    const layers = getWmsLikeLayers();
+    const sources = getNonWmsSources();
+    Object.keys(layers).forEach((layerClass) => {
+      Object.keys(sources).forEach((sourceClass) => {
+        const layer = layers[layerClass];
+        const source = sources[sourceClass];
+        layer.setSource(source);
+
+        it(`returns false for ${layerClass} with ${sourceClass}`, () => {
+          expect(isWmsLayer(layer)).toBe(false);
+        });
+      });
+    });
+  });
+
+});


### PR DESCRIPTION
## Description

Originally I just wanted to increase coverage, and picked sth. supposedly trivial to test, but then I stumbled about the logic behind `isWmsLayer`:

- Is this needed in a typed world at all?
- if it is needed, is it likely used in many projects?
- does it make sense the way it is now, so that e.g. a vector layer with a wms source is considered a wms layer? The longer I look at the code the more wrong it looks to my eye.

## Related issues or pull requests

-

## Pull request type

- [ ] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other (please describe): tests

## Do you introduce a breaking change?

- [ ] Yes
- [x] No, right now not, but it might be we remove the function or change it's behaviour?

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the
  [BSD-2-Clause](https://github.com/terrestris/react-geo/blob/main/LICENSE).
- [x] I have followed the [guidelines for contributing](https://github.com/terrestris/react-geo/blob/main/CONTRIBUTING.md).
- [x] The proposed change fits to the content of the [Code of Conduct](https://github.com/terrestris/react-geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally).
- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
