### PR TITLE
feat: toggle layer visibility when clicking on the name

### DIFF
--- a/src/LayerTree/LayerTree.tsx
+++ b/src/LayerTree/LayerTree.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import { Tree } from 'antd';
-import { AntTreeNodeDropEvent } from 'antd/lib/tree/Tree';
+import { AntTreeNodeDropEvent, AntTreeNodeSelectedEvent } from 'antd/lib/tree/Tree';
 import { ReactElement, ReactNode } from 'react';
 import {
   TreeProps,
@@ -464,6 +464,28 @@ class LayerTree extends React.Component<LayerTreeProps, LayerTreeState> {
   }
 
   /**
+   * Toggles the visibility of a layer when clicking the name.
+   *
+   * @param checkedKeys Contains all checkedKeys.
+   * @param e The ant-tree event object for this event. See ant docs.
+   */
+  onSelect = (checkedKeys: string[], e: AntTreeNodeSelectedEvent) => {
+    // @ts-ignore
+    const checked = !e.node.checked;
+    // @ts-ignore
+    e.node.checked = checked;
+    const eventKey = e.node.props.eventKey;
+    if (eventKey) {
+      const layer = MapUtil.getLayerByOlUid(this.props.map, eventKey);
+      if (!layer) {
+        Logger.error('layer is not defined');
+        return;
+      }
+      this.setLayerVisibility(layer, checked);
+    }
+  };
+
+  /**
    * Sets the layer visibility. Calls itself recursively for groupLayers.
    *
    * @param layer The layer.
@@ -620,6 +642,7 @@ class LayerTree extends React.Component<LayerTreeProps, LayerTreeState> {
         className={finalClassName}
         checkedKeys={this.state.checkedKeys}
         onCheck={this.onCheck.bind(this)}
+        onSelect={this.onSelect}
         onExpand={this.onExpand}
         {...ddListeners}
         {...passThroughProps}


### PR DESCRIPTION
## Description

Layer visibility in the layer tree will also be toggled when clicking on the name instead on the checkbox.

## Pull request type

- [ ] Bugfix
- [x] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the
  [BSD-2-Clause](https://github.com/terrestris/react-geo/blob/main/LICENSE).
- [x] I have followed the [guidelines for contributing](https://github.com/terrestris/react-geo/blob/main/CONTRIBUTING.md).
- [x] The proposed change fits to the content of the [Code of Conduct](https://github.com/terrestris/react-geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally).
- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.

@terrestris/devs Please review.