### PR TITLE
fix: make toggle on click configurable

### DIFF
--- a/src/LayerTree/LayerTree.tsx
+++ b/src/LayerTree/LayerTree.tsx
@@ -64,6 +64,8 @@ interface OwnProps {
    * the layer instance of the current tree node.
    */
   nodeTitleRenderer?: (layer: OlLayerBase) => React.ReactNode;
+
+  toggleOnClick?: boolean;
 }
 
 interface LayerTreeState {
@@ -92,7 +94,8 @@ class LayerTree extends React.Component<LayerTreeProps, LayerTreeState> {
   static defaultProps = {
     draggable: true,
     checkable: true,
-    filterFunction: () => true
+    filterFunction: () => true,
+    toggleOnClick: false
   };
 
   /**
@@ -623,6 +626,7 @@ class LayerTree extends React.Component<LayerTreeProps, LayerTreeState> {
       layerGroup,
       map,
       nodeTitleRenderer,
+      toggleOnClick,
       ...passThroughProps
     } = this.props;
 
@@ -642,7 +646,7 @@ class LayerTree extends React.Component<LayerTreeProps, LayerTreeState> {
         className={finalClassName}
         checkedKeys={this.state.checkedKeys}
         onCheck={this.onCheck.bind(this)}
-        onSelect={this.onSelect}
+        onSelect={toggleOnClick ? this.onSelect : undefined}
         onExpand={this.onExpand}
         {...ddListeners}
         {...passThroughProps}


### PR DESCRIPTION
## Description

Disables the change from #3002 by default and makes in configurable via prop.

## Related issues or pull requests

#3002 

## Pull request type

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the
  [BSD-2-Clause](https://github.com/terrestris/react-geo/blob/main/LICENSE).
- [x] I have followed the [guidelines for contributing](https://github.com/terrestris/react-geo/blob/main/CONTRIBUTING.md).
- [x] The proposed change fits to the content of the [Code of Conduct](https://github.com/terrestris/react-geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally).
- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.

@terrestris/devs Please review.