### PR TITLE
Fix some antd warnings

### DIFF
--- a/src/Button/DigitizeButton/DigitizeButton.tsx
+++ b/src/Button/DigitizeButton/DigitizeButton.tsx
@@ -1238,7 +1238,7 @@ class DigitizeButton extends React.Component<DigitizeButtonProps, DigitizeButton
               title={modalPromptTitle}
               okText={modalPromptOkButtonText}
               cancelText={modalPromptCancelButtonText}
-              visible={this.state.showLabelPrompt}
+              open={this.state.showLabelPrompt}
               closable={false}
               onOk={this.onModalLabelOk}
               onCancel={this.onModalLabelCancel}

--- a/src/FeatureLabelModal/FeatureLabelModal.tsx
+++ b/src/FeatureLabelModal/FeatureLabelModal.tsx
@@ -54,7 +54,7 @@ export const FeatureLabelModal: React.FC<FeatureLabelModalProps> = ({
   }
 
   return <Modal
-    visible={showPrompt}
+    open={showPrompt}
     closable={false}
     onOk={onOkInternal}
     onCancel={onCancel}

--- a/src/Slider/LayerTransparencySlider/LayerTransparencySlider.tsx
+++ b/src/Slider/LayerTransparencySlider/LayerTransparencySlider.tsx
@@ -64,7 +64,9 @@ class LayerTransparencySlider extends React.Component<LayerTransparencySliderPro
 
     return (
       <Slider
-        tipFormatter={value => `${value}%`}
+        tooltip={{
+          formatter: value => `${value}%`
+        }}
         defaultValue={this.getLayerTransparency()}
         onChange={(value: number) => {
           this.setLayerTransparency(value);

--- a/src/Slider/MultiLayerSlider/MultiLayerSlider.tsx
+++ b/src/Slider/MultiLayerSlider/MultiLayerSlider.tsx
@@ -187,7 +187,9 @@ class MultiLayerSlider extends React.Component<MultiLayerSliderProps> {
         defaultValue={defaultValue}
         min={0}
         max={100}
-        tipFormatter={this.formatTip.bind(this)}
+        tooltip={{
+          formatter: this.formatTip.bind(this)
+        }}
         onChange={this.valueUpdated.bind(this)}
         {...passThroughProps}
       />

--- a/src/Slider/TimeSlider/TimeSlider.tsx
+++ b/src/Slider/TimeSlider/TimeSlider.tsx
@@ -182,7 +182,9 @@ class TimeSlider extends React.Component<TimeSliderProps> {
           range={true}
           min={moment(min).unix()}
           max={moment(max).unix()}
-          tipFormatter={val => this.formatTimestamp(val)}
+          tooltip={{
+            formatter: val => this.formatTimestamp(val)
+          }}
           onChange={val => this.valueUpdated(val)}
           value={this.convert(value) as [number, number]}
           marks={convertedMarks}
@@ -197,7 +199,9 @@ class TimeSlider extends React.Component<TimeSliderProps> {
           range={false}
           min={moment(min).unix()}
           max={moment(max).unix()}
-          tipFormatter={val => this.formatTimestamp(val)}
+          tooltip={{
+            formatter: val => this.formatTimestamp(val)
+          }}
           onChange={val => this.valueUpdated(val)}
           value={this.convert(value) as number}
           marks={convertedMarks}

--- a/src/UserChip/UserChip.spec.tsx
+++ b/src/UserChip/UserChip.spec.tsx
@@ -36,7 +36,13 @@ describe('<UserChip />', () => {
   });
 
   it('should render a dropdown', async () => {
-    render(<UserChip userName="Shinji Kagawa" userMenu={<div role="menu">Example menu</div>} />);
+    const exampleMenu = {
+      items: [{
+        label: <div role="menu">Example menu</div>,
+        key: 'example'
+      }]
+    };
+    render(<UserChip userName="Shinji Kagawa" userMenu={exampleMenu}/>);
     const chip = screen.getByText('SK').parentElement;
     await userEvent.click(chip);
     const menu = screen.getByText('Example menu');
@@ -45,7 +51,7 @@ describe('<UserChip />', () => {
   });
 
   it('should not render a dropdown for invalid configuration', () => {
-    render(<UserChip userName="Shinji Kagawa" userMenu={null} />);
+    render(<UserChip userName="Shinji Kagawa" userMenu={undefined} />);
     const menu = screen.queryByRole('menu');
     expect(menu).not.toBeInTheDocument();
   });

--- a/src/UserChip/UserChip.tsx
+++ b/src/UserChip/UserChip.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
 import {
   Avatar,
-  Dropdown
+  Dropdown,
+  MenuProps
 } from 'antd';
 
 import { AvatarProps } from 'antd/lib/avatar';
@@ -22,9 +23,9 @@ export interface BaseProps {
    */
   imageSrc?: string;
   /**
-   * The react element representing the user menu
+   * The user menu
    */
-  userMenu?: React.ReactNode;
+  userMenu?: MenuProps;
   /**
    * The user name.
    */
@@ -136,10 +137,10 @@ class UserChip extends React.Component<UserChipProps> {
       userMenu
     } = this.props;
 
-    if (userMenu && React.isValidElement(userMenu)) {
+    if (userMenu?.items) {
       return (
         <Dropdown
-          overlay={userMenu}
+          menu={userMenu}
           trigger={['click']}
           getPopupContainer={() => {
             return document.getElementsByClassName(this._className)[0] as HTMLElement;


### PR DESCRIPTION
## Description

Get rid of some antd warnings about config deprecations.

In particular: 
* replace `visible` by `open` for modals
* replace `tipFormatter` by `tooltip.formatter` for slider based components
*  remove `overlay` property from Dropdown in favor of `menu`
  * ⚠️ Breaking change ⚠️ If you use a `UserChip` component in your projects, you should pass an object of type `MenuProps` instead of `Menu` now
  * Please refere to [antd hints](https://4x.ant.design/components/dropdown/#Usage-upgrade-after-4.24.0) for migration examples

Please review @terrestris/devs 


## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [x] Yes
- [ ] No

## Checklist

- [ ] I understand and agree that the changes in this PR will be licensed under the
  [BSD-2-Clause](https://github.com/terrestris/react-geo/blob/main/LICENSE).
- [ ] I have followed the [guidelines for contributing](https://github.com/terrestris/react-geo/blob/main/CONTRIBUTING.md).
- [ ] The proposed change fits to the content of the [Code of Conduct](https://github.com/terrestris/react-geo/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally).
- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
