### PR TITLE
Custom headers and a loading mask for the `Legend` component

### DIFF
--- a/src/LayerTree/LayerTree.tsx
+++ b/src/LayerTree/LayerTree.tsx
@@ -229,7 +229,6 @@ class LayerTree extends React.Component<LayerTreeProps, LayerTreeState> {
     const collection = groupLayer.getLayers();
     const addEvtKey = collection.on('add', this.onCollectionAdd);
     const removeEvtKey = collection.on('remove', this.onCollectionRemove);
-    // @ts-ignore
     const changeEvtKey = groupLayer.on('change:layers', this.onChangeLayers);
 
     this.olListenerKeys.push(addEvtKey, removeEvtKey, changeEvtKey);

--- a/src/Legend/Legend.example.md
+++ b/src/Legend/Legend.example.md
@@ -39,7 +39,7 @@ class LegendExample extends React.Component {
 
     this.places =  new OlLayerTile({
       name: 'Places',
-      legendUrl: 'https://www.koeln.de/files/images/Karnevalstrikot_Spieler_270.jpg',
+      legendUrl: 'https://terrestris.github.io/react-geo/assets/legend1.png',
       source: new OlSourceTileWMS({
         url: 'https://ahocevar.com/geoserver/wms',
         params: {LAYERS: 'ne:ne_10m_populated_places', TILED: true, TRANSPARENT: 'true'},

--- a/src/Legend/Legend.spec.tsx
+++ b/src/Legend/Legend.spec.tsx
@@ -31,11 +31,13 @@ describe('<Legend />', () => {
   beforeAll(() => {
     enableFetchMocks();
     (window.URL.createObjectURL as jest.Mock) = jest.fn().mockReturnValue(mockLegend);
+    (window.URL.revokeObjectURL as jest.Mock) = jest.fn();
   });
 
   afterAll(() => {
     disableFetchMocks();
     (window.URL.createObjectURL as jest.Mock).mockRestore();
+    (window.URL.revokeObjectURL as jest.Mock).mockRestore();
   });
 
   beforeEach(() => {

--- a/src/Legend/Legend.spec.tsx
+++ b/src/Legend/Legend.spec.tsx
@@ -1,35 +1,68 @@
-import { render, screen } from '@testing-library/react';
 import * as React from 'react';
 
-import OlLayerTile from 'ol/layer/Tile';
-import OlSourceTileWMS from 'ol/source/TileWMS';
-import OlSourceTileJson from 'ol/source/TileJSON';
+import {
+  render,
+  screen,
+  waitFor
+} from '@testing-library/react';
 
-import Legend from './Legend';
+import {
+  enableFetchMocks,
+  disableFetchMocks,
+  FetchMock
+} from 'jest-fetch-mock';
 
 import MapUtil from '@terrestris/ol-util/dist/MapUtil/MapUtil';
 
+import OlLayerTile from 'ol/layer/Tile';
+import OlSourceTileWMS from 'ol/source/TileWMS';
+import OlLayerImage from 'ol/layer/Image';
+import OlSourceImageWMS from 'ol/source/ImageWMS';
+
+import Legend from './Legend';
+
 describe('<Legend />', () => {
-  let layer1;
-  let layer2;
+  // A yellow (#ffed00) 1 x 1 px full opaque image
+  const mockLegend = 'data:image/png;base64,' +
+    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5bhPwAHzALtznmijAAAAABJRU5ErkJggg==';
+  let layer1: OlLayerTile<OlSourceTileWMS>;
+  let layer2: OlLayerImage<OlSourceImageWMS>;
+
+  beforeAll(() => {
+    enableFetchMocks();
+    (window.URL.createObjectURL as jest.Mock) = jest.fn().mockReturnValue(mockLegend);
+  });
+
+  afterAll(() => {
+    disableFetchMocks();
+    (window.URL.createObjectURL as jest.Mock).mockRestore();
+  });
 
   beforeEach(() => {
     layer1 = new OlLayerTile({
-      name: 'OSM-WMS',
+      properties: {
+        name: 'OSM-WMS',
+      },
       source: new OlSourceTileWMS({
         url: 'https://ows.terrestris.de/osm/service',
         params: {LAYERS: 'OSM-WMS', TILED: true},
         serverType: 'geoserver'
       })
     });
-    layer2 = new OlLayerTile({
-      legendUrl: 'https://www.koeln.de/files/images/Karnevalstrikot_Spieler_270.jpg',
-      name: 'A layer',
-      source: new OlSourceTileJson({
+    layer2 = new OlLayerImage({
+      properties: {
+        name: 'A layer',
+        legendUrl: 'https://www.koeln.de/files/images/Karnevalstrikot_Spieler_270.jpg'
+      },
+      source: new OlSourceImageWMS({
         url: 'https://example.org',
         crossOrigin: 'anonymous'
       })
     });
+  });
+
+  afterEach(() => {
+    (fetch as FetchMock).mockReset();
   });
 
   it('is defined', () => {
@@ -43,22 +76,31 @@ describe('<Legend />', () => {
 
   describe('Legend created with Layer', () => {
 
-    it('takes the legendGraphic from layer.get("legendUrl") if configured', () => {
+    it('takes the legendGraphic from layer.get("legendUrl") if configured', async () => {
+      (fetch as FetchMock).mockResponse(JSON.stringify(mockLegend));
+
       render(<Legend layer={layer2} />);
       const image = screen.getByRole('img');
       expect(image).toBeVisible();
-      expect(image).toHaveAttribute('src', layer2.get('legendUrl'));
+      await waitFor(() => {
+        expect(image).toHaveAttribute('src', mockLegend);
+      });
     });
 
-    it('generates getLegendGraphicUrl if no "legendUrl" configured', () => {
+    it('generates getLegendGraphicUrl if no "legendUrl" configured', async () => {
+      (fetch as FetchMock).mockResponse(JSON.stringify(mockLegend));
+
       render(<Legend layer={layer1} />);
       const image = screen.getByRole('img');
-      const legendUrl = MapUtil.getLegendGraphicUrl(layer1);
       expect(image).toBeVisible();
-      expect(image).toHaveAttribute('src', legendUrl);
+      await waitFor(() => {
+        expect(image).toHaveAttribute('src', mockLegend);
+      });
     });
 
-    it('generates getLegendGraphicUrl if no "legendUrl" configured (extraParams)', () => {
+    it('generates getLegendGraphicUrl if no "legendUrl" configured (extraParams)', async () => {
+      (fetch as FetchMock).mockResponse(JSON.stringify(mockLegend));
+
       const extraParams = {
         HEIGHT: 400,
         WIDTH: 400,
@@ -68,7 +110,12 @@ describe('<Legend />', () => {
       const image = screen.getByRole('img');
       const legendUrl = MapUtil.getLegendGraphicUrl(layer1, extraParams);
       expect(image).toBeVisible();
-      expect(image).toHaveAttribute('src', legendUrl);
+      expect((fetch as FetchMock)).toHaveBeenCalledWith(legendUrl, {
+        headers: undefined
+      });
+      await waitFor(() => {
+        expect(image).toHaveAttribute('src', mockLegend);
+      });
     });
 
     it('creates an alt attribute corresponding to layername', () => {
@@ -77,7 +124,6 @@ describe('<Legend />', () => {
       expect(image).toBeVisible();
       expect(image).toHaveAttribute('alt', `${layer1.get('name')} legend`);
     });
-
   });
 
 });

--- a/src/Legend/Legend.tsx
+++ b/src/Legend/Legend.tsx
@@ -143,10 +143,16 @@ export class Legend extends React.Component<LegendProps, LegendState> {
         throw new Error('No successful response returned while getting the legend graphic');
       }
 
+      if (this.state.imgSrc) {
+        URL.revokeObjectURL(this.state.imgSrc);
+      }
+
       this.setState({
         imgSrc: URL.createObjectURL(await response.blob())
       });
     } catch (error) {
+      Logger.error('Error while setting the img src: ', error);
+
       this.onError(error);
     } finally {
       this.setState({


### PR DESCRIPTION
## Description

<!-- Please give a short description of the changes you propose. Please use prose and try not to be too technical, if possible. Make sure to mention people that you think should know about the PR. -->

This adds support for custom request headers (e.g. an authentication token) to the `<Legend>` component and also adds a loading indicator to it.

Please review @terrestris/devs.

## Related issues or pull requests

<!-- Please list issues or pull requests that the changes you propose are related to. It does not matter if they are still open and/or unmerged, any link is appreciated. -->

--

## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [ ] Bugfix
- [x] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the
  [BSD-2-Clause](https://github.com/terrestris/react-geo/blob/main/LICENSE).
- [x] I have followed the [guidelines for contributing](https://github.com/terrestris/react-geo/blob/main/CONTRIBUTING.md).
- [x] The proposed change fits to the content of the [Code of Conduct](https://github.com/terrestris/react-geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally).
- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
