### PR TITLE
Refactor `LayerSwitcher` and `MapComponent`

### DIFF
--- a/src/LayerSwitcher/LayerSwitcher.spec.tsx
+++ b/src/LayerSwitcher/LayerSwitcher.spec.tsx
@@ -1,8 +1,7 @@
 import { render, within, screen } from '@testing-library/react';
-import * as React from 'react';
+import React from 'react';
 import userEvent from '@testing-library/user-event';
 import TestUtil from '../Util/TestUtil';
-import Logger from '@terrestris/base-util/dist/Logger';
 
 import LayerSwitcher from './LayerSwitcher';
 import OlLayerTile from 'ol/layer/Tile';
@@ -46,13 +45,13 @@ describe('<LayerSwitcher />', () => {
 
   it('contains map element', () => {
     const { container } = render(<LayerSwitcher layers={layers} map={map} />);
-    const mapElement = within(container).getByRole('img');
+    const mapElement = within(container).getByRole('menu');
     expect(mapElement).toBeVisible();
   });
 
   it('adds a custom className', () => {
     render(<LayerSwitcher layers={layers} map={map} className="peter" />);
-    const firstChild = screen.getByRole('form');
+    const firstChild = screen.getByRole('menu');
     expect(firstChild).toHaveClass('peter');
   });
 
@@ -61,7 +60,7 @@ describe('<LayerSwitcher />', () => {
       backgroundColor: 'yellow',
       position: 'inherit'
     }} />);
-    const firstChild = screen.getByRole('form');
+    const firstChild = screen.getByRole('menu');
     expect(firstChild).toHaveStyle({
       backgroundColor: 'yellow'
     });

--- a/src/LayerSwitcher/LayerSwitcher.tsx
+++ b/src/LayerSwitcher/LayerSwitcher.tsx
@@ -49,7 +49,6 @@ export type LayerSwitcherProps = OwnProps & React.HTMLAttributes<HTMLDivElement>
  * @class LayerSwitcher
  * @extends React.Component
  */
-// export class LayerSwitcher extends React.Component<LayerSwitcherProps, LayerSwitcherState> {
 export const LayerSwitcher: React.FC<LayerSwitcherProps> = ({
   identifierProperty = 'name',
   labelProperty = 'name',

--- a/src/LayerSwitcher/LayerSwitcher.tsx
+++ b/src/LayerSwitcher/LayerSwitcher.tsx
@@ -103,6 +103,7 @@ export const LayerSwitcher: React.FC<LayerSwitcherProps> = ({
         .map(cloneLayer)
         .forEach(layer => switcherMap.addLayer(layer));
     }
+    updateLayerVisibility();
   }, [switcherMap]);
 
   /**
@@ -146,13 +147,12 @@ export const LayerSwitcher: React.FC<LayerSwitcherProps> = ({
    */
   const updateLayerVisibility = () => {
     layers.forEach((l, i) => {
-      const clone = switcherMap
-        ?.getAllLayers()
-        ?.find(lc => lc.get(identifierProperty) === l.get(identifierProperty));
-      l.setVisible(visibleLayerIndexRef.current === i);
+      const visible = visibleLayerIndexRef.current === i;
+      l.setVisible(visible);
+      const clone = switcherMap?.getAllLayers()?.find(lc => lc.get(identifierProperty) === l.get(identifierProperty));
       if (clone) {
-        clone.setVisible(visibleLayerIndexRef.current === i);
-        if (visibleLayerIndexRef.current === i) {
+        clone.setVisible(visible);
+        if (visible) {
           setPreviewLayer(clone);
         }
       }
@@ -165,9 +165,9 @@ export const LayerSwitcher: React.FC<LayerSwitcherProps> = ({
    */
   const onSwitcherClick = (evt: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
     evt.stopPropagation();
-    switcherMap?.getAllLayers().forEach((layer, index: number) => {
+    layers.forEach((layer, index: number) => {
       if (layer.getVisible()) {
-        if (switcherMap?.getAllLayers()?.length - 1 === index) {
+        if (layers.length - 1 === index) {
           visibleLayerIndexRef.current = 0;
         } else {
           visibleLayerIndexRef.current = index + 1;
@@ -191,6 +191,7 @@ export const LayerSwitcher: React.FC<LayerSwitcherProps> = ({
   return (
     <div
       className={finalClassName}
+      role="menu"
       {...passThroughProps}
     >
       <div

--- a/src/LayerSwitcher/LayerSwitcher.tsx
+++ b/src/LayerSwitcher/LayerSwitcher.tsx
@@ -1,9 +1,7 @@
-import * as React from 'react';
-import _isEqual from 'lodash/isEqual';
-import Logger from '@terrestris/base-util/dist/Logger';
-import { ArrayTwoOrMore } from '@terrestris/base-util/dist/types';
+import React, { useEffect, useRef, useState } from 'react';
 
 import OlMap from 'ol/Map';
+import OlLayerBase from 'ol/layer/Base';
 import OlLayerGroup from 'ol/layer/Group';
 import OlLayerTile from 'ol/layer/Tile';
 import OlTileSource from 'ol/source/Tile';
@@ -26,15 +24,19 @@ export interface OwnProps {
   /**
    * The layers to be available in the switcher.
    */
-  layers: ArrayTwoOrMore<OlLayerTile<OlTileSource> | OlLayerGroup>;
+  layers: OlLayerBase[];
   /**
    * The main map the layers should be synced with.
    */
   map: OlMap;
-}
-
-interface LayerSwitcherState {
-  previewLayer: OlLayerTile<OlTileSource> | OlLayerGroup | null;
+  /**
+   * The property that identifies the layer.
+   */
+  identifierProperty?: string;
+  /**
+   * The property that labels the layer.
+   */
+  labelProperty?: string;
 }
 
 export type LayerSwitcherProps = OwnProps & React.HTMLAttributes<HTMLDivElement>;
@@ -47,13 +49,21 @@ export type LayerSwitcherProps = OwnProps & React.HTMLAttributes<HTMLDivElement>
  * @class LayerSwitcher
  * @extends React.Component
  */
-export class LayerSwitcher extends React.Component<LayerSwitcherProps, LayerSwitcherState> {
+// export class LayerSwitcher extends React.Component<LayerSwitcherProps, LayerSwitcherState> {
+export const LayerSwitcher: React.FC<LayerSwitcherProps> = ({
+  identifierProperty = 'name',
+  labelProperty = 'name',
+  map,
+  layers,
+  className: classNameProp,
+  ...passThroughProps
+}) => {
 
   /**
    * The internal map of the LayerSwitcher
    * @private
    */
-  _map: OlMap | null = null;
+  const [switcherMap, setSwitcherMap] = useState<OlMap>();
 
   /**
    * The internal index of visible layer in provided layers array. If all passed
@@ -61,67 +71,39 @@ export class LayerSwitcher extends React.Component<LayerSwitcherProps, LayerSwit
    * default.
    * @private
    */
-  _visibleLayerIndex: number = 0;
+  const visibleLayerIndexRef = useRef<number>(0);
 
-  /**
-   * Internal layer array, copy of passed layers. Will be used within internal
-   * map of the LayerSwitcher.
-   * @private
-   */
-  _layerClones: Array<OlLayerTile<OlTileSource> | OlLayerGroup> = [];
+  const [previewLayer, setPreviewLayer] = useState<OlLayerBase>();
 
   /**
    * The className added to this component.
    * @private
    */
-  _className = `${CSS_PREFIX}layer-switcher`;
+  const className = `${CSS_PREFIX}layer-switcher`;
 
-  /**
-   * Creates the LayerSwitcher.
-   *
-   * @constructs LayerSwitcher
-   */
-  constructor(props: LayerSwitcherProps) {
-    super(props);
-    this._map = this.getMap();
-    this.state = {
-      previewLayer: null
+  useEffect(() => {
+    const mapClone =  new OlMap({
+      view: map.getView(),
+      controls: []
+    });
+    setSwitcherMap(mapClone);
+    return () => {
+      if (switcherMap) {
+        switcherMap.getLayers().clear();
+        switcherMap.setTarget(undefined);
+        setSwitcherMap(undefined);
+      }
     };
-  }
+  }, [map]);
 
-  /**
-   * A react lifecycle method called when the component did mount.
-   */
-  componentDidMount() {
-    this.setMapLayers();
-    this.updateLayerVisibility();
-  }
-
-  /**
-   * Destroy all map specific stuff when umounting the component.
-   *
-   * @memberof LayerSwitcher
-   */
-  componentWillUnMount() {
-    if (this._map) {
-      this._map.getLayers().clear();
-      this._map.setTarget(undefined);
-      this._map = null;
+  useEffect(() => {
+    if (switcherMap) {
+      switcherMap.getLayers().clear();
+      layers
+        .map(cloneLayer)
+        .forEach(layer => switcherMap.addLayer(layer));
     }
-  }
-
-  /**
-   * Invoked immediately after updating occurs. This method is not called for
-   * the initial render.
-   *
-   * @param prevProps The previous props.
-   */
-  componentDidUpdate(prevProps: LayerSwitcherProps) {
-    if (!(_isEqual(this.props.layers, prevProps.layers))) {
-      this.setMapLayers();
-      this.updateLayerVisibility();
-    }
-  }
+  }, [switcherMap]);
 
   /**
    * Clones a layer
@@ -129,14 +111,14 @@ export class LayerSwitcher extends React.Component<LayerSwitcherProps, LayerSwit
    * @param layer The layer to clone.
    * @returns The cloned layer.
    */
-  cloneLayer(layer: OlLayerTile<OlTileSource> | OlLayerGroup): OlLayerTile<OlTileSource> | OlLayerGroup {
+  function cloneLayer(layer: OlLayerBase): OlLayerBase {
     if (layer instanceof OlLayerGroup) {
       return new OlLayerGroup({
         layers: layer.getLayers().getArray().map(l => {
           if (!(l instanceof OlLayerTile) || !(l instanceof OlLayerGroup)) {
             throw new Error('Layer of layergroup is of unclonable type');
           }
-          return this.cloneLayer(l);
+          return cloneLayer(l);
         }),
         properties: {
           originalLayer: layer
@@ -158,58 +140,22 @@ export class LayerSwitcher extends React.Component<LayerSwitcherProps, LayerSwit
   };
 
   /**
-   * (Re-)adds the layers to the preview map and sets the visibleLayerIndex.
-   *
-   */
-  setMapLayers = () => {
-    const {
-      layers
-    } = this.props;
-    if (layers.length < 2) {
-      Logger.warn('LayerSwitcher requires two or more layers.');
-    }
-    this._map?.getLayers().clear();
-    this._layerClones = layers.map((layer, index) => {
-      const layerClone = this.cloneLayer(layer);
-      if (layerClone.getVisible()) {
-        this._visibleLayerIndex = index;
-      }
-      this._map?.addLayer(layerClone);
-      return layerClone;
-    });
-  };
-
-  /**
    * Sets the visiblity of the layers in the props.map and this._map.
    * Also sets the previewLayer in the state.
    *
    */
-  updateLayerVisibility = () => {
-    const {
-      layers
-    } = this.props;
+  const updateLayerVisibility = () => {
     layers.forEach((l, i) => {
-      const clone = this._layerClones.find(lc => lc.get('name') === l.get('name'));
-      l.setVisible(this._visibleLayerIndex === i);
+      const clone = switcherMap
+        ?.getAllLayers()
+        ?.find(lc => lc.get(identifierProperty) === l.get(identifierProperty));
+      l.setVisible(visibleLayerIndexRef.current === i);
       if (clone) {
-        clone.setVisible(this._visibleLayerIndex === i);
-        if (this._visibleLayerIndex === i) {
-          this.setState({ previewLayer: clone });
+        clone.setVisible(visibleLayerIndexRef.current === i);
+        if (visibleLayerIndexRef.current === i) {
+          setPreviewLayer(clone);
         }
       }
-    });
-  };
-
-  /**
-   * Constructs this._map
-   */
-  getMap = (): OlMap => {
-    const {
-      map
-    } = this.props;
-    return new OlMap({
-      view: map.getView(),
-      controls: []
     });
   };
 
@@ -217,63 +163,55 @@ export class LayerSwitcher extends React.Component<LayerSwitcherProps, LayerSwit
    * Clickhandler for the overview switch.
    *
    */
-  onSwitcherClick = (evt: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
+  const onSwitcherClick = (evt: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
     evt.stopPropagation();
-    this._map?.getLayers().getArray().forEach((layer, index: number) => {
+    switcherMap?.getAllLayers().forEach((layer, index: number) => {
       if (layer.getVisible()) {
-        if (this._layerClones.length - 1 === index) {
-          this._visibleLayerIndex = 0;
+        if (switcherMap?.getAllLayers()?.length - 1 === index) {
+          visibleLayerIndexRef.current = 0;
         } else {
-          this._visibleLayerIndex = index + 1;
+          visibleLayerIndexRef.current = index + 1;
         }
       }
     });
-    this.updateLayerVisibility();
+    updateLayerVisibility();
   };
 
   /**
    * The render function.
    */
-  render() {
-    const {
-      className,
-      ...passThroughProps
-    } = this.props;
+  const finalClassName = classNameProp
+    ? `${className} ${classNameProp}`
+    : className;
 
-    const finalClassName = className
-      ? `${className} ${this._className}`
-      : this._className;
-
-    if (!this._map) {
-      return null;
-    }
-
-    return (
-      <div
-        role="form"
-        className={finalClassName}
-        {...passThroughProps}
-      >
-        <div
-          className="clip"
-          onClick={this.onSwitcherClick}
-          role="button"
-        >
-          <MapComponent
-            mapDivId="layer-switcher-map"
-            map={this._map}
-            role="img"
-          />
-          {
-            this.state.previewLayer &&
-            <span className="layer-title">
-              {this.state.previewLayer.get('name')}
-            </span>
-          }
-        </div>
-      </div>
-    );
+  if (!switcherMap) {
+    return null;
   }
-}
+
+  return (
+    <div
+      className={finalClassName}
+      {...passThroughProps}
+    >
+      <div
+        className="clip"
+        onClick={onSwitcherClick}
+        role="button"
+      >
+        <MapComponent
+          mapDivId="layer-switcher-map"
+          map={switcherMap}
+          role="presentation"
+        />
+        {
+          previewLayer &&
+          <span className="layer-title">
+            {previewLayer?.get(labelProperty)}
+          </span>
+        }
+      </div>
+    </div>
+  );
+};
 
 export default LayerSwitcher;

--- a/src/Map/MapComponent/MapComponent.tsx
+++ b/src/Map/MapComponent/MapComponent.tsx
@@ -1,102 +1,44 @@
-import * as React from 'react';
-import { PureComponent } from 'react';
+import React, {
+  useCallback
+} from 'react';
+
 import OlMap from 'ol/Map';
 
-interface DefaultProps {
-  mapDivId: string;
-}
-
-interface BaseProps {
+export interface MapComponentProps extends React.ComponentProps<'div'> {
   map: OlMap;
+  mapDivId?: string;
 }
 
-export type MapComponentProps = BaseProps & Partial<DefaultProps> & React.HTMLAttributes<HTMLDivElement>;
+export const MapComponent: React.FC<MapComponentProps> = ({
+  map,
+  mapDivId = 'map',
+  ...passThroughProps
+}): JSX.Element => {
 
-/**
- * Class representing a map.
- *
- * @class The MapComponent.
- * @extends React.PureComponent
- */
-export class MapComponent extends PureComponent<MapComponentProps> {
-
-  /**
-   * The default properties.
-   */
-  static defaultProps: DefaultProps = {
-    mapDivId: 'map'
-  };
-
-  /**
-   * Create a MapComponent.
-   */
-  constructor(props: MapComponentProps) {
-    super(props);
-  }
-
-  /**
-   * The componentDidMount function.
-   */
-  componentDidMount() {
-    const {
-      map,
-      mapDivId
-    } = this.props;
-
-    map.setTarget(mapDivId);
-  }
-
-  /**
-   * The componentWillUnmount function.
-   */
-  componentWillUnmount() {
-    const {
-      map
-    } = this.props;
-
-    map.setTarget(undefined);
-  }
-
-  /**
-   * Invoked immediately after updating occured and also called for the initial
-   * render.
-   */
-  componentDidUpdate() {
-    const {
-      map
-    } = this.props;
-    map.updateSize();
-  }
-
-  /**
-   * The render function.
-   */
-  render() {
-    let mapDiv;
-
-    const {
-      map,
-      mapDivId,
-      children,
-      role = 'application',
-      ...passThroughProps
-    } = this.props;
-
-    if (map) {
-      mapDiv = <div
-        className="map"
-        role={role}
-        id={mapDivId}
-        {...passThroughProps}
-      >
-        {children}
-      </div>;
+  const refCallback = useCallback((ref: HTMLDivElement) => {
+    if (!map) {
+      return;
     }
+    if (ref == null) {
+      map.setTarget(undefined);
+    } else {
+      map.setTarget(ref);
+    }
+  }, [map]);
 
-    return (
-      mapDiv
-    );
+  if (!map) {
+    return <></>;
   }
-}
+
+  return (
+    <div
+      id={mapDivId}
+      ref={refCallback}
+      className="map"
+      role="presentation"
+      {...passThroughProps}
+    />
+  );
+};
 
 export default MapComponent;

--- a/src/Map/MapComponent/MapComponent.tsx
+++ b/src/Map/MapComponent/MapComponent.tsx
@@ -19,7 +19,7 @@ export const MapComponent: React.FC<MapComponentProps> = ({
     if (!map) {
       return;
     }
-    if (ref == null) {
+    if (ref === null) {
       map.setTarget(undefined);
     } else {
       map.setTarget(ref);


### PR DESCRIPTION
## Description

This refactors the `LayerSwitcher` and the `MapComponent`. Both are transformed to react function components.

The `LayerSwitcher` is also restructured to have less internal functions and variables.
Two new optional properties where added ('identifierProperty', 'labelProperty') and the typing of the layers property is looser then before.

## Related issues or pull requests

<!-- Please list issues or pull requests that the changes you propose are related to. It does not matter if they are still open and/or unmerged, any link is appreciated. -->

## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [ ] Bugfix
- [x] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the
  [BSD-2-Clause](https://github.com/terrestris/react-geo/blob/main/LICENSE).
- [x] I have followed the [guidelines for contributing](https://github.com/terrestris/react-geo/blob/main/CONTRIBUTING.md).
- [x] The proposed change fits to the content of the [Code of Conduct](https://github.com/terrestris/react-geo/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally).
- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
