### PR TITLE
fix: example imports

### DIFF
--- a/src/BackgroundLayerChooser/BackgroundLayerChooser.example.md
+++ b/src/BackgroundLayerChooser/BackgroundLayerChooser.example.md
@@ -9,10 +9,10 @@ import OlLayerTile from 'ol/layer/Tile';
 import OlSourceTileWMS from 'ol/source/TileWMS';
 import OlSourceOsm from 'ol/source/OSM';
 
-import BackgroundLayerChooser from '@terrestris/react-geo/BackgroundLayerChooser/BackgroundLayerChooser';
-import MapComponent from '@terrestris/react-geo/Map/MapComponent/MapComponent';
-import MapContext from '@terrestris/react-geo/Context/MapContext/MapContext';
-import { useMap } from '@terrestris/react-geo/Hook/useMap';
+import BackgroundLayerChooser from '@terrestris/react-geo/dist/BackgroundLayerChooser/BackgroundLayerChooser';
+import MapComponent from '@terrestris/react-geo/dist/Map/MapComponent/MapComponent';
+import MapContext from '@terrestris/react-geo/dist/Context/MapContext/MapContext';
+import { useMap } from '@terrestris/react-geo/dist/Hook/useMap';
 
 const layers = [
   new OlLayerTile({

--- a/src/Button/CopyButton/CopyButton.example.md
+++ b/src/Button/CopyButton/CopyButton.example.md
@@ -10,10 +10,10 @@ import OlSourceOsm from 'ol/source/OSM';
 import OlFormatGeoJSON from 'ol/format/GeoJSON';
 import {fromLonLat} from 'ol/proj';
 
-import MapContext from '@terrestris/react-geo/Context/MapContext/MapContext'
-import MapComponent from '@terrestris/react-geo/Map/MapComponent/MapComponent';
-import CopyButton from '@terrestris/react-geo/Button/CopyButton/CopyButton';
-import {DigitizeUtil} from '@terrestris/react-geo/Util/DigitizeUtil';
+import MapContext from '@terrestris/react-geo/dist/Context/MapContext/MapContext'
+import MapComponent from '@terrestris/react-geo/dist/Map/MapComponent/MapComponent';
+import CopyButton from '@terrestris/react-geo/dist/Button/CopyButton/CopyButton';
+import {DigitizeUtil} from '@terrestris/react-geo/dist/Util/DigitizeUtil';
 
 import featuresJson from '../../../assets/simple-geometries.json';
 

--- a/src/Button/DeleteButton/DeleteButton.example.md
+++ b/src/Button/DeleteButton/DeleteButton.example.md
@@ -10,10 +10,10 @@ import OlSourceOsm from 'ol/source/OSM';
 import OlFormatGeoJSON from 'ol/format/GeoJSON';
 import { fromLonLat } from 'ol/proj';
 
-import MapContext from '@terrestris/react-geo/Context/MapContext/MapContext'
-import MapComponent from '@terrestris/react-geo/Map/MapComponent/MapComponent';
-import { DeleteButton } from '@terrestris/react-geo/Button/DeleteButton/DeleteButton';
-import { DigitizeUtil } from '@terrestris/react-geo/Util/DigitizeUtil';
+import MapContext from '@terrestris/react-geo/dist/Context/MapContext/MapContext'
+import MapComponent from '@terrestris/react-geo/dist/Map/MapComponent/MapComponent';
+import { DeleteButton } from '@terrestris/react-geo/dist/Button/DeleteButton/DeleteButton';
+import { DigitizeUtil } from '@terrestris/react-geo/dist/Util/DigitizeUtil';
 
 import federalStates from '../../../assets/federal-states-ger.json';
 

--- a/src/Button/DigitizeButton/DigitizeButton.example.md
+++ b/src/Button/DigitizeButton/DigitizeButton.example.md
@@ -15,8 +15,8 @@ import OlLayerTile from 'ol/layer/Tile';
 import OlSourceOsm from 'ol/source/OSM';
 import { fromLonLat } from 'ol/proj';
 
-import DigitizeButton from '@terrestris/react-geo/Button/DigitizeButton/DigitizeButton';
-import ToggleGroup from '@terrestris/react-geo/Button/ToggleGroup/ToggleGroup';
+import DigitizeButton from '@terrestris/react-geo/dist/Button/DigitizeButton/DigitizeButton';
+import ToggleGroup from '@terrestris/react-geo/dist/Button/ToggleGroup/ToggleGroup';
 
 class DigitizeButtonExample extends React.Component {
 

--- a/src/Button/DrawButton/DrawButton.example.md
+++ b/src/Button/DrawButton/DrawButton.example.md
@@ -9,10 +9,10 @@ import OlLayerTile from 'ol/layer/Tile';
 import OlSourceOsm from 'ol/source/OSM';
 import { fromLonLat } from 'ol/proj';
 
-import MapContext from '@terrestris/react-geo/Context/MapContext/MapContext'
-import DrawButton from '@terrestris/react-geo/Button/DrawButton/DrawButton';
-import ToggleGroup from '@terrestris/react-geo/Button/ToggleGroup/ToggleGroup';
-import MapComponent from '@terrestris/react-geo/Map/MapComponent/MapComponent';
+import MapContext from '@terrestris/react-geo/dist/Context/MapContext/MapContext'
+import DrawButton from '@terrestris/react-geo/dist/Button/DrawButton/DrawButton';
+import ToggleGroup from '@terrestris/react-geo/dist/Button/ToggleGroup/ToggleGroup';
+import MapComponent from '@terrestris/react-geo/dist/Map/MapComponent/MapComponent';
 
 const DrawButtonExample = () => {
 

--- a/src/Button/GeoLocationButton/GeoLocationButton.example.md
+++ b/src/Button/GeoLocationButton/GeoLocationButton.example.md
@@ -9,8 +9,8 @@ import OlLayerTile from 'ol/layer/Tile';
 import OlSourceOSM from 'ol/source/OSM';
 import { fromLonLat } from 'ol/proj';
 
-import GeoLocationButton from '@terrestris/react-geo/Button/GeoLocationButton/GeoLocationButton';
-import ToggleGroup from '@terrestris/react-geo/Button/ToggleGroup/ToggleGroup';
+import GeoLocationButton from '@terrestris/react-geo/dist/Button/GeoLocationButton/GeoLocationButton';
+import ToggleGroup from '@terrestris/react-geo/dist/Button/ToggleGroup/ToggleGroup';
 
 class GeoLocationButtonExample extends React.Component {
 

--- a/src/Button/MeasureButton/MeasureButton.example.md
+++ b/src/Button/MeasureButton/MeasureButton.example.md
@@ -9,8 +9,8 @@ import OlLayerTile from 'ol/layer/Tile';
 import OlSourceOSM from 'ol/source/OSM';
 import { fromLonLat } from 'ol/proj';
 
-import MeasureButton from '@terrestris/react-geo/Button/MeasureButton/MeasureButton';
-import ToggleGroup from '@terrestris/react-geo/Button/ToggleGroup/ToggleGroup';
+import MeasureButton from '@terrestris/react-geo/dist/Button/MeasureButton/MeasureButton';
+import ToggleGroup from '@terrestris/react-geo/dist/Button/ToggleGroup/ToggleGroup';
 
 class MeasureButtonExample extends React.Component {
 

--- a/src/Button/ModifyButton/ModifyButton.example.md
+++ b/src/Button/ModifyButton/ModifyButton.example.md
@@ -10,10 +10,10 @@ import OlSourceOsm from 'ol/source/OSM';
 import OlFormatGeoJSON from 'ol/format/GeoJSON';
 import {fromLonLat} from 'ol/proj';
 
-import MapContext from '@terrestris/react-geo/Context/MapContext/MapContext'
-import MapComponent from '@terrestris/react-geo/Map/MapComponent/MapComponent';
-import {ModifyButton} from '@terrestris/react-geo/Button/ModifyButton/ModifyButton';
-import {DigitizeUtil} from '@terrestris/react-geo/Util/DigitizeUtil';
+import MapContext from '@terrestris/react-geo/dist/Context/MapContext/MapContext'
+import MapComponent from '@terrestris/react-geo/dist/Map/MapComponent/MapComponent';
+import {ModifyButton} from '@terrestris/react-geo/dist/Button/ModifyButton/ModifyButton';
+import {DigitizeUtil} from '@terrestris/react-geo/dist/Util/DigitizeUtil';
 
 import featuresJson from '../../../assets/simple-geometries.json';
 

--- a/src/Button/PrintButton/PrintButton.example.md
+++ b/src/Button/PrintButton/PrintButton.example.md
@@ -19,9 +19,9 @@ import OlView from 'ol/View';
 import WMTS from 'ol/source/WMTS';
 import WMTSTileGrid from 'ol/tilegrid/WMTS';
 
-import MapComponent from '@terrestris/react-geo/Map/MapComponent/MapComponent';
-import MapContext from '@terrestris/react-geo/Context/MapContext/MapContext'
-import PrintButton from '@terrestris/react-geo/Button/PrintButton/PrintButton';
+import MapComponent from '@terrestris/react-geo/dist/Map/MapComponent/MapComponent';
+import MapContext from '@terrestris/react-geo/dist/Context/MapContext/MapContext'
+import PrintButton from '@terrestris/react-geo/dist/Button/PrintButton/PrintButton';
 
 import { Progress } from 'antd';
 

--- a/src/Button/SelectFeaturesButton/SelectFeaturesButton.example.md
+++ b/src/Button/SelectFeaturesButton/SelectFeaturesButton.example.md
@@ -12,9 +12,9 @@ import OlVectorSource from 'ol/source/Vector';
 import OlFormatGeoJSON from 'ol/format/GeoJSON';
 import { fromLonLat } from 'ol/proj';
 
-import MapContext from '@terrestris/react-geo/Context/MapContext/MapContext'
-import MapComponent from '@terrestris/react-geo/Map/MapComponent/MapComponent';
-import SelectFeaturesButton from '@terrestris/react-geo/Button/SelectFeaturesButton/SelectFeaturesButton';
+import MapContext from '@terrestris/react-geo/dist/Context/MapContext/MapContext'
+import MapComponent from '@terrestris/react-geo/dist/Map/MapComponent/MapComponent';
+import SelectFeaturesButton from '@terrestris/react-geo/dist/Button/SelectFeaturesButton/SelectFeaturesButton';
 
 import federalStates from '../../../assets/federal-states-ger.json';
 

--- a/src/Button/SimpleButton/SimpleButton.example.md
+++ b/src/Button/SimpleButton/SimpleButton.example.md
@@ -4,7 +4,7 @@ for more documentation and examples.
 Just a SimpleButton without any configuration:
 
 ```jsx
-import SimpleButton from '@terrestris/react-geo/Button/SimpleButton/SimpleButton';
+import SimpleButton from '@terrestris/react-geo/dist/Button/SimpleButton/SimpleButton';
 
 <SimpleButton>
   Click me
@@ -14,7 +14,7 @@ import SimpleButton from '@terrestris/react-geo/Button/SimpleButton/SimpleButton
 A SimpleButton with a `tooltip` and a `tooltipPlacement`:
 
 ```jsx
-import SimpleButton from '@terrestris/react-geo/Button/SimpleButton/SimpleButton';
+import SimpleButton from '@terrestris/react-geo/dist/Button/SimpleButton/SimpleButton';
 
 <SimpleButton
   tooltip="bottom tooltip"
@@ -27,7 +27,7 @@ import SimpleButton from '@terrestris/react-geo/Button/SimpleButton/SimpleButton
 A SimpleButton with a Font Awesome icon.
 
 ```jsx
-import SimpleButton from '@terrestris/react-geo/Button/SimpleButton/SimpleButton';
+import SimpleButton from '@terrestris/react-geo/dist/Button/SimpleButton/SimpleButton';
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faCoffee } from '@fortawesome/free-solid-svg-icons';
@@ -44,7 +44,7 @@ import { faCoffee } from '@fortawesome/free-solid-svg-icons';
 A round SimpleButton using shape config:
 
 ```jsx
-import SimpleButton from '@terrestris/react-geo/Button/SimpleButton/SimpleButton';
+import SimpleButton from '@terrestris/react-geo/dist/Button/SimpleButton/SimpleButton';
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faDownload } from '@fortawesome/free-solid-svg-icons';

--- a/src/Button/ToggleButton/ToggleButton.example.md
+++ b/src/Button/ToggleButton/ToggleButton.example.md
@@ -3,7 +3,7 @@ This demonstrates the use of ToggleButtons.
 A ToggleButton without any configuration:
 
 ```jsx
-import ToggleButton from '@terrestris/react-geo/Button/ToggleButton/ToggleButton';
+import ToggleButton from '@terrestris/react-geo/dist/Button/ToggleButton/ToggleButton';
 
 <ToggleButton
   onToggle={()=>{}}
@@ -15,7 +15,7 @@ import ToggleButton from '@terrestris/react-geo/Button/ToggleButton/ToggleButton
 A ToggleButton initially pressed:
 
 ```jsx
-import ToggleButton from '@terrestris/react-geo/Button/ToggleButton/ToggleButton';
+import ToggleButton from '@terrestris/react-geo/dist/Button/ToggleButton/ToggleButton';
 
 <ToggleButton
   pressed={true}
@@ -28,7 +28,7 @@ import ToggleButton from '@terrestris/react-geo/Button/ToggleButton/ToggleButton
 A ToggleButton with an icon and a pressedIcon:
 
 ```jsx
-import ToggleButton from '@terrestris/react-geo/Button/ToggleButton/ToggleButton';
+import ToggleButton from '@terrestris/react-geo/dist/Button/ToggleButton/ToggleButton';
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faFaceFrown, faFaceSmile } from '@fortawesome/free-solid-svg-icons';

--- a/src/Button/ToggleGroup/ToggleGroup.example.md
+++ b/src/Button/ToggleGroup/ToggleGroup.example.md
@@ -1,8 +1,8 @@
 This demonstrates the use of ToggleGroups.
 
 ```jsx
-import ToggleGroup from '@terrestris/react-geo/Button/ToggleGroup/ToggleGroup';
-import ToggleButton from '@terrestris/react-geo/Button/ToggleButton/ToggleButton';
+import ToggleGroup from '@terrestris/react-geo/dist/Button/ToggleGroup/ToggleGroup';
+import ToggleButton from '@terrestris/react-geo/dist/Button/ToggleButton/ToggleButton';
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faFaceFrown, faFaceSmile } from '@fortawesome/free-solid-svg-icons';

--- a/src/Button/UploadButton/UploadButton.example.md
+++ b/src/Button/UploadButton/UploadButton.example.md
@@ -3,7 +3,7 @@ This example demonstrates the use of the `UploadButton`.
 UploadButton:
 
 ```jsx
-import UploadButton from '@terrestris/react-geo/Button/UploadButton/UploadButton';
+import UploadButton from '@terrestris/react-geo/dist/Button/UploadButton/UploadButton';
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faUpload } from '@fortawesome/free-solid-svg-icons';
@@ -23,8 +23,8 @@ import { faUpload } from '@fortawesome/free-solid-svg-icons';
 UploadButton with a texted SimpleButton as child:
 
 ```jsx
-import UploadButton from '@terrestris/react-geo/Button/UploadButton/UploadButton';
-import SimpleButton from '@terrestris/react-geo/Button/SimpleButton/SimpleButton';
+import UploadButton from '@terrestris/react-geo/dist/Button/UploadButton/UploadButton';
+import SimpleButton from '@terrestris/react-geo/dist/Button/SimpleButton/SimpleButton';
 
 <UploadButton
   onChange={e => {
@@ -36,7 +36,7 @@ import SimpleButton from '@terrestris/react-geo/Button/SimpleButton/SimpleButton
 ```
 
 ```jsx
-import UploadButton from '@terrestris/react-geo/Button/UploadButton/UploadButton';
+import UploadButton from '@terrestris/react-geo/dist/Button/UploadButton/UploadButton';
 
 <UploadButton
   onChange={e => {

--- a/src/Button/ZoomButton/ZoomButton.example.md
+++ b/src/Button/ZoomButton/ZoomButton.example.md
@@ -9,7 +9,7 @@ import OlLayerTile from 'ol/layer/Tile';
 import OlSourceOSM from 'ol/source/OSM';
 import { fromLonLat } from 'ol/proj';
 
-import ZoomButton from '@terrestris/react-geo/Button/ZoomButton/ZoomButton';
+import ZoomButton from '@terrestris/react-geo/dist/Button/ZoomButton/ZoomButton';
 
 class ZoomButtonExample extends React.Component {
 

--- a/src/Button/ZoomToExtentButton/ZoomToExtentButton.example.md
+++ b/src/Button/ZoomToExtentButton/ZoomToExtentButton.example.md
@@ -9,7 +9,7 @@ import OlLayerTile from 'ol/layer/Tile';
 import OlSourceOSM from 'ol/source/OSM';
 import { fromLonLat } from 'ol/proj';
 
-import ZoomToExtentButton from '@terrestris/react-geo/Button/ZoomToExtentButton/ZoomToExtentButton';
+import ZoomToExtentButton from '@terrestris/react-geo/dist/Button/ZoomToExtentButton/ZoomToExtentButton';
 
 class ZoomToExtentButtonExample extends React.Component {
 

--- a/src/CircleMenu/CircleMenu.example.md
+++ b/src/CircleMenu/CircleMenu.example.md
@@ -17,8 +17,8 @@ import OlStyleStyle from 'ol/style/Style';
 import OlStyleCircle from 'ol/style/Circle';
 import OlStyleFill from 'ol/style/Fill';
 
-import CircleMenu from '@terrestris/react-geo/CircleMenu/CircleMenu';
-import SimpleButton from '@terrestris/react-geo/Button/SimpleButton/SimpleButton';
+import CircleMenu from '@terrestris/react-geo/dist/CircleMenu/CircleMenu';
+import SimpleButton from '@terrestris/react-geo/dist/Button/SimpleButton/SimpleButton';
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faPencil, faChartLine, faLink, faThumbsUp, faBullhorn } from '@fortawesome/free-solid-svg-icons';

--- a/src/Container/AddWmsPanel/AddWmsPanel.example.md
+++ b/src/Container/AddWmsPanel/AddWmsPanel.example.md
@@ -11,8 +11,8 @@ import OlLayerTile from 'ol/layer/Tile';
 import OlSourceOSM from 'ol/source/OSM';
 import { fromLonLat } from 'ol/proj';
 
-import AddWmsPanel from '@terrestris/react-geo/Container/AddWmsPanel/AddWmsPanel';
-import SimpleButton from '@terrestris/react-geo/Button/SimpleButton/SimpleButton';
+import AddWmsPanel from '@terrestris/react-geo/dist/Container/AddWmsPanel/AddWmsPanel';
+import SimpleButton from '@terrestris/react-geo/dist/Button/SimpleButton/SimpleButton';
 
 import CapabilitiesUtil from '@terrestris/ol-util/dist/CapabilitiesUtil/CapabilitiesUtil';
 

--- a/src/Context/MapContext/MapContext.example.md
+++ b/src/Context/MapContext/MapContext.example.md
@@ -8,8 +8,8 @@ If you are using function-components head over to the `useMap` example in the "H
 ```jsx
 import * as React from 'react';
 
-import MapContext from '@terrestris/react-geo/Context/MapContext/MapContext';
-import MapComponent from '@terrestris/react-geo/Map/MapComponent/MapComponent';
+import MapContext from '@terrestris/react-geo/dist/Context/MapContext/MapContext';
+import MapComponent from '@terrestris/react-geo/dist/Map/MapComponent/MapComponent';
 import OlMap from 'ol/Map';
 import OlView from 'ol/View';
 import OlLayerTile from 'ol/layer/Tile';

--- a/src/CoordinateInfo/CoordinateInfo.example.md
+++ b/src/CoordinateInfo/CoordinateInfo.example.md
@@ -20,7 +20,7 @@ import { fromLonLat } from 'ol/proj';
 
 import * as copy from 'copy-to-clipboard';
 
-import CoordinateInfo from '@terrestris/react-geo/CoordinateInfo/CoordinateInfo';
+import CoordinateInfo from '@terrestris/react-geo/dist/CoordinateInfo/CoordinateInfo';
 
 const queryLayer = new OlLayerTile({
   name: 'States (USA)',

--- a/src/Field/CoordinateReferenceSystemCombo/CoordinateReferenceSystemCombo.example.md
+++ b/src/Field/CoordinateReferenceSystemCombo/CoordinateReferenceSystemCombo.example.md
@@ -18,7 +18,7 @@ import {
 import { applyTransform } from 'ol/extent';
 
 import CoordinateReferenceSystemCombo from
-  '@terrestris/react-geo/Field/CoordinateReferenceSystemCombo/CoordinateReferenceSystemCombo';
+  '@terrestris/react-geo/dist/Field/CoordinateReferenceSystemCombo/CoordinateReferenceSystemCombo';
 
 const predefinedCrsDefinitions = [{
   code: '25832',

--- a/src/Field/NominatimSearch/NominatimSearch.example.md
+++ b/src/Field/NominatimSearch/NominatimSearch.example.md
@@ -9,8 +9,8 @@ import OlLayerTile from 'ol/layer/Tile';
 import OlSourceOSM from 'ol/source/OSM';
 import {fromLonLat} from 'ol/proj';
 
-import MapComponent from '@terrestris/react-geo/Map/MapComponent/MapComponent';
-import NominatimSearch from '@terrestris/react-geo/Field/NominatimSearch/NominatimSearch';
+import MapComponent from '@terrestris/react-geo/dist/Map/MapComponent/MapComponent';
+import NominatimSearch from '@terrestris/react-geo/dist/Field/NominatimSearch/NominatimSearch';
 
 const NominatimSearchExample = () => {
   const [map, setMap] = useState();

--- a/src/Field/ScaleCombo/ScaleCombo.example.md
+++ b/src/Field/ScaleCombo/ScaleCombo.example.md
@@ -9,7 +9,7 @@ import OlLayerTile from 'ol/layer/Tile';
 import OlSourceOSM from 'ol/source/OSM';
 import { fromLonLat } from 'ol/proj';
 
-import ScaleCombo from '@terrestris/react-geo/Field/ScaleCombo/ScaleCombo';
+import ScaleCombo from '@terrestris/react-geo/dist/Field/ScaleCombo/ScaleCombo';
 
 class ScaleComboExample extends React.Component {
 

--- a/src/Field/WfsSearch/WfsSearch.example.md
+++ b/src/Field/WfsSearch/WfsSearch.example.md
@@ -9,7 +9,7 @@ import OlLayerTile from 'ol/layer/Tile';
 import OlSourceOSM from 'ol/source/OSM';
 import { fromLonLat } from 'ol/proj';
 
-import WfsSearch from '@terrestris/react-geo/Field/WfsSearch/WfsSearch';
+import WfsSearch from '@terrestris/react-geo/dist/Field/WfsSearch/WfsSearch';
 
 class WfsSearchExample extends React.Component {
 

--- a/src/Field/WfsSearchInput/WfsSearchInput.example.md
+++ b/src/Field/WfsSearchInput/WfsSearchInput.example.md
@@ -12,8 +12,8 @@ import OlSourceOSM from 'ol/source/OSM';
 import OlFormatGeoJSON from 'ol/format/GeoJSON';
 import { fromLonLat } from 'ol/proj';
 
-import AgFeatureGrid from '@terrestris/react-geo/Grid/AgFeatureGrid/AgFeatureGrid';
-import WfsSearchInput from '@terrestris/react-geo/Field/WfsSearchInput/WfsSearchInput';
+import AgFeatureGrid from '@terrestris/react-geo/dist/Grid/AgFeatureGrid/AgFeatureGrid';
+import WfsSearchInput from '@terrestris/react-geo/dist/Field/WfsSearchInput/WfsSearchInput';
 
 class WfsSearchInputExample extends React.Component {
 

--- a/src/Grid/AgFeatureGrid/AgFeatureGrid.example.md
+++ b/src/Grid/AgFeatureGrid/AgFeatureGrid.example.md
@@ -11,7 +11,7 @@ import OlSourceOSM from 'ol/source/OSM';
 import OlFormatGeoJSON from 'ol/format/GeoJSON';
 import { fromLonLat } from 'ol/proj';
 
-import AgFeatureGrid from '@terrestris/react-geo/Grid/AgFeatureGrid/AgFeatureGrid';
+import AgFeatureGrid from '@terrestris/react-geo/dist/Grid/AgFeatureGrid/AgFeatureGrid';
 
 import federalStates from '../../../assets/federal-states-ger.json';
 

--- a/src/Grid/FeatureGrid/FeatureGrid.example.md
+++ b/src/Grid/FeatureGrid/FeatureGrid.example.md
@@ -10,7 +10,7 @@ import OlSourceOSM from 'ol/source/OSM';
 import OlFormatGeoJSON from 'ol/format/GeoJSON';
 import { fromLonLat } from 'ol/proj';
 
-import FeatureGrid from '@terrestris/react-geo/Grid/FeatureGrid/FeatureGrid';
+import FeatureGrid from '@terrestris/react-geo/dist/Grid/FeatureGrid/FeatureGrid';
 
 import federalStates from '../../../assets/federal-states-ger.json';
 
@@ -118,7 +118,7 @@ import Input from 'antd/lib/input';
 
 import UrlUtil from '@terrestris/base-util/dist/UrlUtil/UrlUtil';
 
-import FeatureGrid from '@terrestris/react-geo/Grid/FeatureGrid/FeatureGrid';
+import FeatureGrid from '@terrestris/react-geo/dist/Grid/FeatureGrid/FeatureGrid';
 
 // Credits to Maps Icons Collection https://mapicons.mapsmarker.com.
 import mapMarker from '../../../assets/bus-map-marker.png';

--- a/src/Grid/PropertyGrid/PropertyGrid.example.md
+++ b/src/Grid/PropertyGrid/PropertyGrid.example.md
@@ -4,7 +4,7 @@ This is an example containing a property grid:
 import OlFeature from 'ol/Feature';
 import OlGeomPoint from 'ol/geom/Point';
 
-import PropertyGrid from '@terrestris/react-geo/Grid/PropertyGrid/PropertyGrid';
+import PropertyGrid from '@terrestris/react-geo/dist/Grid/PropertyGrid/PropertyGrid';
 
 const feature = new OlFeature({
   geometry: new OlGeomPoint([19.09, 1.09]),

--- a/src/HigherOrderComponent/DropTargetMap/DropTargetMap.example.md
+++ b/src/HigherOrderComponent/DropTargetMap/DropTargetMap.example.md
@@ -10,10 +10,10 @@ import OlView from 'ol/View';
 import OlLayerTile from 'ol/layer/Tile';
 import OlSourceOSM from 'ol/source/OSM';
 
-import onDropAware from '@terrestris/react-geo/HigherOrderComponent/DropTargetMap/DropTargetMap';
-import MapComponent from '@terrestris/react-geo/Map/MapComponent/MapComponent';
-import MapProvider from '@terrestris/react-geo/Provider/MapProvider/MapProvider';
-import { mappify } from '@terrestris/react-geo/HigherOrderComponent/MappifiedComponent/MappifiedComponent';
+import onDropAware from '@terrestris/react-geo/dist/HigherOrderComponent/DropTargetMap/DropTargetMap';
+import MapComponent from '@terrestris/react-geo/dist/Map/MapComponent/MapComponent';
+import MapProvider from '@terrestris/react-geo/dist/Provider/MapProvider/MapProvider';
+import { mappify } from '@terrestris/react-geo/dist/HigherOrderComponent/MappifiedComponent/MappifiedComponent';
 
 /**
  * Create the OlMap (you could do some asynchronus stuff here).

--- a/src/HigherOrderComponent/LoadifiedComponent/LoadifiedComponent.example.md
+++ b/src/HigherOrderComponent/LoadifiedComponent/LoadifiedComponent.example.md
@@ -4,9 +4,9 @@ The example below you see a `SimpleButton` that changes the `Titlebar`'s loading
 ```jsx
 import * as React from 'react';
 
-import SimpleButton from '@terrestris/react-geo/Button/SimpleButton/SimpleButton';
-import Titlebar from '@terrestris/react-geo/Panel/Titlebar/Titlebar';
-import { loadify } from '@terrestris/react-geo/HigherOrderComponent/LoadifiedComponent/LoadifiedComponent';
+import SimpleButton from '@terrestris/react-geo/dist/Button/SimpleButton/SimpleButton';
+import Titlebar from '@terrestris/react-geo/dist/Panel/Titlebar/Titlebar';
+import { loadify } from '@terrestris/react-geo/dist/HigherOrderComponent/LoadifiedComponent/LoadifiedComponent';
 
 const LoadingPanel = loadify(Titlebar);
 
@@ -59,8 +59,8 @@ import OlSourceOSM from 'ol/source/OSM';
 import OlSourceTileWMS from 'ol/source/TileWMS';
 import { fromLonLat } from 'ol/proj';
 
-import LayerTree from '@terrestris/react-geo/LayerTree/LayerTree';
-import { loadify } from '@terrestris/react-geo/HigherOrderComponent/LoadifiedComponent/LoadifiedComponent';
+import LayerTree from '@terrestris/react-geo/dist/LayerTree/LayerTree';
+import { loadify } from '@terrestris/react-geo/dist/HigherOrderComponent/LoadifiedComponent/LoadifiedComponent';
 
 const LoadingTree = loadify(LayerTree);
 

--- a/src/HigherOrderComponent/VisibleComponent/VisibleComponent.example.md
+++ b/src/HigherOrderComponent/VisibleComponent/VisibleComponent.example.md
@@ -7,9 +7,9 @@ In the example below you see three components wrapped by the use of
 it won't be rendered.
 
 ```jsx
-import SimpleButton from '@terrestris/react-geo/Button/SimpleButton/SimpleButton';
+import SimpleButton from '@terrestris/react-geo/dist/Button/SimpleButton/SimpleButton';
 
-import { isVisibleComponent } from '@terrestris/react-geo/HigherOrderComponent/VisibleComponent/VisibleComponent';
+import { isVisibleComponent } from '@terrestris/react-geo/dist/HigherOrderComponent/VisibleComponent/VisibleComponent';
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faSearch, faPowerOff } from '@fortawesome/free-solid-svg-icons';

--- a/src/Hook/useMap.example.md
+++ b/src/Hook/useMap.example.md
@@ -6,10 +6,10 @@ It replaces the old `MapProvider` and `mappify` HOC.
 ```jsx
 import * as React from 'react';
 
-import MapComponent from '@terrestris/react-geo/Map/MapComponent/MapComponent';
-import LayerTree from '@terrestris/react-geo/LayerTree/LayerTree';
-import MapContext from '@terrestris/react-geo/Context/MapContext/MapContext';
-import { useMap } from '@terrestris/react-geo/Hook/useMap';
+import MapComponent from '@terrestris/react-geo/dist/Map/MapComponent/MapComponent';
+import LayerTree from '@terrestris/react-geo/dist/LayerTree/LayerTree';
+import MapContext from '@terrestris/react-geo/dist/Context/MapContext/MapContext';
+import { useMap } from '@terrestris/react-geo/dist/Hook/useMap';
 import OlMap from 'ol/Map';
 import OlView from 'ol/View';
 import OlLayerTile from 'ol/layer/Tile';

--- a/src/LayerSwitcher/LayerSwitcher.example.md
+++ b/src/LayerSwitcher/LayerSwitcher.example.md
@@ -11,7 +11,7 @@ import OlLayerTile from 'ol/layer/Tile';
 import OlSourceStamen from 'ol/source/Stamen';
 import OlSourceOsm from 'ol/source/OSM';
 
-import LayerSwitcher from '@terrestris/react-geo/LayerSwitcher/LayerSwitcher';
+import LayerSwitcher from '@terrestris/react-geo/dist/LayerSwitcher/LayerSwitcher';
 
 class LayerSwitcherExample extends React.Component {
 

--- a/src/LayerTree/LayerTree.example.md
+++ b/src/LayerTree/LayerTree.example.md
@@ -11,7 +11,7 @@ import OlSourceOSM from 'ol/source/OSM';
 import OlSourceTileWMS from 'ol/source/TileWMS';
 import { fromLonLat } from 'ol/proj';
 
-import LayerTree from '@terrestris/react-geo/LayerTree/LayerTree';
+import LayerTree from '@terrestris/react-geo/dist/LayerTree/LayerTree';
 
 class LayerTreeExample extends React.Component {
 

--- a/src/Legend/Legend.example.md
+++ b/src/Legend/Legend.example.md
@@ -9,7 +9,7 @@ import OlLayerTile from 'ol/layer/Tile';
 import OlSourceTileWMS from 'ol/source/TileWMS';
 import { fromLonLat } from 'ol/proj';
 
-import Legend from '@terrestris/react-geo/Legend/Legend';
+import Legend from '@terrestris/react-geo/dist/Legend/Legend';
 
 class LegendExample extends React.Component {
 

--- a/src/Map/FloatingMapLogo/FloatingMapLogo.example.md
+++ b/src/Map/FloatingMapLogo/FloatingMapLogo.example.md
@@ -8,7 +8,7 @@ import OlView from 'ol/View';
 import OlLayerTile from 'ol/layer/Tile';
 import OlSourceOsm from 'ol/source/OSM';
 
-import FloatingMapLogo from '@terrestris/react-geo/Map/FloatingMapLogo/FloatingMapLogo';
+import FloatingMapLogo from '@terrestris/react-geo/dist/Map/FloatingMapLogo/FloatingMapLogo';
 
 import logo from '../../../assets/user.png';
 

--- a/src/Map/MapComponent/MapComponent.example.md
+++ b/src/Map/MapComponent/MapComponent.example.md
@@ -18,10 +18,10 @@ import OlView from 'ol/View';
 import OlLayerTile from 'ol/layer/Tile';
 import OlSourceOsm from 'ol/source/OSM';
 
-import MapComponent from '@terrestris/react-geo/Map/MapComponent/MapComponent';
-import NominatimSearch from '@terrestris/react-geo/Field/NominatimSearch/NominatimSearch';
-import MapProvider from '@terrestris/react-geo/Provider/MapProvider/MapProvider';
-import { mappify } from '@terrestris/react-geo/HigherOrderComponent/MappifiedComponent/MappifiedComponent';
+import MapComponent from '@terrestris/react-geo/dist/Map/MapComponent/MapComponent';
+import NominatimSearch from '@terrestris/react-geo/dist/Field/NominatimSearch/NominatimSearch';
+import MapProvider from '@terrestris/react-geo/dist/Provider/MapProvider/MapProvider';
+import { mappify } from '@terrestris/react-geo/dist/HigherOrderComponent/MappifiedComponent/MappifiedComponent';
 
 const Map = mappify(MapComponent);
 const Search = mappify(NominatimSearch);

--- a/src/Panel/Panel/Panel.example.md
+++ b/src/Panel/Panel/Panel.example.md
@@ -1,7 +1,7 @@
 This example demonstrates the use of Panels
 
 ```jsx
-import Panel from '@terrestris/react-geo/Panel/Panel/Panel';
+import Panel from '@terrestris/react-geo/dist/Panel/Panel/Panel';
 
 <Panel
   style={{position: 'relative'}}
@@ -16,7 +16,7 @@ import Panel from '@terrestris/react-geo/Panel/Panel/Panel';
 ```
 
 ```jsx
-import Panel from '@terrestris/react-geo/Panel/Panel/Panel';
+import Panel from '@terrestris/react-geo/dist/Panel/Panel/Panel';
 
 <div style={{display: 'flex'}}>
   <Panel
@@ -46,7 +46,7 @@ import Panel from '@terrestris/react-geo/Panel/Panel/Panel';
 ```
 
 ```jsx
-import Panel from '@terrestris/react-geo/Panel/Panel/Panel';
+import Panel from '@terrestris/react-geo/dist/Panel/Panel/Panel';
 
 <Panel
   style={{position: 'relative'}}
@@ -64,7 +64,7 @@ import Panel from '@terrestris/react-geo/Panel/Panel/Panel';
 ```
 
 ```jsx
-import Panel from '@terrestris/react-geo/Panel/Panel/Panel';
+import Panel from '@terrestris/react-geo/dist/Panel/Panel/Panel';
 
 <Panel
   style={{position: 'relative'}}
@@ -87,7 +87,7 @@ import Panel from '@terrestris/react-geo/Panel/Panel/Panel';
 ```
 
 ```jsx
-import Panel from '@terrestris/react-geo/Panel/Panel/Panel';
+import Panel from '@terrestris/react-geo/dist/Panel/Panel/Panel';
 
 <Panel
   style={{position: 'relative'}}
@@ -101,7 +101,7 @@ import Panel from '@terrestris/react-geo/Panel/Panel/Panel';
 ```
 
 ```jsx
-import Panel from '@terrestris/react-geo/Panel/Panel/Panel';
+import Panel from '@terrestris/react-geo/dist/Panel/Panel/Panel';
 
 <Panel
   style={{position: 'relative'}}

--- a/src/Panel/TimeLayerSliderPanel/TimeLayerSliderPanel.example.md
+++ b/src/Panel/TimeLayerSliderPanel/TimeLayerSliderPanel.example.md
@@ -14,7 +14,7 @@ import OlSourceTileWMS from 'ol/source/TileWMS';
 import { transformExtent } from 'ol/proj';
 import { getCenter } from 'ol/extent';
 
-import TimeLayerSliderPanel from '@terrestris/react-geo/Panel/TimeLayerSliderPanel/TimeLayerSliderPanel';
+import TimeLayerSliderPanel from '@terrestris/react-geo/dist/Panel/TimeLayerSliderPanel/TimeLayerSliderPanel';
 
 class TimeLayerSliderPanelExample extends React.Component {
 

--- a/src/Panel/Titlebar/Titlebar.example.md
+++ b/src/Panel/Titlebar/Titlebar.example.md
@@ -3,7 +3,7 @@ This example demonstrates the Titlebar.
 Just a Titlebar:
 
 ```jsx
-import Titlebar from '@terrestris/react-geo/Panel/Titlebar/Titlebar';
+import Titlebar from '@terrestris/react-geo/dist/Panel/Titlebar/Titlebar';
 
 <Titlebar />
 ```
@@ -11,7 +11,7 @@ import Titlebar from '@terrestris/react-geo/Panel/Titlebar/Titlebar';
 A Titlebar with a title:
 
 ```jsx
-import Titlebar from '@terrestris/react-geo/Panel/Titlebar/Titlebar';
+import Titlebar from '@terrestris/react-geo/dist/Panel/Titlebar/Titlebar';
 
 <Titlebar>
   Title
@@ -21,8 +21,8 @@ import Titlebar from '@terrestris/react-geo/Panel/Titlebar/Titlebar';
 A Titlebar with a title and tools
 
 ```jsx
-import SimpleButton from '@terrestris/react-geo/Button/SimpleButton/SimpleButton';
-import Titlebar from '@terrestris/react-geo/Panel/Titlebar/Titlebar';
+import SimpleButton from '@terrestris/react-geo/dist/Button/SimpleButton/SimpleButton';
+import Titlebar from '@terrestris/react-geo/dist/Panel/Titlebar/Titlebar';
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faGlobe } from '@fortawesome/free-solid-svg-icons';

--- a/src/Slider/LayerTransparencySlider/LayerTransparencySlider.example.md
+++ b/src/Slider/LayerTransparencySlider/LayerTransparencySlider.example.md
@@ -9,7 +9,7 @@ import OlLayerTile from 'ol/layer/Tile';
 import OlSourceOSM from 'ol/source/OSM';
 import { fromLonLat } from 'ol/proj';
 
-import LayerTransparencySlider from '@terrestris/react-geo/Slider/LayerTransparencySlider/LayerTransparencySlider';
+import LayerTransparencySlider from '@terrestris/react-geo/dist/Slider/LayerTransparencySlider/LayerTransparencySlider';
 
 class LayerTransparencySliderExample extends React.Component {
 

--- a/src/Slider/MultiLayerSlider/MultiLayerSlider.example.md
+++ b/src/Slider/MultiLayerSlider/MultiLayerSlider.example.md
@@ -13,7 +13,7 @@ import OlView from 'ol/View';
 import OlLayerTile from 'ol/layer/Tile';
 import OlSourceTileWMS from 'ol/source/TileWMS';
 
-import MultiLayerSlider from '@terrestris/react-geo/Slider/MultiLayerSlider/MultiLayerSlider';
+import MultiLayerSlider from '@terrestris/react-geo/dist/Slider/MultiLayerSlider/MultiLayerSlider';
 
 class MultiLayerSliderExample extends React.Component {
 

--- a/src/Toolbar/Toolbar.example.md
+++ b/src/Toolbar/Toolbar.example.md
@@ -1,8 +1,8 @@
 This is a example using a toolbar having vertically and horizontally aligned child elements (buttons in this example).
 
 ```jsx
-import SimpleButton from '@terrestris/react-geo/Button/SimpleButton/SimpleButton';
-import Toolbar from '@terrestris/react-geo/Toolbar/Toolbar';
+import SimpleButton from '@terrestris/react-geo/dist/Button/SimpleButton/SimpleButton';
+import Toolbar from '@terrestris/react-geo/dist/Toolbar/Toolbar';
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faSearch, faInfo } from '@fortawesome/free-solid-svg-icons';

--- a/src/UserChip/UserChip.example.md
+++ b/src/UserChip/UserChip.example.md
@@ -1,7 +1,7 @@
 This is a example using an UserChip.
 
 ```jsx
-import UserChip from '@terrestris/react-geo/UserChip/UserChip';
+import UserChip from '@terrestris/react-geo/dist/UserChip/UserChip';
 
 import logo from '../../assets/user.png';
 

--- a/src/Window/Window.example.md
+++ b/src/Window/Window.example.md
@@ -5,8 +5,8 @@ Click to open window:
 ```jsx
 import * as React from 'react';
 
-import SimpleButton from '@terrestris/react-geo/Button/SimpleButton/SimpleButton';
-import Window from '@terrestris/react-geo/Window/Window';
+import SimpleButton from '@terrestris/react-geo/dist/Button/SimpleButton/SimpleButton';
+import Window from '@terrestris/react-geo/dist/Window/Window';
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faTimes } from '@fortawesome/free-solid-svg-icons';

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -41,7 +41,8 @@ module.exports = {
     return `import ${name} from '@terrestris/react-geo/${dir}/${name}';`;
   },
   moduleAliases: {
-    '@terrestris/react-geo': path.resolve(__dirname, 'src')
+    // rewrite the example sources internally to the src folder to use e.g. hot reloading
+    '@terrestris/react-geo/dist': path.resolve(__dirname, 'src')
   },
   require: [
     'whatwg-fetch',


### PR DESCRIPTION
This closes https://github.com/terrestris/react-geo/issues/2544 by rewriting the import pathes to correctly use the `dist` folder.

In order to keep styleguidist serving those examples live with hot reloading while developing, the alias has been adjusted to load classes from the src instead of this dist folder.

@terrestris/devs please review