### PR TITLE
feat: add optional icon to header of SearchResultsPanel

### DIFF
--- a/src/Panel/SearchResultsPanel/SearchResultsPanel.less
+++ b/src/Panel/SearchResultsPanel/SearchResultsPanel.less
@@ -1,62 +1,70 @@
 .search-wrapper {
-    flex: 1;
-    display: flex;
-    flex-direction: column;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
 
-    .ant-input {
-      background-color: white;
-    }
+  .ant-input {
+    background-color: white;
   }
+}
 
-  .search-result-div {
-    width: 50vw;
-    position: absolute;
-    top: 47px;
-    z-index: 9999;
+.search-result-div {
+  width: 50vw;
+  position: absolute;
+  top: 47px;
+  z-index: 9999;
 
-    .ant-collapse {
-      max-height: 400px;
-      overflow-y: auto;
+  .ant-collapse {
+    max-height: 400px;
+    overflow-y: auto;
 
-      .ant-list div.result-text {
-        padding: 0 10px;
+    .ant-list div.result-text {
+      padding: 0 10px;
+    }
+
+    >.ant-collapse-item>.ant-collapse-header {
+      line-height: 32px;
+      padding: 5px 0 5px 15px;
+      align-items: center;
+
+      i.arrow {
+        line-height: 40px;
       }
 
-      .ant-collapse-header {
-        padding: 5px 0 5px 40px;
+      .search-result-panel-header {
+        display: flex;
+        align-items: center;
 
-        i.arrow {
-          line-height: 40px;
+        >span {
+          flex: 1;
         }
 
-        .search-result-panel-header {
-          display: flex;
-          align-items: center;
+        .search-option-avatar {
+          max-width: 32px;
+          margin-right: 15px;
+          border-radius: 15px;
+          background: transparent;
 
-          >span {
-            flex: 1;
-          }
-
-          .search-option-avatar {
-            max-width: 32px;
-            margin-right: 15px;
-            border-radius: 0;
-            background: transparent;
+          svg {
+            height: 60%;
+            vertical-align: middle;
+            color: black;
           }
         }
       }
+    }
 
-      .ant-collapse-content {
-        background: transparent;
+    .ant-collapse-content {
+      background: transparent;
+      padding: 0;
+
+      >.ant-collapse-content-box {
         padding: 0;
 
-        >.ant-collapse-content-box {
-          padding: 0;
-
-          .ant-list-item:hover {
-            cursor: pointer;
-          }
+        .ant-list-item:hover {
+          cursor: pointer;
         }
       }
     }
   }
+}

--- a/src/Panel/SearchResultsPanel/SearchResultsPanel.tsx
+++ b/src/Panel/SearchResultsPanel/SearchResultsPanel.tsx
@@ -5,6 +5,7 @@ import OlSourceVector from 'ol/source/Vector';
 import OlMap from 'ol/Map';
 
 import {
+  Avatar,
   Collapse,
   CollapseProps,
   List
@@ -23,9 +24,10 @@ export interface Category {
   title: string;
   /** Each feature is expected to have at least the properties `title` and `geometry` */
   features: OlFeature[];
+  icon?: React.ReactNode | string;
 }
 
-interface SearchResultsPanelProps extends Partial<CollapseProps>{
+interface SearchResultsPanelProps extends Partial<CollapseProps> {
   searchResults: Category[];
   numTotal: number;
   searchTerms: string[];
@@ -103,7 +105,8 @@ const SearchResultsPanel = (props: SearchResultsPanelProps) => {
   const renderPanelForCategory = (category: Category, categoryIdx: number) => {
     const {
       features,
-      title
+      title,
+      icon
     } = category;
     if (!features || _isEmpty(features)) {
       return;
@@ -112,6 +115,13 @@ const SearchResultsPanel = (props: SearchResultsPanelProps) => {
     const header = (
       <div className="search-result-panel-header">
         <span>{`${title} (${features.length})`}</span>
+        {
+          icon &&
+          <Avatar
+            className="search-option-avatar"
+            src={icon}
+          />
+        }
       </div>
     );
 


### PR DESCRIPTION
## Description

Show optionally configured in header of search results collapse panels. If provided, the icon will be shown as avatar right to panel title and feature count.

![image](https://user-images.githubusercontent.com/3939355/223417274-3d737457-a38f-41c9-9fab-f9afc697616f.png)

Icon can be passed as string path or react node (e.g. FontAwesomeIcon).

Please review @terrestris/devs 

## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [ ] Bugfix
- [x] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [ ] I understand and agree that the changes in this PR will be licensed under the
  [BSD-2-Clause](https://github.com/terrestris/react-geo/blob/main/LICENSE).
- [ ] I have followed the [guidelines for contributing](https://github.com/terrestris/react-geo/blob/main/CONTRIBUTING.md).
- [ ] The proposed change fits to the content of the [Code of Conduct](https://github.com/terrestris/react-geo/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally).
- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
