### PR TITLE
fix: keep feature id in `CoordinateInfo`

### DIFF
--- a/src/CoordinateInfo/CoordinateInfo.tsx
+++ b/src/CoordinateInfo/CoordinateInfo.tsx
@@ -10,6 +10,7 @@ import OlMap from 'ol/Map';
 import OlMapBrowserEvent from 'ol/MapBrowserEvent';
 
 import _isString from 'lodash/isString';
+import _cloneDeep from 'lodash/cloneDeep';
 
 import Logger from '@terrestris/base-util/dist/Logger';
 
@@ -233,18 +234,16 @@ export class CoordinateInfo extends React.Component<CoordinateInfoProps, Coordin
   }
 
   getCoordinateInfoState(): CoordinateInfoState {
-    const featuresClone: { [name: string]: OlFeature[] } = {};
-    Object.entries(this.state.features)
-      .forEach(([layerName, feats]) => {
-        featuresClone[layerName] = feats.map(feat => feat.clone());
-      });
-
+    // We're cloning the click coordinate and features to
+    // not pass the internal state reference to the parent component.
+    // Also note that we explicitly don't use feature.clone() to
+    // keep all feature properties (in particular the id) intact.
     const coordinateInfoState: CoordinateInfoState = {
       clickCoordinate: this.state.clickCoordinate ?
-        [...this.state.clickCoordinate] :
+        _cloneDeep(this.state.clickCoordinate) :
         null,
       loading: this.state.loading,
-      features: featuresClone
+      features: _cloneDeep(this.state.features)
     };
 
     return coordinateInfoState;


### PR DESCRIPTION
## Description

<!-- Please give a short description of the changes you propose. Please use prose and try not to be too technical, if possible. Make sure to mention people that you think should know about the PR. -->

We're cloning the click coordinate and features to not pass the internal state reference to the parent component. Also note that we explicitly don't use `feature.clone()` to keep all feature properties (in particular the id) intact.

Please review @terrestris/devs.

## Related issues or pull requests

<!-- Please list issues or pull requests that the changes you propose are related to. It does not matter if they are still open and/or unmerged, any link is appreciated. -->

--

## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the
  [BSD-2-Clause](https://github.com/terrestris/react-geo/blob/main/LICENSE).
- [x] I have followed the [guidelines for contributing](https://github.com/terrestris/react-geo/blob/main/CONTRIBUTING.md).
- [x] The proposed change fits to the content of the [Code of Conduct](https://github.com/terrestris/react-geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally).
- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
