### PR TITLE
fix: enables layer array after no layer was selected

### DIFF
--- a/src/BackgroundLayerChooser/BackgroundLayerChooser.tsx
+++ b/src/BackgroundLayerChooser/BackgroundLayerChooser.tsx
@@ -150,20 +150,19 @@ export const BackgroundLayerChooser: React.FC<BackgroundLayerChooserProps> = ({
             visibility: layerOptionsVisible ? 'visible' : 'hidden'
           }}
         >
-          {selectedLayer ?
-            layers.map(layer => {
-              return (
-                <BackgroundLayerPreview
-                  key={getUid(layer)}
-                  activeLayer={selectedLayer}
-                  onClick={l => onLayerSelect(l)}
-                  layer={layer}
-                  backgroundLayerFilter={backgroundLayerFilter}
-                  zoom={zoom}
-                  center={center}
-                />
-              );
-            }) : null
+          {layers.map(layer => {
+            return (
+              <BackgroundLayerPreview
+                key={getUid(layer)}
+                activeLayer={selectedLayer}
+                onClick={l => onLayerSelect(l)}
+                layer={layer}
+                backgroundLayerFilter={backgroundLayerFilter}
+                zoom={zoom}
+                center={center}
+              />
+            );
+          })
           }
           {allowEmptyBackground &&
             <SimpleButton

--- a/src/BackgroundLayerPreview/BackgroundLayerPreview.tsx
+++ b/src/BackgroundLayerPreview/BackgroundLayerPreview.tsx
@@ -19,7 +19,7 @@ export type BackgroundLayerPreviewProps = {
   width?: number;
   height?: number;
   layer: OlLayer;
-  activeLayer: OlLayer;
+  activeLayer: OlLayer | undefined;
   onClick: (l: OlLayer) => void;
   zoom?: number;
   center?: Coordinate;


### PR DESCRIPTION
## Description

Ensures that layers are always mapped.


## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [ ] No

## Checklist

- [ ] I understand and agree that the changes in this PR will be licensed under the
  [BSD-2-Clause](https://github.com/terrestris/react-geo/blob/main/LICENSE).
- [ ] I have followed the [guidelines for contributing](https://github.com/terrestris/react-geo/blob/main/CONTRIBUTING.md).
- [ ] The proposed change fits to the content of the [Code of Conduct](https://github.com/terrestris/react-geo/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally).
- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
