### PR TITLE
feat: adds a radius property to the measure circle button

### DIFF
--- a/src/Button/MeasureButton/MeasureButton.tsx
+++ b/src/Button/MeasureButton/MeasureButton.tsx
@@ -861,9 +861,14 @@ class MeasureButton extends React.Component<MeasureButtonProps> {
         if (!measureRadius) {
           output = MeasureUtil.formatArea(geom, map, decimalPlacesInTooltips, geodesic);
         } else {
+          const area = MeasureUtil.getAreaOfCircle(geom, map);
           const decimalHelper = Math.pow(10, decimalPlacesInTooltips);
           const radius = Math.round(geom.getRadius() * decimalHelper) / decimalHelper;
           output = `${radius.toString()} m`;
+          if (area > (Math.PI * 1000000)) {
+            output = (Math.round(geom.getRadius() / 100 * decimalHelper) /
+            decimalHelper) + ' km';
+          }
         }
       } else if (geom instanceof OlGeomPolygon) {
         output = MeasureUtil.formatArea(geom, map, decimalPlacesInTooltips, geodesic);

--- a/src/Button/MeasureButton/MeasureButton.tsx
+++ b/src/Button/MeasureButton/MeasureButton.tsx
@@ -866,7 +866,7 @@ class MeasureButton extends React.Component<MeasureButtonProps> {
           const radius = Math.round(geom.getRadius() * decimalHelper) / decimalHelper;
           output = `${radius.toString()} m`;
           if (area > (Math.PI * 1000000)) {
-            output = (Math.round(geom.getRadius() / 100 * decimalHelper) /
+            output = (Math.round(geom.getRadius() / 1000 * decimalHelper) /
             decimalHelper) + ' km';
           }
         }

--- a/src/Button/MeasureButton/MeasureButton.tsx
+++ b/src/Button/MeasureButton/MeasureButton.tsx
@@ -121,6 +121,10 @@ interface OwnProps {
    * Whether the measure is using geodesic or cartesian mode. Geodesic is used by default.
    */
   geodesic: boolean;
+  /**
+   * If set true, instead of the area, the radius  will be measured.
+   */
+  measureRadius?: boolean;
 }
 
 export type MeasureType = 'line' | 'polygon' | 'angle' | 'circle';
@@ -156,7 +160,8 @@ class MeasureButton extends React.Component<MeasureButtonProps> {
     },
     pressed: false,
     onToggle: () => undefined,
-    geodesic: true
+    geodesic: true,
+    measureRadius: false
   };
 
   /**
@@ -831,7 +836,8 @@ class MeasureButton extends React.Component<MeasureButtonProps> {
       measureType,
       decimalPlacesInTooltips,
       map,
-      geodesic
+      geodesic,
+      measureRadius
     } = this.props;
 
     if (!this._measureTooltipElement) {
@@ -852,7 +858,13 @@ class MeasureButton extends React.Component<MeasureButtonProps> {
 
       if (geom instanceof OlGeomCircle) {
         measureTooltipCoord = geom.getLastCoordinate();
-        output = MeasureUtil.formatArea(geom, map, decimalPlacesInTooltips, geodesic);
+        if (!measureRadius) {
+          output = MeasureUtil.formatArea(geom, map, decimalPlacesInTooltips, geodesic);
+        } else {
+          const decimalHelper = Math.pow(10, decimalPlacesInTooltips);
+          const radius = Math.round(geom.getRadius() * decimalHelper) / decimalHelper;
+          output = `${radius.toString()} m`;
+        }
       } else if (geom instanceof OlGeomPolygon) {
         output = MeasureUtil.formatArea(geom, map, decimalPlacesInTooltips, geodesic);
         // attach area at interior point


### PR DESCRIPTION
## Description

Adds a measureRadius property, that when set to true, measures the radius of a circle instead of the area.


## Pull request type

- [ ] Bugfix
- [x] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
