### PR TITLE
Configurable onClick property for SearchResultPanel

### DIFF
--- a/src/Panel/SearchResultsPanel/SearchResultsPanel.tsx
+++ b/src/Panel/SearchResultsPanel/SearchResultsPanel.tsx
@@ -36,7 +36,7 @@ interface SearchResultsPanelProps extends Partial<CollapseProps> {
   /** A renderer function returning a prefix component for each list item */
   listPrefixRenderer?: (item: any) => undefined | JSX.Element;
   layerStyle?: undefined | OlStyle;
-  extentShift?: number | undefined;
+  onClick?: (item: any) => void;
 }
 
 const SearchResultsPanel = (props: SearchResultsPanelProps) => {
@@ -49,7 +49,8 @@ const SearchResultsPanel = (props: SearchResultsPanelProps) => {
     actionsCreator = () => undefined,
     listPrefixRenderer = () => undefined,
     layerStyle,
-    extentShift,
+    onClick = item =>
+      map.getView().fit(item.feature.getGeometry(), { size: map.getSize() }),
     ...passThroughProps
   } = props;
 
@@ -149,34 +150,7 @@ const SearchResultsPanel = (props: SearchResultsPanelProps) => {
               key={item.idx}
               onMouseOver={onMouseOver(item.feature)}
               onMouseOut={() => highlightLayer?.getSource()?.clear()}
-              onClick={() => {
-                const extent = item.feature.getGeometry().getExtent();
-                let adjustedExtent: number[] | undefined = undefined;
-
-                if (extentShift) {
-                  const mapSize = map.getSize();
-
-                  let domWidth = 0;
-                  if (mapSize && mapSize.length > 1) {
-                    domWidth = mapSize[0];
-                  }
-
-                  const extentWidth = extent[2] - extent[0];
-                  const pixelsPerCoordinate = extentWidth / domWidth;
-                  const shiftInCoordinates = pixelsPerCoordinate * extentShift;
-
-                  adjustedExtent = [
-                    extent[0] - shiftInCoordinates,
-                    extent[1],
-                    extent[2],
-                    extent[3]
-                  ];
-                }
-
-                map.getView().fit(adjustedExtent ? adjustedExtent : extent, {
-                  size: map.getSize()
-                });
-              }}
+              onClick={() => onClick(item)}
               actions={actionsCreator(item)}
             >
               <div


### PR DESCRIPTION
## Description

This PR adjusts the `SearchResultPanel` with an optional property (`extentShift`) to apply  an offset to the features extent of an entry in the search results. This can be used when the map is overlaid by elements and the map center is no longer the actual map center at that moment.

@terrestris/devs please review

## Pull request type

- [ ] Bugfix
- [x] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the
  [BSD-2-Clause](https://github.com/terrestris/react-geo/blob/main/LICENSE).
- [x] I have followed the [guidelines for contributing](https://github.com/terrestris/react-geo/blob/main/CONTRIBUTING.md).
- [x] The proposed change fits to the content of the [Code of Conduct](https://github.com/terrestris/react-geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally).
- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
