### PR TITLE
Fix ToggleButton and make use of onSuccess in CoordinateInfo

### DIFF
--- a/src/Button/ToggleButton/ToggleButton.tsx
+++ b/src/Button/ToggleButton/ToggleButton.tsx
@@ -82,7 +82,7 @@ export const ToggleButton: React.FC<ToggleButtonProps> = ({
   value,
   onClick,
   onChange = () => {},
-  buttonTransparent = true,
+  buttonTransparent = false,
   ...passThroughProps
 }) => {
 

--- a/src/CoordinateInfo/CoordinateInfo.tsx
+++ b/src/CoordinateInfo/CoordinateInfo.tsx
@@ -25,6 +25,7 @@ export const CoordinateInfo: FC<CoordinateInfoProps> = ({
   featureCount = 1,
   fetchOpts = {},
   onError = () => undefined,
+  onSuccess = () => undefined,
   queryLayers = [],
   resultRenderer = () => <></>
 }) => {
@@ -34,6 +35,7 @@ export const CoordinateInfo: FC<CoordinateInfoProps> = ({
     featureCount,
     fetchOpts,
     onError,
+    onSuccess,
     queryLayers,
   });
 


### PR DESCRIPTION
## Description

This PR update the `ToggleButton` property `buttonTransparent` to `false` again and makes use of the `onSuccess` property in `CoordinateInfo` component.

:exclamation: After a new version of react-util is available, it must be referenced here in the package.json.

@terrestris/devs please review

## Related issues or pull requests

<!-- Please list issues or pull requests that the changes you propose are related to. It does not matter if they are still open and/or unmerged, any link is appreciated. -->

## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the
  [BSD-2-Clause](https://github.com/terrestris/react-geo/blob/main/LICENSE).
- [x] I have followed the [guidelines for contributing](https://github.com/terrestris/react-geo/blob/main/CONTRIBUTING.md).
- [x] The proposed change fits to the content of the [Code of Conduct](https://github.com/terrestris/react-geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally).
- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
