### PR TITLE
Accelerate the start of the styleguide (in dev mode)

### DIFF
--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -5,21 +5,26 @@ const reactDogGenTypeScript = require('react-docgen-typescript');
 module.exports = {
   title: 'react-geo',
   styleguideDir: './build/styleguide',
-  webpackConfig: webpackCommonConf,
+  webpackConfig: {
+    ...webpackCommonConf,
+    mode: process.env.NODE_ENV
+  },
   usageMode: 'expand',
   template: {
     favicon: 'https://terrestris.github.io/react-geo/assets/favicon.ico'
   },
-  propsParser: reactDogGenTypeScript
-    .withCustomConfig('./tsconfig.json', {
-      savePropValueAsString: true,
-      propFilter: (prop) => {
-        if (prop.parent) {
-          return !prop.parent.fileName.includes('node_modules');
-        }
-        return true;
-      }
-    }).parse,
+  minimize: process.env.NODE_ENV === 'production',
+  propsParser: process.env.NODE_ENV === 'production' ?
+    reactDogGenTypeScript
+      .withCustomConfig('./tsconfig.json', {
+        propFilter: (prop) => {
+          if (prop.parent) {
+            return !prop.parent.fileName.includes('node_modules');
+          }
+          return true;
+        }})
+      .parse :
+    undefined,
   ignore: [
     '**/__tests__/**',
     '**/*.spec.{js,jsx,ts,tsx}',


### PR DESCRIPTION
## Description

<!-- Please give a short description of the changes you propose. Please use prose and try not to be too technical, if possible. Make sure to mention people that you think should know about the PR. -->

This accelerates the startup of the styleguidist server in dev mode by the factor of ~5-10.

## Related issues or pull requests

<!-- Please list issues or pull requests that the changes you propose are related to. It does not matter if they are still open and/or unmerged, any link is appreciated. -->

--

## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [ ] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [x] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the
  [BSD-2-Clause](https://github.com/terrestris/react-geo/blob/main/LICENSE).
- [x] I have followed the [guidelines for contributing](https://github.com/terrestris/react-geo/blob/main/CONTRIBUTING.md).
- [x] The proposed change fits to the content of the [Code of Conduct](https://github.com/terrestris/react-geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally).
- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
