### PR TITLE
docs: use a supported URL for the Snyk badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![GitHub license](https://img.shields.io/github/license/terrestris/react-geo?style=flat-square)](https://github.com/terrestris/react-geo/blob/main/LICENSE)
 [![Coverage Status](https://img.shields.io/coveralls/github/terrestris/react-geo?style=flat-square)](https://coveralls.io/github/terrestris/react-geo?branch=main)
 ![GitHub action build](https://img.shields.io/github/actions/workflow/status/terrestris/react-geo/on-push-main.yml?branch=main&style=flat-square)
-[![Known Vulnerabilities](https://img.shields.io/snyk/vulnerabilities/github/terrestris/react-geo?style=flat-square)](https://snyk.io/test/github/terrestris/react-geo)
+[![Known Vulnerabilities](https://snyk.io/test/github/terrestris/react-geo/badge.svg)](https://snyk.io/test/github/terrestris/react-geo)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](https://github.com/terrestris/react-geo/blob/main/CONTRIBUTING.md)
 
 `react-geo` is a JavaScript library providing a large number of components to build modern mapping applications. It is used in combination with [React](https://github.com/facebook/react), [OpenLayers](https://github.com/openlayers/openlayers) and [Ant Design](https://github.com/ant-design/ant-design).


### PR DESCRIPTION
## Description

This PR suggests t use a different URL for the [Snyk badge](https://support.snyk.io/hc/en-us/articles/360003997277-Badge-Support-for-Repositories).

Before:

![image](https://github.com/terrestris/react-geo/assets/227934/c675e39f-52d8-4b20-ba24-829e7c563d6d)

After:

![image](https://github.com/terrestris/react-geo/assets/227934/20339fe2-600e-4f0e-a55c-0b201d58b55d)

(The background can be ignored)


## Related issues or pull requests

<!-- Please list issues or pull requests that the changes you propose are related to. It does not matter if they are still open and/or unmerged, any link is appreciated. -->

## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [ ] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the
  [BSD-2-Clause](https://github.com/terrestris/react-geo/blob/main/LICENSE).
- [x] I have followed the [guidelines for contributing](https://github.com/terrestris/react-geo/blob/main/CONTRIBUTING.md).
- [x] The proposed change fits to the content of the [Code of Conduct](https://github.com/terrestris/react-geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally).
- [x] I have added a screenshot/screencast to illustrate the visual output of my update.
