### PR TITLE
feat: pass through on fetch success callbacks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@fortawesome/react-fontawesome": "^0.2.0",
         "@terrestris/base-util": "^1.1.0",
         "@terrestris/ol-util": "^18.0.0",
-        "@terrestris/react-util": "^5.0.0",
+        "@terrestris/react-util": "^5.1.0",
         "@types/geojson": "^7946.0.14",
         "@types/lodash": "^4.17.1",
         "ag-grid-community": "^31.3.1",
@@ -5670,9 +5670,9 @@
       }
     },
     "node_modules/@terrestris/react-util": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@terrestris/react-util/-/react-util-5.0.0.tgz",
-      "integrity": "sha512-j2Feq2WdhWuFM+U8KSfj7dz4qkh/slR18lQWTOxWJuybtk+9qLr8AVf3myTLaS362Mr1MPI2mAao+W+O8wz20A==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@terrestris/react-util/-/react-util-5.1.0.tgz",
+      "integrity": "sha512-i7xhdBRJvcVKUZmMYc6PFoMWzGgX24OkdxcjONaQ8ycjmGnf9tOdXIXHiYAx9DjJQgRDoqu1q1qW1AuR3CCbVA==",
       "dependencies": {
         "@camptocamp/inkmap": "^1.4.0",
         "@terrestris/base-util": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@fortawesome/react-fontawesome": "^0.2.0",
     "@terrestris/base-util": "^1.1.0",
     "@terrestris/ol-util": "^18.0.0",
-    "@terrestris/react-util": "^5.0.0",
+    "@terrestris/react-util": "^5.1.0",
     "@types/geojson": "^7946.0.14",
     "@types/lodash": "^4.17.1",
     "ag-grid-community": "^31.3.1",

--- a/src/Field/NominatimSearch/NominatimSearch.tsx
+++ b/src/Field/NominatimSearch/NominatimSearch.tsx
@@ -69,6 +69,7 @@ export const NominatimSearch: FC<NominatimSearchProps> = ({
   onChange = () => undefined,
   onClear,
   onFetchError,
+  onFetchSuccess,
   onSelect,
   polygonGeoJSON,
   renderOption,

--- a/src/Field/WfsSearchField/WfsSearchField.tsx
+++ b/src/Field/WfsSearchField/WfsSearchField.tsx
@@ -27,6 +27,7 @@ export type WfsSearchFieldProps = {
   onBeforeSearch?: (value: string) => string;
   onChange?: (val: OlFeature[] | undefined) => undefined;
   value?: OlFeature[] | undefined;
+  visible?: boolean;
 } & SearchConfig & Omit<WfsQueryArgs, 'searchConfig' | 'searchTerm'> & Omit<AutoCompleteProps, 'onChange'>;
 
 const defaultClassName = `${CSS_PREFIX}wfssearch`;
@@ -63,6 +64,7 @@ export const WfsSearchField: FC<WfsSearchFieldProps> = ({
   wfsFormatOptions,
   onFetchError,
   onFetchSuccess,
+  visible,
   ...passThroughProps
 }) => {
 
@@ -226,6 +228,10 @@ export const WfsSearchField: FC<WfsSearchFieldProps> = ({
         value={searchTerm}
       />
     );
+  }
+
+  if (!visible) {
+    return null;
   }
 
   return (

--- a/src/Field/WfsSearchField/WfsSearchField.tsx
+++ b/src/Field/WfsSearchField/WfsSearchField.tsx
@@ -26,7 +26,7 @@ export type WfsSearchFieldProps = {
   onBeforeSearch?: (value: string) => string;
   onChange?: (val: OlFeature[] | undefined) => undefined;
   value?: OlFeature[] | undefined;
-} & SearchConfig & Omit<WfsQueryArgs, 'searchConfig'|'searchTerm'>;
+} & SearchConfig & Omit<WfsQueryArgs, 'searchConfig' | 'searchTerm'>;
 
 const defaultClassName = `${CSS_PREFIX}wfssearch`;
 

--- a/src/Field/WfsSearchField/WfsSearchField.tsx
+++ b/src/Field/WfsSearchField/WfsSearchField.tsx
@@ -7,6 +7,7 @@ import { SearchConfig } from '@terrestris/ol-util/dist/WfsFilterUtil/WfsFilterUt
 import useMap from '@terrestris/react-util/dist/Hooks/useMap/useMap';
 import { useWfs, WfsQueryArgs } from '@terrestris/react-util/dist/Hooks/useWfs/useWfs';
 import { AutoComplete, Input, Spin } from 'antd';
+import { AutoCompleteProps } from 'antd/lib/auto-complete';
 import { DefaultOptionType, OptionProps } from 'antd/lib/select';
 import _get from 'lodash/get';
 import _isNil from 'lodash/isNil';
@@ -26,7 +27,7 @@ export type WfsSearchFieldProps = {
   onBeforeSearch?: (value: string) => string;
   onChange?: (val: OlFeature[] | undefined) => undefined;
   value?: OlFeature[] | undefined;
-} & SearchConfig & Omit<WfsQueryArgs, 'searchConfig' | 'searchTerm'>;
+} & SearchConfig & Omit<WfsQueryArgs, 'searchConfig' | 'searchTerm'> & Omit<AutoCompleteProps, 'onChange'>;
 
 const defaultClassName = `${CSS_PREFIX}wfssearch`;
 


### PR DESCRIPTION
Pass through on fetch success callbacks in WfsSearchField and NominatimSearchField.

Makes WfsSearchField more similar to NominatimSearchFielf by passing through args to `useWfs` and `Autocomplete`.

## Description

<!-- Please give a short description of the changes you propose. Please use prose and try not to be too technical, if possible. Make sure to mention people that you think should know about the PR. -->

## Related issues or pull requests

<!-- Please list issues or pull requests that the changes you propose are related to. It does not matter if they are still open and/or unmerged, any link is appreciated. -->

## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [ ] Bugfix
- [x] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [ ] I understand and agree that the changes in this PR will be licensed under the
  [BSD-2-Clause](https://github.com/terrestris/react-geo/blob/main/LICENSE).
- [ ] I have followed the [guidelines for contributing](https://github.com/terrestris/react-geo/blob/main/CONTRIBUTING.md).
- [ ] The proposed change fits to the content of the [Code of Conduct](https://github.com/terrestris/react-geo/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally).
- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
