### PR TITLE
Render urls as anchor element

### DIFF
--- a/src/Grid/PropertyGrid/PropertyGrid.example.md
+++ b/src/Grid/PropertyGrid/PropertyGrid.example.md
@@ -13,7 +13,7 @@ const feature = new OlFeature({
 const attributeObject = {
   foo: 'bar',
   foo2: 'bar2',
-  foo3: 'bar3',
+  foo3: 'https://terrestris.github.io/react-geo/',
   foo9: 'bar9',
   name: 'Point'
 };

--- a/src/Grid/PropertyGrid/PropertyGrid.spec.tsx
+++ b/src/Grid/PropertyGrid/PropertyGrid.spec.tsx
@@ -15,7 +15,8 @@ describe('<PropertyGrid />', () => {
     foo: 'bar',
     bvb: 'yarmolenko',
     mip: 'map',
-    name: 'Point'
+    name: 'Point',
+    link: 'https://www.example.com'
   };
 
   testFeature.setProperties(attributeObject);
@@ -132,4 +133,22 @@ describe('<PropertyGrid />', () => {
       }
     });
   });
+
+  it('renders urls as links', () => {
+    const props = {
+      feature: testFeature
+    };
+    const wrapper = TestUtil.mountComponent(PropertyGrid, props);
+
+    const dataSource = wrapper.instance().getDataSource();
+    dataSource.forEach((dataSourceElement) => {
+      const attributeValue = dataSourceElement.attributeValue;
+      const renderedValue = wrapper.find('a').filterWhere((a) => a.text() === attributeValue);
+      if (dataSourceElement.attributeName === 'link') {
+        expect(renderedValue).toHaveLength(1);
+      } else {
+        expect(renderedValue).toHaveLength(0);
+      }
+    });
+  })
 });

--- a/src/Grid/PropertyGrid/PropertyGrid.tsx
+++ b/src/Grid/PropertyGrid/PropertyGrid.tsx
@@ -96,11 +96,15 @@ class PropertyGrid extends React.Component<PropertyGridProps> {
     return dataSource;
   }
 
+  isUrl(value: string) {
+    return /^(?:\w+:)?\/\/([^\s.]+\.\S{2}|localhost[:?\d]*)\S*$/.test(value);
+  }
+
   /**
    * Generates the column definition for the given feature.
    */
   getColumns() {
-    const columns = [{
+    const columns: TableProps<any>["columns"] = [{
       title: this.props.attributeNameColumnTitle,
       dataIndex: 'attributeName',
       key: 'attributeName',
@@ -109,7 +113,14 @@ class PropertyGrid extends React.Component<PropertyGridProps> {
       title: this.props.attributeValueColumnTitle,
       dataIndex: 'attributeValue',
       key: 'attributeValue',
-      width: `${100 - this.props.attributeNameColumnWidthInPercent}%`
+      width: `${100 - this.props.attributeNameColumnWidthInPercent}%`,
+      render: (value) => {
+        if (this.isUrl(value)) {
+          return <a href={value} target="_blank">{value}</a>;
+        } else {
+          return value;
+        }
+      }
     }];
 
     return columns;


### PR DESCRIPTION
## Description

This adds a custom `render` function for the `PropertyGrid` value column.

![image](https://github.com/terrestris/react-geo/assets/1849416/5b11a55f-1176-4ad5-b453-ce3ee3d16c4b)


If the value is a string an represents a link the value is renderer with an anchor element (`<a href="...">`).

<!-- Please give a short description of the changes you propose. Please use prose and try not to be too technical, if possible. Make sure to mention people that you think should know about the PR. -->

## Related issues or pull requests

<!-- Please list issues or pull requests that the changes you propose are related to. It does not matter if they are still open and/or unmerged, any link is appreciated. -->

## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [ ] Bugfix
- [x] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the
  [BSD-2-Clause](https://github.com/terrestris/react-geo/blob/main/LICENSE).
- [x] I have followed the [guidelines for contributing](https://github.com/terrestris/react-geo/blob/main/CONTRIBUTING.md).
- [x] The proposed change fits to the content of the [Code of Conduct](https://github.com/terrestris/react-geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally).
- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
