### PR TITLE
fix: remove visible prop from search fields

### DIFF
--- a/src/Field/NominatimSearch/NominatimSearch.tsx
+++ b/src/Field/NominatimSearch/NominatimSearch.tsx
@@ -30,16 +30,6 @@ interface OwnProps {
    */
   onSelect?: (item: NominatimPlace) => void;
   /**
-   * Indicate if we should render the input and results. When setting to false,
-   * you need to handle user input and result yourself
-   */
-  visible?: boolean;
-  /**
-   * The searchTerm may be given as prop. This is useful when setting
-   * `visible` to `false`.
-   */
-  searchTerm?: string;
-  /**
    * An optional CSS class which should be added.
    */
   className?: string;
@@ -75,7 +65,6 @@ export const NominatimSearch: FC<NominatimSearchProps> = ({
   renderOption,
   searchResultLanguage,
   viewBox,
-  visible = true,
   ...passThroughProps
 }) => {
 
@@ -167,10 +156,6 @@ export const NominatimSearch: FC<NominatimSearchProps> = ({
     }
   };
 
-  if (!visible) {
-    return null;
-  }
-
   return (
     <AutoComplete<string, any>
       className={className}
@@ -178,6 +163,7 @@ export const NominatimSearch: FC<NominatimSearchProps> = ({
       placeholder="Ortsname, Straßenname, Stadtteilname, POI usw."
       onChange={onValueChange}
       onSelect={onMenuItemSelected}
+      value={searchTerm}
       {...passThroughProps}
     >
       {

--- a/src/Field/WfsSearchField/WfsSearchField.tsx
+++ b/src/Field/WfsSearchField/WfsSearchField.tsx
@@ -27,8 +27,7 @@ export type WfsSearchFieldProps = {
   onBeforeSearch?: (value: string) => string;
   onChange?: (val: OlFeature[] | undefined) => undefined;
   value?: OlFeature[] | undefined;
-  visible?: boolean;
-} & SearchConfig & Omit<WfsQueryArgs, 'searchConfig' | 'searchTerm'> & Omit<AutoCompleteProps, 'onChange'>;
+} & SearchConfig & Omit<WfsQueryArgs, 'searchConfig'|'searchTerm'> & Omit<AutoCompleteProps, 'onChange'>;
 
 const defaultClassName = `${CSS_PREFIX}wfssearch`;
 
@@ -64,7 +63,6 @@ export const WfsSearchField: FC<WfsSearchFieldProps> = ({
   wfsFormatOptions,
   onFetchError,
   onFetchSuccess,
-  visible,
   ...passThroughProps
 }) => {
 
@@ -228,10 +226,6 @@ export const WfsSearchField: FC<WfsSearchFieldProps> = ({
         value={searchTerm}
       />
     );
-  }
-
-  if (!visible) {
-    return null;
   }
 
   return (


### PR DESCRIPTION
## Description

removes unnecessary `visible` prop from wfs and nominatim search fields.

## Related issues or pull requests

<!-- Please list issues or pull requests that the changes you propose are related to. It does not matter if they are still open and/or unmerged, any link is appreciated. -->

## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [x] Yes
- [ ] No

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the
  [BSD-2-Clause](https://github.com/terrestris/react-geo/blob/main/LICENSE).
- [ ] I have followed the [guidelines for contributing](https://github.com/terrestris/react-geo/blob/main/CONTRIBUTING.md).
- [ ] The proposed change fits to the content of the [Code of Conduct](https://github.com/terrestris/react-geo/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally).
- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
