### PR TITLE
fix: stop onDragStart propagation

### DIFF
--- a/src/LayerTree/LayerTree.tsx
+++ b/src/LayerTree/LayerTree.tsx
@@ -117,6 +117,7 @@ const LayerTree: React.FC<LayerTreeProps> = ({
       key: getUid(layer),
       title: <div
         onClick={e => e.stopPropagation()}
+        onDragStart={e => e.stopPropagation()}
       >
         {getTreeNodeTitle(layer)}
       </div>,


### PR DESCRIPTION
## Description

This stops the onDragStart event inside the title element

## Related issues or pull requests

<!-- Please list issues or pull requests that the changes you propose are related to. It does not matter if they are still open and/or unmerged, any link is appreciated. -->

## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the
  [BSD-2-Clause](https://github.com/terrestris/react-geo/blob/main/LICENSE).
- [ ] I have followed the [guidelines for contributing](https://github.com/terrestris/react-geo/blob/main/CONTRIBUTING.md).
- [ ] The proposed change fits to the content of the [Code of Conduct](https://github.com/terrestris/react-geo/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally).
- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
