### PR TITLE
fix: layerswitcher always shows next layer instead of current layer

### DIFF
--- a/src/LayerSwitcher/LayerSwitcher.spec.tsx
+++ b/src/LayerSwitcher/LayerSwitcher.spec.tsx
@@ -78,7 +78,11 @@ describe('<LayerSwitcher />', () => {
 
   it('switches the visible layer on click', async () => {
     const { container } = renderInMapContext(map, <LayerSwitcher layers={layers} />);
-    const switcher = within(container).getByRole('button');
+
+    // eslint-disable-next-line testing-library/no-container,testing-library/no-node-access
+    const layerSwitcher = container.querySelector('.react-geo-layer-switcher');
+
+    const switcher = within(layerSwitcher).getByRole('button');
 
     const layer0visible = layers[0].getVisible();
     const layer1visible = layers[1].getVisible();

--- a/src/LayerSwitcher/LayerSwitcher.spec.tsx
+++ b/src/LayerSwitcher/LayerSwitcher.spec.tsx
@@ -1,4 +1,5 @@
-import { render, screen,within } from '@testing-library/react';
+import { renderInMapContext } from '@terrestris/react-util/dist/Util/rtlTestUtils';
+import { screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import OlLayer from 'ol/layer/Layer';
 import OlLayerTile from 'ol/layer/Tile';
@@ -37,24 +38,24 @@ describe('<LayerSwitcher />', () => {
   });
 
   it('can be rendered', () => {
-    const { container } = render(<LayerSwitcher layers={layers} map={map} />);
+    const { container } = renderInMapContext(map, <LayerSwitcher layers={layers} />);
     expect(container).toBeVisible();
   });
 
   it('contains map element', () => {
-    const { container } = render(<LayerSwitcher layers={layers} map={map} />);
+    const { container } = renderInMapContext(map, <LayerSwitcher layers={layers} />);
     const mapElement = within(container).getByRole('menu');
     expect(mapElement).toBeVisible();
   });
 
   it('adds a custom className', () => {
-    render(<LayerSwitcher layers={layers} map={map} className="peter" />);
+    renderInMapContext(map, <LayerSwitcher layers={layers} className="peter" />);
     const firstChild = screen.getByRole('menu');
     expect(firstChild).toHaveClass('peter');
   });
 
   it('passes style prop', () => {
-    render(<LayerSwitcher layers={layers} map={map} style={{
+    renderInMapContext(map, <LayerSwitcher layers={layers} style={{
       backgroundColor: 'yellow',
       position: 'inherit'
     }} />);
@@ -68,7 +69,7 @@ describe('<LayerSwitcher />', () => {
   });
 
   it('sets all but one layer to invisible', () => {
-    render(<LayerSwitcher layers={layers} map={map} />);
+    renderInMapContext(map, <LayerSwitcher layers={layers} />);
     const layer0visibile = layers[0].getVisible();
     const layer1visibile = layers[1].getVisible();
     expect(layer0visibile && layer1visibile).toBe(false);
@@ -76,7 +77,7 @@ describe('<LayerSwitcher />', () => {
   });
 
   it('switches the visible layer on click', async () => {
-    const { container } = render(<LayerSwitcher layers={layers} map={map} />);
+    const { container } = renderInMapContext(map, <LayerSwitcher layers={layers} />);
     const switcher = within(container).getByRole('button');
 
     const layer0visible = layers[0].getVisible();
@@ -90,7 +91,7 @@ describe('<LayerSwitcher />', () => {
 
   it('assumes the first provided layer as visible if the initial visibility of all layers is false', () => {
     layers.forEach(l => l.setVisible(false));
-    render(<LayerSwitcher layers={layers} map={map} />);
+    renderInMapContext(map, <LayerSwitcher layers={layers} />);
     expect(layers[0].getVisible()).toBeTruthy();
   });
 


### PR DESCRIPTION
## Description

this changes the LayerSwitcher Component so it always shows the next layer instead of the current one.

![Peek 2024-06-04 17-28](https://github.com/terrestris/react-geo/assets/8100558/96c1ae32-7632-450f-8801-9fdb0466b72a)

## Related issues or pull requests

<!-- Please list issues or pull requests that the changes you propose are related to. It does not matter if they are still open and/or unmerged, any link is appreciated. -->

## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the
  [BSD-2-Clause](https://github.com/terrestris/react-geo/blob/main/LICENSE).
- [ ] I have followed the [guidelines for contributing](https://github.com/terrestris/react-geo/blob/main/CONTRIBUTING.md).
- [ ] The proposed change fits to the content of the [Code of Conduct](https://github.com/terrestris/react-geo/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally).
- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
