### PR TITLE
fix: use antd css variables to make button active

### DIFF
--- a/src/Button/ToggleButton/ToggleButton.example.md
+++ b/src/Button/ToggleButton/ToggleButton.example.md
@@ -75,3 +75,39 @@ const StandaloneToggleButton = () => {
 
 <StandaloneToggleButton />
 ```
+
+A ToggleButton with a different type and a customized theme:
+
+```jsx
+import ToggleButton from '@terrestris/react-geo/dist/Button/ToggleButton/ToggleButton';
+import {ConfigProvider} from 'antd';
+import * as React from 'react';
+
+const StandaloneToggleButton = () => {
+  const [pressed, setPressed] = React.useState();
+
+  return (
+    <ConfigProvider theme={{
+      cssVar: true,
+      components: {
+        Button: {
+          defaultActiveBg: 'lightgreen'
+        }
+      },
+      token: {
+        colorBgBase: 'lightblue'
+      }
+    }}>
+      <ToggleButton
+        type="dashed"
+        pressed={pressed}
+        onChange={() => setPressed(!pressed)}
+      >
+        Toggle me
+      </ToggleButton>
+    </ConfigProvider>
+  );
+};
+
+<StandaloneToggleButton />
+```

--- a/src/Button/ToggleButton/ToggleButton.less
+++ b/src/Button/ToggleButton/ToggleButton.less
@@ -1,0 +1,25 @@
+.react-geo-togglebutton.btn-pressed.ant-btn-primary {
+  color: var(--ant-color-text-light-solid, #fff);
+  background: var(--ant-color-primary-active, #0958d9);
+}
+
+.react-geo-togglebutton.btn-pressed.ant-btn-default {
+  color: var(--ant-button-default-active-color, #0958d9);
+  border-color: var(--ant-button-default-active-border-color, #0958d9);
+  background: var(--ant-button-default-active-bg, #ffffff);
+}
+
+.react-geo-togglebutton.btn-pressed.ant-btn-link {
+  color: var(--ant-color-link-active, #0958d9);
+}
+
+.react-geo-togglebutton.btn-pressed.ant-btn-dashed {
+  color: var(--ant-button-default-active-color, #0958d9);
+  border-color: var(--ant-button-default-active-border-color, #0958d9);
+  background: var(--ant-button-default-active-bg, #ffffff);
+}
+
+.react-geo-togglebutton.btn-pressed.ant-btn-text {
+  color: var(--ant-color-text, rgba(0, 0, 0, 0.88));
+  background: var(--ant-color-bg-text-active, rgba(0, 0, 0, 0.15));
+}

--- a/src/Button/ToggleButton/ToggleButton.tsx
+++ b/src/Button/ToggleButton/ToggleButton.tsx
@@ -1,6 +1,7 @@
+import './ToggleButton.less';
+
 import {
   Button,
-  theme,
   Tooltip
 } from 'antd';
 import {
@@ -10,10 +11,6 @@ import {
 import React, {
   MouseEvent
 } from 'react';
-
-const { useToken } = theme;
-
-import _isFunction from 'lodash/isFunction';
 
 import { CSS_PREFIX } from '../../constants';
 import { SimpleButtonProps } from '../SimpleButton/SimpleButton';
@@ -58,11 +55,6 @@ interface OwnProps {
    * The onChange callback.
    */
   onChange?: (evt: MouseEvent<HTMLButtonElement>, value?: string) => void;
-
-  /**
-   * Sets button background to transparent instead of primary color.
-   */
-  buttonTransparent?: boolean;
 }
 
 export type ToggleButtonProps = OwnProps & Omit<SimpleButtonProps, 'onChange' | 'value'>;
@@ -82,11 +74,8 @@ export const ToggleButton: React.FC<ToggleButtonProps> = ({
   value,
   onClick,
   onChange = () => {},
-  buttonTransparent = false,
   ...passThroughProps
 }) => {
-
-  const token = useToken();
 
   const handleChange = (evt: React.MouseEvent<HTMLButtonElement>) => {
     if (onClick) {
@@ -118,14 +107,6 @@ export const ToggleButton: React.FC<ToggleButtonProps> = ({
       {...tooltipProps}
     >
       <Button
-        style={{
-          backgroundColor:
-            buttonTransparent
-              ? 'transparent'
-              : pressed
-                ? token.token.colorPrimaryActive
-                : token.token.colorPrimary
-        }}
         type={type}
         onClick={handleChange}
         onChange={onChange}

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,8 +20,8 @@ export { FeatureLabelModal } from './FeatureLabelModal/FeatureLabelModal';
 export {
   default as CoordinateReferenceSystemCombo
 } from './Field/CoordinateReferenceSystemCombo/CoordinateReferenceSystemCombo';
-export { SearchField } from './Field/SearchField/SearchField';
 export { default as ScaleCombo } from './Field/ScaleCombo/ScaleCombo';
+export { SearchField } from './Field/SearchField/SearchField';
 export { AgFeatureGrid } from './Grid/AgFeatureGrid/AgFeatureGrid';
 export { FeatureGrid } from './Grid/FeatureGrid/FeatureGrid';
 export { default as PropertyGrid } from './Grid/PropertyGrid/PropertyGrid';


### PR DESCRIPTION
BREAKING CHANGE: This removes the buttonTransparent property. See the example on how to customize the color via the ConfigProvider.

## Description

By using the antd css variables we do not override the backgroundColor while still being able to style the button via the antd theming.

## Related issues or pull requests

<!-- Please list issues or pull requests that the changes you propose are related to. It does not matter if they are still open and/or unmerged, any link is appreciated. -->

## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [ ] Bugfix
- [x] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [x] Yes
- [ ] No

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the
  [BSD-2-Clause](https://github.com/terrestris/react-geo/blob/main/LICENSE).
- [ ] I have followed the [guidelines for contributing](https://github.com/terrestris/react-geo/blob/main/CONTRIBUTING.md).
- [ ] The proposed change fits to the content of the [Code of Conduct](https://github.com/terrestris/react-geo/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally).
- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
