### PR TITLE
feat: update coordinate button to use the new result value

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@fortawesome/react-fontawesome": "^0.2.2",
         "@terrestris/base-util": "^2.0.0",
         "@terrestris/ol-util": ">=18",
-        "@terrestris/react-util": "^8.0.0",
+        "@terrestris/react-util": "^8.0.2",
         "@types/lodash": "^4.17.4",
         "ag-grid-community": "^31.3.2",
         "ag-grid-react": "^31.3.2",
@@ -5689,9 +5689,9 @@
       }
     },
     "node_modules/@terrestris/react-util": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@terrestris/react-util/-/react-util-8.0.0.tgz",
-      "integrity": "sha512-VlNYxK7Whj7/Z4NCEGOkZ2ANDmHhoD8fp70hIkJz1DARAet/++YBCFZ2wce6E2PB9A7tlMr4INUcKiT/gggd0g==",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@terrestris/react-util/-/react-util-8.0.2.tgz",
+      "integrity": "sha512-oTnGqpgl/ayBZBXLR2Aa4Yb4xNxgarTzMcg4u5ECNjokX+C7FS1P4yjmHLts/2D9oVabpae2VV1byZw736bUCQ==",
       "dependencies": {
         "@camptocamp/inkmap": "^1.4.0",
         "@terrestris/base-util": "^2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@fortawesome/react-fontawesome": "^0.2.2",
         "@terrestris/base-util": "^2.0.0",
         "@terrestris/ol-util": ">=18",
-        "@terrestris/react-util": "^7.0.0",
+        "@terrestris/react-util": "^8.0.0",
         "@types/lodash": "^4.17.4",
         "ag-grid-community": "^31.3.2",
         "ag-grid-react": "^31.3.2",
@@ -5689,9 +5689,9 @@
       }
     },
     "node_modules/@terrestris/react-util": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@terrestris/react-util/-/react-util-7.0.0.tgz",
-      "integrity": "sha512-UI5ohQVD00T4taieId4efi0cJ1CFVS7Nti8Hbo2zNEiYIBOBO7F02WDQEMRWcMXcu2ZTsFtziDH9TOtulX0ttQ==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@terrestris/react-util/-/react-util-8.0.0.tgz",
+      "integrity": "sha512-VlNYxK7Whj7/Z4NCEGOkZ2ANDmHhoD8fp70hIkJz1DARAet/++YBCFZ2wce6E2PB9A7tlMr4INUcKiT/gggd0g==",
       "dependencies": {
         "@camptocamp/inkmap": "^1.4.0",
         "@terrestris/base-util": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "@fortawesome/react-fontawesome": "^0.2.2",
     "@terrestris/base-util": "^2.0.0",
     "@terrestris/ol-util": ">=18",
-    "@terrestris/react-util": "^7.0.0",
+    "@terrestris/react-util": "^8.0.0",
     "@types/lodash": "^4.17.4",
     "ag-grid-community": "^31.3.2",
     "ag-grid-react": "^31.3.2",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "@fortawesome/react-fontawesome": "^0.2.2",
     "@terrestris/base-util": "^2.0.0",
     "@terrestris/ol-util": ">=18",
-    "@terrestris/react-util": "^8.0.0",
+    "@terrestris/react-util": "^8.0.2",
     "@types/lodash": "^4.17.4",
     "ag-grid-community": "^31.3.2",
     "ag-grid-react": "^31.3.2",

--- a/src/CoordinateInfo/CoordinateInfo.example.md
+++ b/src/CoordinateInfo/CoordinateInfo.example.md
@@ -109,7 +109,7 @@ const CoordinateInfoExample = () => {
           };
 
           return (
-            Object.keys(features).length === 1 && features[Object.keys(features)[0]].length === 1 ?
+            features.length > 0 ?
               <div>
                 <div
                   style={{
@@ -155,8 +155,8 @@ const CoordinateInfoExample = () => {
                   >
                     <Statistic
                       title="State"
-                      value={getValue(features[Object.keys(features)[0]][0], 'STATE_NAME')
-                        || getValue(features[Object.keys(features)[0]][0], 'name')}
+                      value={getValue(features[0].feature, 'STATE_NAME')
+                        || getValue(features[0].feature, 'name')}
                     />
                   </Spin>
                   <Tooltip
@@ -166,7 +166,7 @@ const CoordinateInfoExample = () => {
                       style={{ marginTop: 16 }}
                       type="primary"
                       onClick={() => {
-                        copy(features[Object.keys(features)[0]][0].get('STATE_NAME'));
+                        copy(features[0].feature.get('STATE_NAME'));
                       }}
                       icon={
                         <FontAwesomeIcon
@@ -177,7 +177,9 @@ const CoordinateInfoExample = () => {
                   </Tooltip>
                 </div>
               </div> :
-              <span>Click on a state to get details about the clicked coordinate.</span>
+              <span>
+                Click on a state to get details about the clicked coordinate.
+              </span>
           );
         }}
       />


### PR DESCRIPTION
BREAKING CHANGE: The input of the render function is no longer grouped by featureType
 but returns an object for each feature that contains the feature, the layer and the feature type.

If you need the grouping, you can do the following

```
import { groupBy, mapValues } from 'lodash';

<CoordinateInfo
  resultRenderer={({ features }) => {
    const grouped = groupBy(features, 'featureType');
    const groupedAndMapped = mapValues(grouped, results => results.map(r => r.feature));
    // ...
  }}
/>
```

## Description

See https://github.com/terrestris/react-util/pull/733

## Related issues or pull requests

<!-- Please list issues or pull requests that the changes you propose are related to. It does not matter if they are still open and/or unmerged, any link is appreciated. -->

## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [ ] Bugfix
- [x] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [x] Yes
- [ ] No

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the
  [BSD-2-Clause](https://github.com/terrestris/react-geo/blob/main/LICENSE).
- [ ] I have followed the [guidelines for contributing](https://github.com/terrestris/react-geo/blob/main/CONTRIBUTING.md).
- [ ] The proposed change fits to the content of the [Code of Conduct](https://github.com/terrestris/react-geo/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally).
- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
