### PR TITLE
fix: adjust some css nesting, allows for use of the table scroll property without breaking the css

### DIFF
--- a/src/Grid/PropertyGrid/PropertyGrid.less
+++ b/src/Grid/PropertyGrid/PropertyGrid.less
@@ -11,36 +11,36 @@
       height: 100%;
       display: flex;
       flex-direction: column;
+    }
+  }
 
-      .ant-table {
-        flex: 1;
+  .ant-table {
+    flex: 1;
 
-        .ant-table-fixed-header .ant-table-header {
-          margin-bottom: inherit !important; // Inline style from antd
-          padding-bottom: inherit !important; // Inline style from antd
-        }
+    .ant-table-fixed-header .ant-table-header {
+      margin-bottom: inherit !important; // Inline style from antd
+      padding-bottom: inherit !important; // Inline style from antd
+    }
 
-        .ant-table-content {
-          height: 100%;
-          display: flex;
-          flex-direction: column;
+    .ant-table-container {
+      height: 100%;
+      display: flex;
+      flex-direction: column;
 
-          .ant-table-header {
-            overflow: inherit;
-          }
+      .ant-table-header {
+        overflow: inherit;
+      }
 
-          .ant-table-body {
-            overflow: auto;
-          }
+      .ant-table-body {
+        overflow: auto;
+      }
 
-          .ant-table-cell {
-            padding: 4px;
-          }
+      .ant-table-cell {
+        padding: 4px;
+      }
 
-          th {
-            text-align: center;
-          }
-        }
+      th {
+        text-align: center;
       }
     }
   }

--- a/src/Grid/PropertyGrid/PropertyGrid.tsx
+++ b/src/Grid/PropertyGrid/PropertyGrid.tsx
@@ -23,7 +23,7 @@ interface OwnProps {
   attributeNameColumnTitle?: string;
   /**
    * Value in percent representing the width of the attribute name column
-   * The width of attribute value column wil be calculated depending in this
+   * The width of the attribute value column will be calculated based on this
    */
   attributeNameColumnWidthInPercent?: number;
   /**


### PR DESCRIPTION
## Description

![image](https://github.com/terrestris/react-geo/assets/8100558/159c9fd5-c345-4bbd-a138-16d5db434fdd)

## Related issues or pull requests

<!-- Please list issues or pull requests that the changes you propose are related to. It does not matter if they are still open and/or unmerged, any link is appreciated. -->

## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the
  [BSD-2-Clause](https://github.com/terrestris/react-geo/blob/main/LICENSE).
- [ ] I have followed the [guidelines for contributing](https://github.com/terrestris/react-geo/blob/main/CONTRIBUTING.md).
- [ ] The proposed change fits to the content of the [Code of Conduct](https://github.com/terrestris/react-geo/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally).
- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
