### PR TITLE
feat: add onFeatureSelect listener to modify button

### DIFF
--- a/src/Button/MeasureButton/MeasureButton.less
+++ b/src/Button/MeasureButton/MeasureButton.less
@@ -1,6 +1,6 @@
 .react-geo-measure-tooltip {
   position: relative;
-  background: var(--measure-dynamic-tooltip-background-color, rgba(0, 0, 0, 0.5););
+  background: var(--measure-dynamic-tooltip-background-color, rgba(0, 0, 0, 0.5));
   border-radius: 4px;
   color: white;
   padding: 4px 8px;

--- a/src/Button/ModifyButton/ModifyButton.tsx
+++ b/src/Button/ModifyButton/ModifyButton.tsx
@@ -46,7 +46,7 @@ interface OwnProps {
   editLabel?: boolean;
 }
 
-export type ModifyButtonProps = OwnProps & Omit<UseModifyProps, 'active' | 'onFeatureSelect'> &
+export type ModifyButtonProps = OwnProps & Omit<UseModifyProps, 'active'> &
   Partial<ToggleButtonProps>;
 
 /**
@@ -57,6 +57,7 @@ const defaultClassName = `${CSS_PREFIX}modifybutton`;
 export const ModifyButton: React.FC<ModifyButtonProps> = ({
   className,
   hitTolerance = 5,
+  onFeatureSelect,
   onModifyStart,
   onModifyEnd,
   onTranslateStart,
@@ -79,12 +80,13 @@ export const ModifyButton: React.FC<ModifyButtonProps> = ({
 }) => {
   const [editLabelFeature, setEditLabelFeature] = useState<OlFeature<OlGeometry>|null>(null);
 
-  const onFeatureSelect = useCallback((event: OlSelectEvent) => {
+  const onFeatureSelectInternal = useCallback((event: OlSelectEvent) => {
     if (editLabel) {
       const labeled = event.selected.find(f => f.get('isLabel'));
       setEditLabelFeature(labeled || null);
     }
-  }, [editLabel]);
+    onFeatureSelect?.(event);
+  }, [editLabel, onFeatureSelect]);
 
   useModify({
     selectStyle,
@@ -98,7 +100,7 @@ export const ModifyButton: React.FC<ModifyButtonProps> = ({
     active: !!pressed,
     modifyInteractionConfig,
     translateInteractionConfig,
-    onFeatureSelect,
+    onFeatureSelect: onFeatureSelectInternal,
     hitTolerance
   });
 


### PR DESCRIPTION
## Description

add onFeatureSelect listener to modify button

## Related issues or pull requests

<!-- Please list issues or pull requests that the changes you propose are related to. It does not matter if they are still open and/or unmerged, any link is appreciated. -->

## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [ ] Bugfix
- [x] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the
  [BSD-2-Clause](https://github.com/terrestris/react-geo/blob/main/LICENSE).
- [x] I have followed the [guidelines for contributing](https://github.com/terrestris/react-geo/blob/main/CONTRIBUTING.md).
- [x] The proposed change fits to the content of the [Code of Conduct](https://github.com/terrestris/react-geo/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally).
- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
