### PR TITLE
Tweaks the `TimeLayerSliderPanel` in design and functionality

### DIFF
--- a/src/Panel/TimeLayerSliderPanel/TimeLayerSliderPanel.example.md
+++ b/src/Panel/TimeLayerSliderPanel/TimeLayerSliderPanel.example.md
@@ -25,7 +25,7 @@ class TimeLayerSliderPanelExample extends React.Component {
       new OlLayerTile({
         extent: extent,
         type: 'WMSTime',
-        timeFormat: 'YYYY-MM-DDTHH:mm:ss.sssZ',
+        timeFormat: 'YYYY-MM-DDTHH:mm',
         roundToFullHours: true,
         source: new OlSourceTileWMS({
           attributions: ['Iowa State University'],
@@ -79,6 +79,7 @@ class TimeLayerSliderPanelExample extends React.Component {
           timeAwareLayers={this.layers}
           tooltips={tooltips}
           autoPlaySpeedOptions={[0.5, 1, 2, 3, 4, 5, 600]}
+          dateFormat='YYYY-MM-DD HH:mm'
         />
       </div>
     );

--- a/src/Panel/TimeLayerSliderPanel/TimeLayerSliderPanel.less
+++ b/src/Panel/TimeLayerSliderPanel/TimeLayerSliderPanel.less
@@ -1,22 +1,23 @@
 .time-layer-slider {
-  bottom: 35px;
   display: flex;
-  justify-content: center;
+  flex-direction: row;
+  justify-content: flex-start;
   align-items: center;
+  gap: 15px;
   width: 100%;
   background-color: white;
-  border-bottom: 1px solid lightgray;
+  padding: 10px 0;
 
   button {
     margin-left: 5px;
   }
 
   .timeslider {
-    flex: 1;
-    margin: 10px;
+    flex: 1 1 0;
+    min-width: 0;
 
     &.ant-slider-with-marks {
-      margin: 10px 60px 20px 60px;
+      margin: 10px 20px 20px 20px;
     }
   }
 
@@ -26,8 +27,14 @@
     }
   }
 
-  .playback {
+  .playback,
+  .speed-picker {
     border-radius: 2px 0 0 2px;
+    flex: 0 0 auto;
+  }
+
+  .speed-picker {
+    margin-right: 20px;
   }
 
   .ant-select-selection {
@@ -39,21 +46,48 @@
 
   .time-value {
     text-align: center;
-    width: 100px;
-    padding: 0 10px;
     font-weight: bold;
+    flex: 0 0 auto;
+    overflow: hidden;
+    max-width: 100px;
+    font-size: 1.0em;
+    white-space: normal;
+    overflow-wrap: break-word;
+    display: inline-block;
   }
 
   &.no-layers-available {
     pointer-events: none;
-    opacity: .8;
+    opacity: 0.8;
     color: rgba(0, 0, 0, 0.35);
     .ant-slider-mark span,
     .ant-select {
-     color: rgba(0, 0, 0, 0.35);
+      color: rgba(0, 0, 0, 0.35);
     }
     button {
-      opacity: .5;
+      opacity: 0.5;
     }
+  }
+
+  .ant-slider-mark-text {
+    max-width: 80px;
+    white-space: normal;
+    word-wrap: break-word;
+    text-align: center;
+    font-size: small;
+    display: inline-block;
+    overflow: hidden;
+  }
+
+  .ant-slider-mark-text:hover {
+    overflow: visible;
+    white-space: normal;
+    background: #fff;
+    border: 1px solid #d9d9d9;
+    padding: 4px;
+    border-radius: 4px;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+    z-index: 10;
+    position: absolute;
   }
 }


### PR DESCRIPTION
## Description

The adjustments proposed here will improve the design and functionality of the TimeLayerSliderPanel. 

* Spacing between elements has been added and the positioning of the mark labels has been adjusted. 
* The "Set to now button" is reasonably changed to "Set to most recent Date" to call up the last available time. 
* Debouncing has been introduced in the queries so that no long list of queries is generated when the slider is moved, but only the current selected time.
* In addition, the date format of the example has been minimally adjusted.

![image](https://github.com/user-attachments/assets/66ef262b-d437-4d45-9ae9-b47d46e5a62a)

@terrestris/devs please review

## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [ ] Bugfix
- [x] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the
  [BSD-2-Clause](https://github.com/terrestris/react-geo/blob/main/LICENSE).
- [x] I have followed the [guidelines for contributing](https://github.com/terrestris/react-geo/blob/main/CONTRIBUTING.md).
- [x] The proposed change fits to the content of the [Code of Conduct](https://github.com/terrestris/react-geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally).
- [x] I have added a screenshot/screencast to illustrate the visual output of my update.
