### PR TITLE
Further TimeLayerSliderPanel updates (loading spin)

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -22,7 +22,7 @@ module.exports = {
   transformIgnorePatterns: [
     'node_modules/(?!(ol|@camptocamp/inkmap|@terrestris/*[a-z]*-util|d3-selection|color-*[a-z]*)|(rc-*[a-z]*)|' +
     'filter-obj|query-string|decode-uri-component|split-on-first|shpjs/|rbush|quickselect|geostyler-openlayers-parser|' +
-    'geostyler-style)'
+    'geostyler-style|geotiff|quick-lru)'
   ],
   setupFiles: [
     '<rootDir>/jest/__mocks__/matchMediaMock.js'

--- a/src/Panel/TimeLayerSliderPanel/TimeLayerSliderPanel.example.md
+++ b/src/Panel/TimeLayerSliderPanel/TimeLayerSliderPanel.example.md
@@ -78,7 +78,7 @@ class TimeLayerSliderPanelExample extends React.Component {
           initEndDate={moment()}
           timeAwareLayers={this.layers}
           tooltips={tooltips}
-          autoPlaySpeedOptions={[0.5, 1, 2, 3, 4, 5, 600]}
+          autoPlaySpeedOptions={[0.5, 1, 2, 3]}
           dateFormat='YYYY-MM-DD HH:mm'
         />
       </div>

--- a/src/Panel/TimeLayerSliderPanel/TimeLayerSliderPanel.less
+++ b/src/Panel/TimeLayerSliderPanel/TimeLayerSliderPanel.less
@@ -7,17 +7,39 @@
   width: 100%;
   background-color: white;
   padding: 10px 0;
+  position: relative;
 
   button {
     margin-left: 5px;
   }
 
-  .timeslider {
-    flex: 1 1 0;
-    min-width: 0;
+  .time-slider-container {
+    display: flex;
+    align-items: center;
+    width: 100%;
+    position: relative;
 
-    &.ant-slider-with-marks {
-      margin: 10px 20px 20px 20px;
+    .timeslider {
+      flex: 1 1 0;
+      min-width: 0;
+
+      &.ant-slider-with-marks {
+        margin: 10px 20px 20px 20px;
+      }
+    }
+
+    .spin-indicator {
+      margin-left: 10px;
+      width: 24px;
+      height: 24px;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+
+      .ant-spin {
+        width: 16px;
+        height: 16px;
+      }
     }
   }
 
@@ -50,7 +72,7 @@
     flex: 0 0 auto;
     overflow: hidden;
     max-width: 100px;
-    font-size: 1.0em;
+    font-size: 1em;
     white-space: normal;
     overflow-wrap: break-word;
     display: inline-block;

--- a/src/Panel/TimeLayerSliderPanel/TimeLayerSliderPanel.tsx
+++ b/src/Panel/TimeLayerSliderPanel/TimeLayerSliderPanel.tsx
@@ -313,10 +313,10 @@ export const TimeLayerSliderPanel: React.FC<TimeLayerSliderPanelProps> = memo(
 
         if (_isFinite(playbackSpeed)) {
           wmsTimeHandler(
-            moment(newValue.clone().add(playbackSpeed, 'seconds').format())
+            moment(newValue.clone().add(playbackSpeed, 'hours').format())
           );
           setCurrentValue(
-            moment(newValue.clone().add(playbackSpeed, 'seconds').format())
+            moment(newValue.clone().add(playbackSpeed, 'hours').format())
           );
         } else {
           const time = moment(
@@ -502,7 +502,7 @@ export const TimeLayerSliderPanel: React.FC<TimeLayerSliderPanelProps> = memo(
           pressedIcon={<FontAwesomeIcon icon={faPauseCircle} />}
         />
         <Select
-          defaultValue={1}
+          defaultValue={'hours'}
           className={extraCls + ' speed-picker'}
           onChange={onPlaybackSpeedChange}
           popupMatchSelectWidth={false}


### PR DESCRIPTION
## Description

This MR makes further adjustments to the `TimeLayerSliderPanel` and implements a spin to display the loading activity. The default of the autoplay function is set from seconds to hours.

@terrestris/devs please review

## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [ ] Bugfix
- [x] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the
  [BSD-2-Clause](https://github.com/terrestris/react-geo/blob/main/LICENSE).
- [x] I have followed the [guidelines for contributing](https://github.com/terrestris/react-geo/blob/main/CONTRIBUTING.md).
- [x] The proposed change fits to the content of the [Code of Conduct](https://github.com/terrestris/react-geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added or updated tests and documentation, and the test suite passes (run `npm run check` locally).
- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
