### PR TITLE
fix: correct variable name for column definitions in checkbox selecti…

### DIFF
--- a/src/Grid/AgFeatureGrid/AgFeatureGrid.tsx
+++ b/src/Grid/AgFeatureGrid/AgFeatureGrid.tsx
@@ -572,8 +572,10 @@ export function AgFeatureGrid<T>({
         return columnDefs;
       }
       // check for checkbox column - if not present => add
-      const checkboxSelectionPresent = colDefs?.
-        some((colDef: ColDef<WithKey<T>>) => _has(colDef, 'checkboxSelection') && !_isNil(colDef.checkboxSelection));
+      const checkboxSelectionPresent = columnDefs?.
+        some((colDef: ColDef<WithKey<T>>) =>
+          _has(colDef, 'checkboxSelection') && !_isNil(colDef.checkboxSelection)
+        );
       if (checkboxSelectionPresent) {
         return columnDefs;
       }


### PR DESCRIPTION
## Description

This PR fixes a minor issue where the variable name used to check for the presence of `checkboxSelection` in column definitions was incorrect. The variable `colDefs` was renamed to `columnDefs` as `colDefs` was used before it was initialized.

@terrestris/devs please review

## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the
  [BSD-2-Clause](https://github.com/terrestris/react-geo/blob/main/LICENSE).
- [x] I have followed the [guidelines for contributing](https://github.com/terrestris/react-geo/blob/main/CONTRIBUTING.md).
- [x] The proposed change fits to the content of the [Code of Conduct](https://github.com/terrestris/react-geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added or updated tests and documentation, and the test suite passes (run `npm run check` locally).
- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
