### PR TITLE
Add optional layer visibility change callback

### DIFF
--- a/src/LayerTree/LayerTree.tsx
+++ b/src/LayerTree/LayerTree.tsx
@@ -48,7 +48,7 @@ interface OwnProps {
   nodeTitleRenderer?: (layer: OlLayerBase) => React.ReactNode;
 
   /**
-   * Callback function, that will be called if the selection changes.
+   * Callback function that will be called if the selection changes.
    */
   onLayerVisibilityChanged?: (layer: OlLayerBase, checked: boolean) => void;
 }

--- a/src/LayerTree/LayerTree.tsx
+++ b/src/LayerTree/LayerTree.tsx
@@ -46,6 +46,11 @@ interface OwnProps {
    * the layer instance of the current tree node.
    */
   nodeTitleRenderer?: (layer: OlLayerBase) => React.ReactNode;
+
+  /**
+   * Callback function, that will be called if the selection changes.
+   */
+  onLayerVisibilityChanged?: (layer: OlLayerBase, checked: boolean) => void;
 }
 
 const defaultClassName = `${CSS_PREFIX}layertree`;
@@ -57,6 +62,7 @@ const LayerTree: React.FC<LayerTreeProps> = ({
   layerGroup,
   nodeTitleRenderer,
   filterFunction,
+  onLayerVisibilityChanged,
   checkable = true,
   draggable = true,
   ...passThroughProps
@@ -245,6 +251,10 @@ const LayerTree: React.FC<LayerTreeProps> = ({
     }
 
     setLayerVisibility(layer, checked);
+
+    if (_isFunction(onLayerVisibilityChanged)) {
+      onLayerVisibilityChanged(layer, checked);
+    }
   }, [map, setLayerVisibility]);
 
   const onDrop = useCallback((info: NodeDragEventParams<DataNode> & {

--- a/src/LayerTree/LayerTree.tsx
+++ b/src/LayerTree/LayerTree.tsx
@@ -255,7 +255,7 @@ const LayerTree: React.FC<LayerTreeProps> = ({
     if (_isFunction(onLayerVisibilityChanged)) {
       onLayerVisibilityChanged(layer, checked);
     }
-  }, [map, setLayerVisibility]);
+  }, [map, setLayerVisibility, onLayerVisibilityChanged]);
 
   const onDrop = useCallback((info: NodeDragEventParams<DataNode> & {
     dragNode: EventDataNode<DataNode>;


### PR DESCRIPTION
## Description

<!-- Please give a short description of the changes you propose. Please use prose and try not to be too technical, if possible. Make sure to mention people that you think should know about the PR. -->

This allows to be notified whenever a layer is checked / unchecked, which was previously not possible. Overriding `onCheck` does not work for this, as it breaks the selection completely.

@terrestris/devs Please review

## Related issues or pull requests

<!-- Please list issues or pull requests that the changes you propose are related to. It does not matter if they are still open and/or unmerged, any link is appreciated. -->

## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [ ] Bugfix
- [x] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the
  [BSD-2-Clause](https://github.com/terrestris/react-geo/blob/main/LICENSE).
- [x] I have followed the [guidelines for contributing](https://github.com/terrestris/react-geo/blob/main/CONTRIBUTING.md).
- [x] The proposed change fits to the content of the [Code of Conduct](https://github.com/terrestris/react-geo/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm run check` locally).
- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
