### PR TITLE
Enable drawbutton autofocus on text area

### DIFF
--- a/src/FeatureLabelModal/FeatureLabelModal.tsx
+++ b/src/FeatureLabelModal/FeatureLabelModal.tsx
@@ -1,10 +1,10 @@
 import StringUtil from '@terrestris/base-util/dist/StringUtil/StringUtil';
-import { Modal, ModalProps } from 'antd';
+import { InputRef, Modal, ModalProps } from 'antd';
 import TextArea from 'antd/lib/input/TextArea';
 import Feature from 'ol/Feature';
 import Geometry from 'ol/geom/Geometry';
 import * as React from 'react';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 type OwnProps = {
   feature: Feature<Geometry>;
@@ -28,6 +28,8 @@ export const FeatureLabelModal: React.FC<FeatureLabelModalProps> = ({
 }) => {
   const [label, setLabel] = useState<string>('');
   const [showPrompt, setShowPrompt] = useState<boolean>(false);
+
+  const inputRef = useRef<InputRef>(null);
 
   useEffect(() => {
     if (feature) {
@@ -55,12 +57,16 @@ export const FeatureLabelModal: React.FC<FeatureLabelModalProps> = ({
     closable={false}
     onOk={onOkInternal}
     onCancel={onCancel}
+    afterOpenChange={(open) => {
+      open && inputRef.current?.focus();
+    }}
     {...passThroughProps}
   >
     <TextArea
       value={label}
       onChange={e => setLabel(e.target.value)}
       autoSize
+      ref={inputRef}
     />
   </Modal>;
 };

--- a/src/FeatureLabelModal/FeatureLabelModal.tsx
+++ b/src/FeatureLabelModal/FeatureLabelModal.tsx
@@ -58,7 +58,9 @@ export const FeatureLabelModal: React.FC<FeatureLabelModalProps> = ({
     onOk={onOkInternal}
     onCancel={onCancel}
     afterOpenChange={(open) => {
-      open && inputRef.current?.focus();
+      if (open) {
+        inputRef.current?.focus();
+      }
     }}
     {...passThroughProps}
   >


### PR DESCRIPTION
## Description

<!-- Please give a short description of the changes you propose. Please use prose and try not to be too technical, if possible. Make sure to mention people that you think should know about the PR. -->

Simply setting `autoFocus` will not work because antd renders the modal outside of the root element. See also https://github.com/ant-design/ant-design/issues/8668

@terrestris/devs Please review

## Related issues or pull requests

<!-- Please list issues or pull requests that the changes you propose are related to. It does not matter if they are still open and/or unmerged, any link is appreciated. -->

## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the
  [BSD-2-Clause](https://github.com/terrestris/react-geo/blob/main/LICENSE).
- [x] I have followed the [guidelines for contributing](https://github.com/terrestris/react-geo/blob/main/CONTRIBUTING.md).
- [x] The proposed change fits to the content of the [Code of Conduct](https://github.com/terrestris/react-geo/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm run check` locally).
- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
