### PR TITLE
Ag grid update theming

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,12 +23,23 @@ For a full list of available components, their properties and examples see [here
 
 The `react-geo` package includes TypeScript declarations as `*.d.ts` files. The build itself is included in ESM format (currently ES2022).
 
-### Styling
+### Ant-Design ConfigProvider
 
-`react-geo` supports dynamic theming [via CSS variables](https://4x.ant.design/docs/react/customize-theme-variable) and requires the following import inside your project.
+`react-geo` supports [dynamic theming](https://ant.design/docs/react/customize-theme) of the Toggle Button via the antd `ConfigProvider`.
 
-```css
-@import '~antd/dist/antd.variable.min.css';
+```tsx
+<ConfigProvider
+  theme={{
+    cssVar: true,
+    Component: {
+      Button: {
+        primaryActive: '#0958d9'
+      }
+    }
+  }}
+>
+  //...
+</ConfigProvider>
 ```
 
 ## Workshop

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,6 @@
       "version": "26.2.1",
       "license": "BSD-2-Clause",
       "dependencies": {
-        "@ag-grid-community/client-side-row-model": "^32.3.2",
-        "@ag-grid-community/react": "^32.3.2",
-        "@ag-grid-community/styles": "^32.3.2",
         "@dnd-kit/core": "^6.1.0",
         "@dnd-kit/modifiers": "^8.0.0",
         "@dnd-kit/sortable": "^9.0.0",
@@ -23,6 +20,7 @@
         "@terrestris/base-util": "^3.0.0",
         "@terrestris/react-util": "^10.0.1",
         "@types/lodash": "^4.17.4",
+        "ag-grid-react": "^33.0.4",
         "jspdf": "^2.5.1",
         "lodash": "^4.17.21",
         "moment": "^2.30.1",
@@ -115,45 +113,6 @@
       "version": "4.4.0",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@ag-grid-community/client-side-row-model": {
-      "version": "32.3.2",
-      "resolved": "https://registry.npmjs.org/@ag-grid-community/client-side-row-model/-/client-side-row-model-32.3.2.tgz",
-      "integrity": "sha512-ulDslHzoZ3nkBcSEiEXYoULLzhZ6lVnTTL/J7xeFV8esBaDkP4+heesG+0oAG2qKKWSRorsJyTTCJMrNodxerQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@ag-grid-community/core": "32.3.2",
-        "tslib": "^2.3.0"
-      }
-    },
-    "node_modules/@ag-grid-community/core": {
-      "version": "32.3.2",
-      "resolved": "https://registry.npmjs.org/@ag-grid-community/core/-/core-32.3.2.tgz",
-      "integrity": "sha512-m9+x9y1hFoXGklaXxN474pxYc7B/M/hH6pcBtBl+mQpCC4TwUAy516rDsFRH6WqpYiakfBdx1A3mhQbavNEDAQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ag-charts-types": "10.3.1",
-        "tslib": "^2.3.0"
-      }
-    },
-    "node_modules/@ag-grid-community/react": {
-      "version": "32.3.2",
-      "resolved": "https://registry.npmjs.org/@ag-grid-community/react/-/react-32.3.2.tgz",
-      "integrity": "sha512-ItPrOOfXgPEtzEH0BVuB9LigH5AAejsdDgASfe17Js4zkvRxvAwekg8evIpk1EEnmwfr0CWQ6wZjOPnzd4nDcg==",
-      "license": "MIT",
-      "dependencies": {
-        "prop-types": "^15.8.1"
-      },
-      "peerDependencies": {
-        "@ag-grid-community/core": "32.3.2",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@ag-grid-community/styles": {
-      "version": "32.3.3",
-      "resolved": "https://registry.npmjs.org/@ag-grid-community/styles/-/styles-32.3.3.tgz",
-      "integrity": "sha512-QAJc1CPbmFsAAq5M/8r0IOm8HL4Fb3eVK6tZXKzV9zibIereBjUwvvJRaSJa8iwtTlgxCtaULAQyE2gJcctphA=="
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.3.0",
@@ -11277,11 +11236,31 @@
         "node": ">= 10.0.0"
       }
     },
-    "node_modules/ag-charts-types": {
-      "version": "10.3.1",
-      "resolved": "https://registry.npmjs.org/ag-charts-types/-/ag-charts-types-10.3.1.tgz",
-      "integrity": "sha512-oZvu9vJLk6lmzaYi0TmVVmHFZJpVNFziU0bnllx4wR3muXCmnxz5LouKIZ8CYnNiC7VO5HmHNlFu+0DmEO5zxg==",
-      "license": "MIT"
+    "node_modules/ag-grid-community": {
+      "version": "33.0.4",
+      "resolved": "https://registry.npmjs.org/ag-grid-community/-/ag-grid-community-33.0.4.tgz",
+      "integrity": "sha512-iBD8g8bNIl95w9CzCQpDid+eTdmOoT39204sPUOhE9eE50vfoDHIaF5U4fRYQHbLsT4bwbXfQYdsqBAOLJL24w==",
+      "dependencies": {
+        "ag-charts-types": "11.0.4"
+      }
+    },
+    "node_modules/ag-grid-community/node_modules/ag-charts-types": {
+      "version": "11.0.4",
+      "resolved": "https://registry.npmjs.org/ag-charts-types/-/ag-charts-types-11.0.4.tgz",
+      "integrity": "sha512-K/Mi7FXvSCoABLSrqQ70k1QrIL5R6RNCt2NAppOxMEir+DVFPqKZtghruobc2MGVUUKkT9MCn6Dun+fL6yZjfA=="
+    },
+    "node_modules/ag-grid-react": {
+      "version": "33.0.4",
+      "resolved": "https://registry.npmjs.org/ag-grid-react/-/ag-grid-react-33.0.4.tgz",
+      "integrity": "sha512-0Y54BmY03athtqfpO5kTR/gjyP6Qw4LP+EQD2duBZ3yj4SWWlwE1Ob7Lc7OuZRHxl2dxLQy2edagJHrqnmopKw==",
+      "dependencies": {
+        "ag-grid-community": "33.0.4",
+        "prop-types": "^15.8.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
     },
     "node_modules/agent-base": {
       "version": "6.0.2",

--- a/package.json
+++ b/package.json
@@ -65,9 +65,6 @@
     "typecheck": "tsc --noEmit --project tsconfig.json"
   },
   "dependencies": {
-    "@ag-grid-community/client-side-row-model": "^32.3.2",
-    "@ag-grid-community/react": "^32.3.2",
-    "@ag-grid-community/styles": "^32.3.2",
     "@dnd-kit/core": "^6.1.0",
     "@dnd-kit/modifiers": "^8.0.0",
     "@dnd-kit/sortable": "^9.0.0",
@@ -79,6 +76,7 @@
     "@terrestris/base-util": "^3.0.0",
     "@terrestris/react-util": "^10.0.1",
     "@types/lodash": "^4.17.4",
+    "ag-grid-react": "^33.0.4",
     "jspdf": "^2.5.1",
     "lodash": "^4.17.21",
     "moment": "^2.30.1",

--- a/src/Grid/AgFeatureGrid/AgFeatureGrid.tsx
+++ b/src/Grid/AgFeatureGrid/AgFeatureGrid.tsx
@@ -1,7 +1,6 @@
 import MapUtil from '@terrestris/ol-util/dist/MapUtil/MapUtil';
 import useMap from '@terrestris/react-util/dist/Hooks/useMap/useMap';
 import useOlLayer from '@terrestris/react-util/dist/Hooks/useOlLayer/useOlLayer';
-
 import {
   AllCommunityModule,
   CellMouseOutEvent,
@@ -17,20 +16,17 @@ import {
   RowNode,
   RowStyle,
   SelectionChangedEvent,
-  themeBalham,
-  Theme
-} from 'ag-grid-community';
+  Theme,
+  themeBalham} from 'ag-grid-community';
 import {
   AgGridReact,
   AgGridReactProps
 } from 'ag-grid-react';
-
 import _differenceWith from 'lodash/differenceWith';
 import _isFunction from 'lodash/isFunction';
 import _isNil from 'lodash/isNil';
 import _isNumber from 'lodash/isNumber';
 import _isString from 'lodash/isString';
-
 import { getUid } from 'ol';
 import OlFeature from 'ol/Feature';
 import OlGeometry from 'ol/geom/Geometry';
@@ -38,7 +34,6 @@ import OlLayerBase from 'ol/layer/Base';
 import OlLayerVector from 'ol/layer/Vector';
 import OlMapBrowserEvent from 'ol/MapBrowserEvent';
 import OlSourceVector from 'ol/source/Vector';
-
 import React, { Key, ReactElement, useCallback, useEffect, useMemo, useState } from 'react';
 
 import { CSS_PREFIX } from '../../constants';
@@ -596,7 +591,7 @@ export function AgFeatureGrid<T>({
         onSelectionChanged={onSelectionChanged}
         rowData={passedRowData}
         rowSelection={selectable ? {
-          mode: "multiRow",
+          mode: 'multiRow',
           enableClickSelection: false
         } : undefined}
         theme={theme}

--- a/src/Grid/AgFeatureGrid/AgFeatureGrid.tsx
+++ b/src/Grid/AgFeatureGrid/AgFeatureGrid.tsx
@@ -165,17 +165,6 @@ export function AgFeatureGrid<T>({
     style: featureStyle
   }), [features, layerName], true);
 
-  const checkBoxColumnDefinition: ColDef<WithKey<T>> = useMemo(() => ({
-    checkboxSelection: true,
-    headerCheckboxSelection: true,
-    headerName: '',
-    lockPosition: true,
-    pinned: 'left',
-    suppressHeaderMenuButton: true,
-    suppressMovable: true,
-    width: 40
-  }), []);
-
   /**
    * Returns the currently selected row keys.
    *
@@ -321,11 +310,6 @@ export function AgFeatureGrid<T>({
     const feature = features[0];
     const props = feature.getProperties();
 
-    if (selectable) {
-      // adds select checkbox column
-      columns.push(checkBoxColumnDefinition);
-    }
-
     const colDefsFromFeature = Object.keys(props).map((key: string): ColDef<WithKey<T>> | undefined => {
       if (attributeBlacklist.includes(key)) {
         return;
@@ -358,7 +342,7 @@ export function AgFeatureGrid<T>({
       ...columns,
       ...(colDefsFromFeature.filter(c => !_isNil(c)) as ColDef<WithKey<T>>[])
     ];
-  }, [attributeBlacklist, features, selectable, checkBoxColumnDefinition]);
+  }, [attributeBlacklist, features]);
 
   /**
    * Returns the table row data from all the given features.
@@ -611,10 +595,10 @@ export function AgFeatureGrid<T>({
         onRowClicked={onRowClickInner}
         onSelectionChanged={onSelectionChanged}
         rowData={passedRowData}
-        rowSelection={{
+        rowSelection={selectable ? {
           mode: "multiRow",
           enableClickSelection: false
-        }}
+        } : undefined}
         theme={theme}
         {...agGridPassThroughProps}
       />


### PR DESCRIPTION
## Description

This updates AG-Grid to v33. This changes the npm package names and introduces a new way to theme the grid via react properties. This is easier to customize and is similar to the new antd way.

This is a breaking change.

This is how the old version (left side) looks compared to the new version (right side):
![image](https://github.com/user-attachments/assets/f89b6877-9d35-47f6-99cd-6f2a2033ea4c)

This PR also adds some documentation about theming with antd.

## Related issues or pull requests

<!-- Please list issues or pull requests that the changes you propose are related to. It does not matter if they are still open and/or unmerged, any link is appreciated. -->

## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [ ] Bugfix
- [x] Feature
- [x] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [x] Yes
- [ ] No

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the
  [BSD-2-Clause](https://github.com/terrestris/react-geo/blob/main/LICENSE).
- [x] I have followed the [guidelines for contributing](https://github.com/terrestris/react-geo/blob/main/CONTRIBUTING.md).
- [x] The proposed change fits to the content of the [Code of Conduct](https://github.com/terrestris/react-geo/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm run check` locally).
- [x] I have added a screenshot/screencast to illustrate the visual output of my update.
