### PR TITLE
Fixes a zoom error in LayerSwitcher

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,6 +6,7 @@ on:
       - main
       - next
       - 15.x.x
+      - 24.x.x
 
 jobs:
   release:

--- a/.releaserc
+++ b/.releaserc
@@ -1,6 +1,7 @@
 {
   "branches": [
     "main",
+    "24.x.x",
     {
       "name": "next",
       "prerelease": true

--- a/src/LayerSwitcher/LayerSwitcher.tsx
+++ b/src/LayerSwitcher/LayerSwitcher.tsx
@@ -6,6 +6,7 @@ import OlLayerGroup from 'ol/layer/Group';
 import OlLayerTile from 'ol/layer/Tile';
 import OlMap from 'ol/Map';
 import OlTileSource from 'ol/source/Tile';
+import View from 'ol/View';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 
 import { CSS_PREFIX } from '../constants';
@@ -130,13 +131,57 @@ export const LayerSwitcher: React.FC<LayerSwitcherProps> = ({
       return;
     }
 
-    const mapClone =  new OlMap({
-      view: map.getView(),
+    const mainView = map.getView();
+    const projection = mainView.getProjection();
+    if (!projection) {
+      return;
+    }
+
+    // clone view properties so preview map has the same view as the main map
+    // but is separated from the main view to prevent event errors
+    const viewProps = {
+      projection,
+      center: mainView.getCenter(),
+      zoom: mainView.getZoom(),
+      rotation: mainView.getRotation(),
+      minZoom: mainView.getMinZoom(),
+      maxZoom: mainView.getMaxZoom(),
+      minResolution: mainView.getMinResolution(),
+      maxResolution: mainView.getMaxResolution(),
+      extent: mainView.get('extent')
+    };
+
+    const mapClone = new OlMap({
+      view: new View(viewProps),
       controls: []
     });
 
     setSwitcherMap(mapClone);
   }, [map]);
+
+  useEffect(() => {
+    if (!map || !switcherMap) {
+      return;
+    }
+
+    const mainView = map.getView();
+    const previewView = switcherMap.getView();
+
+    const synchronizeViews = () => {
+      previewView.setCenter(mainView.getCenter());
+      previewView.setZoom(mainView.getZoom() ?? 0);
+    };
+
+    synchronizeViews();
+
+    mainView.on('change:center', synchronizeViews);
+    mainView.on('change:resolution', synchronizeViews);
+
+    return () => {
+      mainView.un('change:center', synchronizeViews);
+      mainView.un('change:resolution', synchronizeViews);
+    };
+  }, [map, switcherMap]);
 
   useEffect(() => {
     if (switcherMap) {


### PR DESCRIPTION
## Description

This PR fixes a bug in the zoom behavior of the main map for v24 when the `LayerSwitcher` is included. Previously a too small scale was reached when zooming in. The user expected to zoom closer to the selected area by dragging a box.  
This is achieved by synchronizing the view between the main map and the preview map, instead of using the same view:

Old behavior:  
![old](https://github.com/user-attachments/assets/3ff1ec1f-6222-4c32-b7c5-8ce26ad6ab63)

New behavior:  
![new](https://github.com/user-attachments/assets/42e6189b-24e6-4da5-9a45-a492722b93da)

## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the
  [BSD-2-Clause](https://github.com/terrestris/react-geo/blob/main/LICENSE).
- [x] I have followed the [guidelines for contributing](https://github.com/terrestris/react-geo/blob/main/CONTRIBUTING.md).
- [x] The proposed change fits to the content of the [Code of Conduct](https://github.com/terrestris/react-geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added or updated tests and documentation, and the test suite passes (run `npm run check` locally).
- [x] I have added a screenshot/screencast to illustrate the visual output of my update.
