### PR TITLE
fix: expose onCutEnd callback in DrawCutButton

### DIFF
--- a/src/Button/DrawCutButton/DrawCutButton.tsx
+++ b/src/Button/DrawCutButton/DrawCutButton.tsx
@@ -30,6 +30,11 @@ interface OwnProps {
    */
   digitizeLayer?: OlVectorLayer<OlVectorSource>;
   /**
+   * This callback is called after the cut was performed with all changed features. Removed features geometry is set to
+   * undefined.
+   */
+  onCutEnd?: (changed: OlFeature[]) => void;
+  /**
    * Text to show in the Popconfirm after drawing the cut.
    */
   popConfirmText?: string;
@@ -57,6 +62,7 @@ export const DrawCutButton: FC<DrawCutProps> = ({
   digitizeLayer,
   drawStyle,
   className,
+  onCutEnd,
   pressed,
   popConfirmProps,
   highlightStyle = defaultHighlightStyle,
@@ -100,7 +106,8 @@ export const DrawCutButton: FC<DrawCutProps> = ({
     digitizeLayer,
     drawStyle,
     active: !!pressed,
-    onCutStart
+    onCutStart,
+    onCutEnd
   });
 
   const finalClassName = className


### PR DESCRIPTION
## Description

This exposes the `onCutEnd` callback in the `DrawCutButton` through the interface.

## Related issues or pull requests

<!-- Please list issues or pull requests that the changes you propose are related to. It does not matter if they are still open and/or unmerged, any link is appreciated. -->

## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the
  [BSD-2-Clause](https://github.com/terrestris/react-geo/blob/main/LICENSE).
- [x] I have followed the [guidelines for contributing](https://github.com/terrestris/react-geo/blob/main/CONTRIBUTING.md).
- [x] The proposed change fits to the content of the [Code of Conduct](https://github.com/terrestris/react-geo/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm run check` locally).
- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
