### PR TITLE
Allow to override column definition in `FeatureGrid` again

### DIFF
--- a/src/Grid/FeatureGrid/FeatureGrid.example.md
+++ b/src/Grid/FeatureGrid/FeatureGrid.example.md
@@ -40,7 +40,7 @@ const FeatureGridExample = () => {
         zoomToExtent={true}
         selectable={true}
         attributeBlacklist={['gml_id', 'USE', 'RS', 'RS_ALT']}
-        columns={[{
+        columnDefs={[{
           dataIndex: 'GEN',
           title: 'Name',
           render: nameColumnRenderer,
@@ -123,7 +123,7 @@ const FeatureGridExample = () => {
         selectable={true}
         draggableColumns={true}
         attributeBlacklist={['gml_id', 'USE', 'RS', 'RS_ALT']}
-        columns={[{
+        columnDefs={[{
           dataIndex: 'GEN',
           title: 'Name',
           render: nameColumnRenderer,
@@ -335,7 +335,7 @@ const RemoteFeatureGrid = ({
       highlightStyle={feat => getFeatureStyle(feat, 'rgb(230, 247, 255)')}
       selectStyle={feat => getFeatureStyle(feature, 'rgb(24, 144, 255)')}
       onChange={onTableChange}
-      columns={[{
+      columnDefs={[{
         dataIndex: 'name',
         sorter: true,
         sortOrder: sorter.order,

--- a/src/Grid/FeatureGrid/FeatureGrid.spec.tsx
+++ b/src/Grid/FeatureGrid/FeatureGrid.spec.tsx
@@ -193,7 +193,7 @@ describe('<FeatureGrid />', () => {
     renderInMapContext(map, (
       <FeatureGrid
         features={features}
-        columns={[{
+        columnDefs={[{
           key: 'name',
           dataIndex: 'name',
           title: 'Name override'

--- a/src/Grid/FeatureGrid/FeatureGrid.tsx
+++ b/src/Grid/FeatureGrid/FeatureGrid.tsx
@@ -50,7 +50,14 @@ interface DragIndexState {
   direction?: 'left' | 'right';
 }
 
-interface OwnProps {
+interface OwnProps<RecordType = AnyObject> {
+  /**
+   * Custom column definitions to apply to the given column (mapping via key).
+   * See https://ant.design/components/table/#Column.
+   *
+   * To control the columns manually, pass the `columns` prop to the table.
+   */
+  columnDefs?: ColumnsType<RecordType>;
   /**
    * When active the order of the columns can be changed dynamically using drag & drop.
    */
@@ -63,7 +70,7 @@ interface OwnProps {
     selectedFeatures: OlFeature<OlGeometry>[]) => void;
 }
 
-export type FeatureGridProps<T extends AnyObject = AnyObject> = OwnProps & RgCommonGridProps<T> & TableProps<T>;
+export type FeatureGridProps<T extends AnyObject = AnyObject> = OwnProps<T> & RgCommonGridProps<T> & TableProps<T>;
 
 const defaultClassName = `${CSS_PREFIX}feature-grid`;
 
@@ -114,7 +121,7 @@ export const FeatureGrid = <T extends AnyObject = AnyObject,>({
   attributeFilter,
   children,
   className,
-  columns,
+  columnDefs,
   draggableColumns = false,
   featureStyle = defaultFeatureStyle,
   features,
@@ -302,7 +309,7 @@ export const FeatureGrid = <T extends AnyObject = AnyObject,>({
    * given feature.
   */
   useEffect(() => {
-    const columnDefs: ColumnsType<T> = [];
+    const colDefs: ColumnsType<T> = [];
     if (!features || features.length < 1) {
       return;
     }
@@ -333,25 +340,25 @@ export const FeatureGrid = <T extends AnyObject = AnyObject,>({
         continue;
       }
 
-      columnDefs.push({
+      colDefs.push({
         title: key,
         dataIndex: key,
         key: key,
-        ...columns?.find(col => (col as ColumnType<InternalTableRecord>).dataIndex === key)
+        ...columnDefs?.find(col => (col as ColumnType<InternalTableRecord>).dataIndex === key)
       });
     }
 
-    setColumnDefinition(columnDefs);
-  }, [columns, features, attributeFilter, attributeBlacklist]);
+    setColumnDefinition(colDefs);
+  }, [columnDefs, features, attributeFilter, attributeBlacklist]);
 
   useEffect(() => {
-    const columnDefs = columnDefinition.map((column, i) => ({
+    const colDefs = columnDefinition.map((column, i) => ({
       ...column,
       key: `${i}`,
       onHeaderCell: () => ({ id: `${i}` }),
       onCell: () => ({ id: `${i}` })
     }));
-    setFeatureColumns(columnDefs);
+    setFeatureColumns(colDefs);
   }, [columnDefinition]);
 
   /**


### PR DESCRIPTION
## Description

<!-- Please give a short description of the changes you propose. Please use prose and try not to be too technical, if possible. Make sure to mention people that you think should know about the PR. -->

In the current `FeatureGrid` implementation it's not possible to fully override the auto-generated column definition, e.g. to pass the order or additional columns that do not exist in the passed features. This PR suggests to (re-)add this possibility by passing the `columns` prop. The existing prop `columns` has been renamed to `columnDefs` (**BREAKING CHANGE**).

Please review @terrestris/devs.

## Related issues or pull requests

<!-- Please list issues or pull requests that the changes you propose are related to. It does not matter if they are still open and/or unmerged, any link is appreciated. -->

--

## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [x] Yes
- [ ] No

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the
  [BSD-2-Clause](https://github.com/terrestris/react-geo/blob/main/LICENSE).
- [x] I have followed the [guidelines for contributing](https://github.com/terrestris/react-geo/blob/main/CONTRIBUTING.md).
- [x] The proposed change fits to the content of the [Code of Conduct](https://github.com/terrestris/react-geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added or updated tests and documentation, and the test suite passes (run `npm run check` locally).
- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
