### PR TITLE
fix: fire delete event after removal of feature from source

### DIFF
--- a/src/Button/CopyButton/CopyButton.tsx
+++ b/src/Button/CopyButton/CopyButton.tsx
@@ -67,8 +67,6 @@ const CopyButton: React.FC<CopyButtonProps> = ({
   const layers = useMemo(() => layer ? [layer] : [], [layer]);
 
   const onFeatureSelect = useCallback((event: OlSelectEvent) => {
-    onFeatureCopy?.(event);
-
     const feat = event.selected[0];
 
     if (!feat || !layer || !map) {
@@ -78,6 +76,8 @@ const CopyButton: React.FC<CopyButtonProps> = ({
     const copy = feat.clone();
 
     layer.getSource()?.addFeature(copy);
+
+    onFeatureCopy?.(event);
 
     AnimateUtil.moveFeature(
       map,

--- a/src/Button/DeleteButton/DeleteButton.tsx
+++ b/src/Button/DeleteButton/DeleteButton.tsx
@@ -68,9 +68,9 @@ export const DeleteButton: React.FC<DeleteButtonProps> = ({
     if (!layer) {
       return;
     }
-    onFeatureRemove?.(event);
     const feat = event.selected[0];
     layer.getSource()?.removeFeature(feat);
+    onFeatureRemove?.(event);
   }, [layer, onFeatureRemove]);
 
   useSelectFeatures({


### PR DESCRIPTION
## Description

All other buttons are calling their respective `on...End` events after the action is performed. The `DeleteButton` and the `CopyButton` were the only ones calling the event before it actually has been performed.

## Related issues or pull requests

<!-- Please list issues or pull requests that the changes you propose are related to. It does not matter if they are still open and/or unmerged, any link is appreciated. -->

## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [x] Yes
- [ ] No

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the
  [BSD-2-Clause](https://github.com/terrestris/react-geo/blob/main/LICENSE).
- [ ] I have followed the [guidelines for contributing](https://github.com/terrestris/react-geo/blob/main/CONTRIBUTING.md).
- [ ] The proposed change fits to the content of the [Code of Conduct](https://github.com/terrestris/react-geo/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm run check` locally).
- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
