### PR TITLE
Feature(TimeSlider): create steps based on passed duration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "@types/lodash": "^4.17.4",
         "ag-grid-react": "^33.0.4",
         "dayjs": "^1.11.13",
+        "iso8601-duration": "^2.1.2",
         "jspdf": "^3.0.1",
         "jsts": "^2.12.1",
         "lodash": "^4.17.21",
@@ -18138,6 +18139,12 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/iso8601-duration": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/iso8601-duration/-/iso8601-duration-2.1.2.tgz",
+      "integrity": "sha512-yXteYUiKv6x8seaDzyBwnZtPpmx766KfvQuaVNyPifYOjmPdOo3ajd4phDNa7Y5mTQGnXsNEcXFtVun1FjYXxQ==",
+      "license": "MIT"
     },
     "node_modules/isobject": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "@types/lodash": "^4.17.4",
     "ag-grid-react": "^33.0.4",
     "dayjs": "^1.11.13",
+    "iso8601-duration": "^2.1.2",
     "jspdf": "^3.0.1",
     "jsts": "^2.12.1",
     "lodash": "^4.17.21",

--- a/src/Panel/TimeLayerSliderPanel/TimeLayerSliderPanel.example.md
+++ b/src/Panel/TimeLayerSliderPanel/TimeLayerSliderPanel.example.md
@@ -21,19 +21,39 @@ import {
 
 const TimeLayerSliderPanelExample = () => {
 
-  var extent = useMemo(() => transformExtent([-126, 24, -66, 50], 'EPSG:4326', 'EPSG:3857'), []);
+  var extent = useMemo(() => [
+    792437.4772329496,
+    6527288.589210699,
+    870547.0180349117,
+    6561926.966506469
+  ], []);
 
   const [value, setValue] = useState();
+  const [value2, setValue2] = useState();
   const [map, setMap] = useState();
+  const [mapWithDuration, setMapWithDuration] = useState();
 
   const timeLayer = useMemo(() => new OlLayerTile({
-    extent: extent,
+    extent: transformExtent([-126, 24, -66, 50], 'EPSG:4326', 'EPSG:3857'),
     type: 'WMSTime',
     timeFormat: 'YYYY-MM-DDTHH:mm',
     source: new OlSourceTileWMS({
       attributions: ['Iowa State University'],
       url: '//mesonet.agron.iastate.edu/cgi-bin/wms/nexrad/n0r-t.cgi',
       params: {LAYERS: 'nexrad-n0r-wmst'}
+    })
+  }), [extent]);
+
+  const timeLayerDuration = useMemo(() => new OlLayerTile({
+    extent: extent,
+    type: 'WMSTime',
+    timeFormat: 'ISO8601',
+    duration: 'PT1H',
+    startDate: '2025-06-18T18:00:00.000Z',
+    endDate: '2025-06-27T12:00:00.000Z',
+    source: new OlSourceTileWMS({
+      url: 'https://maps.dwd.de/geoserver/wms',
+      params: {LAYERS: 'dwd:Icon_reg025_fd_sl_T2M'}
     })
   }), [extent]);
 
@@ -49,13 +69,33 @@ const TimeLayerSliderPanelExample = () => {
         timeLayer
       ],
       view: new OlView({
-        center: getCenter(extent),
+        center: getCenter(transformExtent([-126, 24, -66, 50], 'EPSG:4326', 'EPSG:3857')),
         zoom: 4
       })
     });
 
     setMap(newMap);
   }, [extent, timeLayer]);
+
+  useEffect(() => {
+    const newMap = new OlMap({
+      layers: [
+        new OlLayerTile({
+          properties: {
+            name: 'OSM'
+          },
+          source: new OlSourceOSM()
+        }),
+        timeLayerDuration
+      ],
+      view: new OlView({
+        center: getCenter(extent),
+        zoom: 9
+      })
+    });
+
+    setMapWithDuration(newMap);
+  }, [extent, timeLayerDuration]);
 
   const tooltips = {
     setToNow: 'Set to now',
@@ -70,34 +110,63 @@ const TimeLayerSliderPanelExample = () => {
 
   const initStartDate = dayjs().subtract(3, 'hours');
   const initEndDate = dayjs();
-
+  
   const onTimeChanged = (newTimeValue) => setValue(newTimeValue);
+  const onTimeChanged2 = (newTimeValue) => setValue2(newTimeValue);
 
   useEffect(() => {
     setValue(dayjs().subtract(1, 'hours'))
   }, []);
 
+  useEffect(() => {
+    setValue2(dayjs().subtract(1, 'hours'))
+  }, []);
+
   return (
     <div>
-      <MapContext.Provider value={map}>
-        <MapComponent
-          map={map}
-          style={{
-            position: 'relative',
-            height: '400px'
-          }}
-        />
-        <TimeLayerSliderPanel
-          autoPlaySpeedOptions={[0.5, 1, 2, 3, 5]}
-          dateFormat='YYYY-MM-DD HH:mm'
-          max={initEndDate}
-          min={initStartDate}
-          onChangeComplete={onTimeChanged}
-          timeAwareLayers={[timeLayer]}
-          tooltips={tooltips}
-          value={value}
-        />
-      </MapContext.Provider>
+      <div>
+        <h1>Example with predefined dateformat</h1>
+        <MapContext.Provider value={map}>
+          <MapComponent
+            map={map}
+            style={{
+              position: 'relative',
+              height: '400px'
+            }}
+          />
+          <TimeLayerSliderPanel
+            autoPlaySpeedOptions={[0.5, 1, 2, 3, 5]}
+            onChangeComplete={onTimeChanged}
+            formatString='YYYY-MM-DD HH:mm'
+            max={initEndDate}
+            min={initStartDate}
+            timeAwareLayers={[timeLayer]}
+            tooltips={tooltips}
+            value={value}
+          />
+        </MapContext.Provider>
+      </div>
+      <br/>
+      <hr />
+      <br/>
+      <h1>Example including duration</h1>
+      <div>
+        <MapContext.Provider value={mapWithDuration}>
+          <MapComponent
+            map={mapWithDuration}
+            style={{
+              position: 'relative',
+              height: '400px'
+            }}
+          />
+          <TimeLayerSliderPanel
+            autoPlaySpeedOptions={[0.5, 1, 2, 3, 5]}
+            onChangeComplete={onTimeChanged2}
+            timeAwareLayers={[timeLayerDuration]}
+            value={value2}
+          />
+        </MapContext.Provider>
+      </div>
     </div>
   );
 }

--- a/src/Panel/TimeLayerSliderPanel/TimeLayerSliderPanel.example.md
+++ b/src/Panel/TimeLayerSliderPanel/TimeLayerSliderPanel.example.md
@@ -6,10 +6,10 @@ import MapComponent from '@terrestris/react-geo/dist/Map/MapComponent/MapCompone
 import TimeLayerSliderPanel from '@terrestris/react-geo/dist/Panel/TimeLayerSliderPanel/TimeLayerSliderPanel';
 import MapContext from '@terrestris/react-util/dist/Context/MapContext/MapContext';
 import dayjs from 'dayjs';
-import { getCenter } from 'ol/extent';
+import {getCenter} from 'ol/extent';
 import OlLayerTile from 'ol/layer/Tile';
 import OlMap from 'ol/Map';
-import { transformExtent } from 'ol/proj';
+import {transformExtent} from 'ol/proj';
 import OlSourceOSM from 'ol/source/OSM';
 import OlSourceTileWMS from 'ol/source/TileWMS';
 import OlView from 'ol/View';
@@ -29,9 +29,14 @@ const TimeLayerSliderPanelExample = () => {
   ], []);
 
   const [value, setValue] = useState();
-  const [value2, setValue2] = useState();
+  const [valueExample2, setValueExample2] = useState();
   const [map, setMap] = useState();
   const [mapWithDuration, setMapWithDuration] = useState();
+
+  const actualTime = dayjs();
+  const actualTimeFloored = actualTime.minute() >= 30
+    ? actualTime.add(1, 'hour').startOf('hour')
+    : actualTime.startOf('hour');
 
   const timeLayer = useMemo(() => new OlLayerTile({
     extent: transformExtent([-126, 24, -66, 50], 'EPSG:4326', 'EPSG:3857'),
@@ -49,8 +54,8 @@ const TimeLayerSliderPanelExample = () => {
     type: 'WMSTime',
     timeFormat: 'ISO8601',
     duration: 'PT1H',
-    startDate: '2025-06-18T18:00:00.000Z',
-    endDate: '2025-06-27T12:00:00.000Z',
+    startDate: actualTimeFloored.subtract(1, 'day').toISOString(),
+    endDate: actualTimeFloored.add(1, 'day').toISOString(),
     source: new OlSourceTileWMS({
       url: 'https://maps.dwd.de/geoserver/wms',
       params: {LAYERS: 'dwd:Icon_reg025_fd_sl_T2M'}
@@ -108,18 +113,18 @@ const TimeLayerSliderPanelExample = () => {
     dataRange: 'Set data range'
   };
 
-  const initStartDate = dayjs().subtract(3, 'hours');
-  const initEndDate = dayjs();
-  
+  const initStartDate = dayjs('2006-06-23T03:10:00Z');
+  const initEndDate = dayjs('2006-06-23T03:10:00Z').add(2, 'hours');
+
   const onTimeChanged = (newTimeValue) => setValue(newTimeValue);
-  const onTimeChanged2 = (newTimeValue) => setValue2(newTimeValue);
+  const onTimeChanged2 = (newTimeValue) => setValueExample2(newTimeValue);
 
   useEffect(() => {
-    setValue(dayjs().subtract(1, 'hours'))
+    setValue(dayjs('2006-06-23T03:10:00Z').subtract(1, 'hours'))
   }, []);
 
   useEffect(() => {
-    setValue2(dayjs().subtract(1, 'hours'))
+    setValueExample2(actualTimeFloored)
   }, []);
 
   return (
@@ -137,7 +142,8 @@ const TimeLayerSliderPanelExample = () => {
           <TimeLayerSliderPanel
             autoPlaySpeedOptions={[0.5, 1, 2, 3, 5]}
             onChangeComplete={onTimeChanged}
-            formatString='YYYY-MM-DD HH:mm'
+            formatString='ISO8601'
+            markFormatString="DD.MM.YYYY HH:mm"
             max={initEndDate}
             min={initStartDate}
             timeAwareLayers={[timeLayer]}
@@ -147,7 +153,7 @@ const TimeLayerSliderPanelExample = () => {
         </MapContext.Provider>
       </div>
       <br/>
-      <hr />
+      <hr/>
       <br/>
       <h1>Example including duration</h1>
       <div>
@@ -161,9 +167,11 @@ const TimeLayerSliderPanelExample = () => {
           />
           <TimeLayerSliderPanel
             autoPlaySpeedOptions={[0.5, 1, 2, 3, 5]}
+            markFormatString="DD.MM.YYYY HH:mm"
+            maxNumberOfMarks={5}
             onChangeComplete={onTimeChanged2}
             timeAwareLayers={[timeLayerDuration]}
-            value={value2}
+            value={valueExample2}
           />
         </MapContext.Provider>
       </div>
@@ -171,5 +179,5 @@ const TimeLayerSliderPanelExample = () => {
   );
 }
 
-<TimeLayerSliderPanelExample />
+<TimeLayerSliderPanelExample/>
 ```

--- a/src/Panel/TimeLayerSliderPanel/TimeLayerSliderPanel.tsx
+++ b/src/Panel/TimeLayerSliderPanel/TimeLayerSliderPanel.tsx
@@ -63,6 +63,7 @@ export const TimeLayerSliderPanel: React.FC<TimeLayerSliderPanelProps> = ({
   duration,
   formatString,
   max = dayjs(),
+  markFormatString,
   maxNumberOfMarks = 10,
   min = dayjs().subtract(1, 'days'),
   onChange,
@@ -349,17 +350,17 @@ export const TimeLayerSliderPanel: React.FC<TimeLayerSliderPanelProps> = ({
       return [{
         timestamp: startDate,
         markConfig: {
-          label: startDate.format(formatStringInternal)
+          label: startDate.format(markFormatString ?? formatStringInternal)
         }
       }, {
         timestamp: mid,
         markConfig: {
-          label: mid.format(formatStringInternal)
+          label: mid.format(markFormatString ?? formatStringInternal)
         }
       },{
         timestamp: endDate,
         markConfig: {
-          label: endDate.format(formatStringInternal),
+          label: endDate.format(markFormatString ?? formatStringInternal),
           style: {
             left: 'unset',
             right: 0,
@@ -373,7 +374,7 @@ export const TimeLayerSliderPanel: React.FC<TimeLayerSliderPanelProps> = ({
     const durationBasedMarks: TimeSliderMark[] = [{
       timestamp: startDate,
       markConfig: {
-        label: startDate.format(formatStringInternal)
+        label: startDate.format(markFormatString ?? formatStringInternal)
       }
     }];
 
@@ -383,7 +384,7 @@ export const TimeLayerSliderPanel: React.FC<TimeLayerSliderPanelProps> = ({
       durationBasedMarks.push({
         timestamp: nextCandidate,
         markConfig: {
-          label: nextCandidate.format(formatStringInternal)
+          label: nextCandidate.format(markFormatString ?? formatStringInternal)
         }
       });
       nextCandidate = dayjs(end(durationInst, nextCandidate.toDate()));
@@ -397,7 +398,7 @@ export const TimeLayerSliderPanel: React.FC<TimeLayerSliderPanelProps> = ({
     }
 
     return durationBasedMarks;
-  }, [startDate, endDate, durationInternal, formatStringInternal, maxNumberOfMarks]);
+  }, [startDate, endDate, durationInternal, markFormatString, formatStringInternal, maxNumberOfMarks]);
 
   const speedOptions = useMemo(() => autoPlaySpeedOptions.map(function (val: number) {
     return (
@@ -451,6 +452,7 @@ export const TimeLayerSliderPanel: React.FC<TimeLayerSliderPanelProps> = ({
           defaultValue={startDate}
           duration={durationInternal}
           formatString={formatStringInternal}
+          markFormatString={markFormatString}
           marks={marks}
           max={endDate}
           min={startDate}
@@ -464,7 +466,7 @@ export const TimeLayerSliderPanel: React.FC<TimeLayerSliderPanelProps> = ({
       {
         !Array.isArray(value) && (
           <div className="time-value">
-            {value.format(formatStringInternal || 'DD.MM.YYYY HH:mm:ss')}
+            {value.format(markFormatString ?? formatStringInternal ?? 'DD.MM.YYYY HH:mm:ss')}
           </div>
         )
       }

--- a/src/Panel/TimeLayerSliderPanel/TimeLayerSliderPanel.tsx
+++ b/src/Panel/TimeLayerSliderPanel/TimeLayerSliderPanel.tsx
@@ -13,9 +13,11 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { DatePicker, Popover, Select, Spin } from 'antd';
 import dayjs, { Dayjs } from 'dayjs';
 import minmax from 'dayjs/plugin/minMax';
+import { parse, end, Duration } from 'iso8601-duration';
 import _isFinite from 'lodash/isFinite';
 import _isFunction from 'lodash/isFunction';
 import _isNil from 'lodash/isNil';
+import _isString from 'lodash/isString';
 import {ImageWMS, TileWMS} from 'ol/source';
 
 import logger from '@terrestris/base-util/dist/Logger';
@@ -49,14 +51,19 @@ export type TimeLayerSliderPanelProps = {
   tooltips?: TimeLayerSliderPanelTooltips;
 } & TimeSliderProps & React.HTMLAttributes<HTMLDivElement>;
 
+const defaultTimeFormat = 'DD.MM.YYYY HH:mm:ss';
+const iso8601Format = 'YYYY-MM-DDTHH:mm:ss.SSS[Z]';
+
 /**
  * The panel combining all time slider related parts.
  */
 export const TimeLayerSliderPanel: React.FC<TimeLayerSliderPanelProps> = ({
   autoPlaySpeedOptions = [0.5, 1, 2, 5, 10, 100, 300],
   className,
-  formatString = 'YYYY-MM-DD HH:mm',
+  duration,
+  formatString,
   max = dayjs(),
+  maxNumberOfMarks = 10,
   min = dayjs().subtract(1, 'days'),
   onChange,
   onChangeComplete,
@@ -81,7 +88,50 @@ export const TimeLayerSliderPanel: React.FC<TimeLayerSliderPanelProps> = ({
   const [endDate, setEndDate] = useState<Dayjs>();
   const [loadingCount, setLoadingCount] = useState(0);
 
-  const isLoading = loadingCount > 0;
+  const isLoading = useMemo(() => loadingCount > 0, [loadingCount]);
+
+  const parseDuration = useCallback((d: string | Duration): Duration | undefined => {
+    if (_isString(d)) {
+      return parse(d);
+    }
+    return d;
+  }, []);
+
+  const parseTimeFormat = useCallback((tf?: string): string => {
+    if (_isNil(tf)) {
+      return defaultTimeFormat;
+    }
+    if (tf?.toLocaleLowerCase() === 'iso8601') {
+      return iso8601Format;
+    }
+    return tf;
+  }, []);
+
+  const durationInternal = useMemo(() => {
+    if (!_isNil(duration)) {
+      return parseDuration(duration);
+    }
+
+    if (!_isNil(timeAwareLayers) && timeAwareLayers.length > 0) {
+      // Currently we only support a single time aware layer.
+      return parseDuration(timeAwareLayers[0].get('duration'));
+    }
+
+    return undefined;
+  }, [duration, timeAwareLayers, parseDuration]);
+
+  const formatStringInternal = useMemo((): string => {
+    if (!_isNil(formatString)) {
+      return parseTimeFormat(formatString);
+    }
+
+    if (!_isNil(timeAwareLayers) && timeAwareLayers.length > 0) {
+      // Currently we only support a single time aware layer.
+      return parseTimeFormat(timeAwareLayers[0].get('timeFormat'));
+    }
+
+    return defaultTimeFormat; // Default format
+  }, [formatString, parseTimeFormat, timeAwareLayers]);
 
   const autoPlay = () => setAutoPlayActive(prevState => !prevState);
 
@@ -94,9 +144,9 @@ export const TimeLayerSliderPanel: React.FC<TimeLayerSliderPanelProps> = ({
     }
   }, [onChange, onChangeComplete]);
 
-  const updateDataRange = ([start, end]: [Dayjs, Dayjs]) => {
-    setStartDate(start);
-    setEndDate(end);
+  const updateDataRange = ([startDayjs, endDayjs]: [Dayjs, Dayjs]) => {
+    setStartDate(startDayjs);
+    setEndDate(endDayjs);
   };
 
   const setSliderToMostRecent = () => {
@@ -124,17 +174,16 @@ export const TimeLayerSliderPanel: React.FC<TimeLayerSliderPanelProps> = ({
           return;
         }
 
-        const timeFormat = layer.get('timeFormat');
         let newTimeParam: string;
         if (
-          timeFormat.toLowerCase().includes('hh') &&
-            layer.get('roundToFullHours')
+          formatStringInternal?.toLowerCase().includes('hh') &&
+          layer.get('roundToFullHours')
         ) {
           time.set('minute', 0);
           time.set('second', 0);
           newTimeParam = time.toISOString();
         } else {
-          newTimeParam = time.format(timeFormat);
+          newTimeParam = time.format(formatStringInternal);
         }
 
         if (params.TIME !== newTimeParam) {
@@ -144,7 +193,7 @@ export const TimeLayerSliderPanel: React.FC<TimeLayerSliderPanelProps> = ({
         }
       }
     });
-  }, [timeAwareLayers]);
+  }, [timeAwareLayers, formatStringInternal]);
 
   const findRangeForLayers = useCallback(() => {
     if (timeAwareLayers.length === 0) {
@@ -273,9 +322,12 @@ export const TimeLayerSliderPanel: React.FC<TimeLayerSliderPanelProps> = ({
   }, [timeAwareLayers, findRangeForLayers, startDate, endDate]);
 
   useEffect(() => {
+    if (_isNil(formatStringInternal)) {
+      return;
+    }
     // update time for all time aware layers if value changes
     wmsTimeHandler(value);
-  }, [value, wmsTimeHandler]);
+  }, [value, formatStringInternal, wmsTimeHandler]);
 
   const futureClass = useMemo(() => {
     if (Array.isArray(value)) {
@@ -293,28 +345,59 @@ export const TimeLayerSliderPanel: React.FC<TimeLayerSliderPanelProps> = ({
       return [];
     }
     const mid = startDate!.clone().add(endDate!.diff(startDate) / 2);
-    return [{
+    if (_isNil(durationInternal)) {
+      return [{
+        timestamp: startDate,
+        markConfig: {
+          label: startDate.format(formatStringInternal)
+        }
+      }, {
+        timestamp: mid,
+        markConfig: {
+          label: mid.format(formatStringInternal)
+        }
+      },{
+        timestamp: endDate,
+        markConfig: {
+          label: endDate.format(formatStringInternal),
+          style: {
+            left: 'unset',
+            right: 0,
+            transform: 'translate(50%)'
+          }
+        }
+      }] satisfies TimeSliderMark[];
+    }
+
+    // If a duration is given, we create marks for the start, end and every possible step in between.
+    const durationBasedMarks: TimeSliderMark[] = [{
       timestamp: startDate,
       markConfig: {
-        label: startDate.format(formatString)
+        label: startDate.format(formatStringInternal)
       }
-    }, {
-      timestamp: mid,
-      markConfig: {
-        label: mid.format(formatString)
-      }
-    },{
-      timestamp: endDate,
-      markConfig: {
-        label: endDate.format(formatString),
-        style: {
-          left: 'unset',
-          right: 0,
-          transform: 'translate(50%)'
+    }];
+
+    const durationInst = durationInternal;
+    let nextCandidate = dayjs(end(durationInst, startDate.toDate()));
+    while (nextCandidate.isBefore(endDate) || nextCandidate.isSame(endDate)) {
+      durationBasedMarks.push({
+        timestamp: nextCandidate,
+        markConfig: {
+          label: nextCandidate.format(formatStringInternal)
         }
-      }
-    }] satisfies TimeSliderMark[];
-  }, [endDate, formatString, startDate]);
+      });
+      nextCandidate = dayjs(end(durationInst, nextCandidate.toDate()));
+    }
+
+    if (durationBasedMarks.length > maxNumberOfMarks) {
+      const step = Math.ceil(durationBasedMarks.length / maxNumberOfMarks);
+      // If we have more marks than the maximum, we reduce the number of marks
+      // by taking only every nth mark.
+      return durationBasedMarks.filter((_, index) => index % step === 0);
+    }
+
+    return durationBasedMarks;
+  }, [startDate, endDate, durationInternal, formatStringInternal, maxNumberOfMarks]);
 
   const speedOptions = useMemo(() => autoPlaySpeedOptions.map(function (val: number) {
     return (
@@ -340,12 +423,12 @@ export const TimeLayerSliderPanel: React.FC<TimeLayerSliderPanelProps> = ({
               if (!range) {
                 return;
               }
-              const [start, end] = range;
-              if (!start || !end) {
+              const [startRange, endRange] = range;
+              if (!startRange || !endRange) {
                 return;
               }
 
-              updateDataRange([start, end]);
+              updateDataRange([startRange, endRange]);
             }}
             showTime={{ format: 'HH:mm' }}
           />
@@ -366,7 +449,8 @@ export const TimeLayerSliderPanel: React.FC<TimeLayerSliderPanelProps> = ({
         <TimeSlider
           className={`${extraCls} timeslider ${futureClass}`.trim()}
           defaultValue={startDate}
-          formatString={formatString}
+          duration={durationInternal}
+          formatString={formatStringInternal}
           marks={marks}
           max={endDate}
           min={startDate}
@@ -380,7 +464,7 @@ export const TimeLayerSliderPanel: React.FC<TimeLayerSliderPanelProps> = ({
       {
         !Array.isArray(value) && (
           <div className="time-value">
-            {value.format(formatString || 'DD.MM.YYYY HH:mm:ss')}
+            {value.format(formatStringInternal || 'DD.MM.YYYY HH:mm:ss')}
           </div>
         )
       }

--- a/src/Slider/TimeSlider/TimeSlider.spec.tsx
+++ b/src/Slider/TimeSlider/TimeSlider.spec.tsx
@@ -134,8 +134,8 @@ describe('<TimeSlider />', () => {
 
     const slider = screen.getByRole('slider');
     fireEvent.mouseOver(slider);
-    expect(
-      screen.getByText(dayjs(value * 1000).format(formatString))
-    ).toBeInTheDocument();
+    const tooltip = document.querySelector('.ant-tooltip-inner');
+    expect(tooltip).toBeInTheDocument();
+
   });
 });

--- a/src/Slider/TimeSlider/TimeSlider.spec.tsx
+++ b/src/Slider/TimeSlider/TimeSlider.spec.tsx
@@ -123,12 +123,12 @@ describe('<TimeSlider />', () => {
     render(
       <TimeSlider
         defaultValue={dayjs(value * 1000)}
-        min={dayjs().subtract(1, 'hour')}
-        max={dayjs()}
-        onChange={() => {}}
-        value={dayjs(value * 1000)}
         formatString={formatString}
         marks={undefined}
+        max={dayjs()}
+        min={dayjs().subtract(1, 'hour')}
+        onChange={() => {}}
+        value={dayjs(value * 1000)}
       />
     );
 

--- a/src/Slider/TimeSlider/TimeSlider.tsx
+++ b/src/Slider/TimeSlider/TimeSlider.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useCallback, useMemo } from 'react';
 
 import { Slider } from 'antd';
 import dayjs, { Dayjs } from 'dayjs';
@@ -21,6 +21,7 @@ interface OwnProps {
   duration?: Duration | string;
   formatString?: string;
   marks?: TimeSliderMark[];
+  markFormatString?: string;
   max?: Dayjs;
   maxNumberOfMarks?: number;
   min?: Dayjs;
@@ -37,6 +38,7 @@ const TimeSlider: React.FC<TimeSliderProps> = ({
   defaultValue = dayjs(),
   duration,
   formatString = 'DD.MM. HH:mm',
+  markFormatString,
   marks,
   max = dayjs(),
   min = dayjs().subtract(1, 'hour'),
@@ -71,9 +73,9 @@ const TimeSlider: React.FC<TimeSliderProps> = ({
     return convertedMks;
   }, [marks]);
 
-  const formatTimestamp = (unix: number): string => {
-    return unix ? dayjs(unix * 1000).format(formatString) : '';
-  };
+  const formatTimestamp = useCallback((unix: number): string => {
+    return unix ? dayjs(unix * 1000).format(markFormatString ?? formatString) : '';
+  }, [markFormatString, formatString]);
 
   const valueUpdated = (val: number | number[]) => {
     const updatedValue = _isArray(val)

--- a/src/Slider/TimeSlider/TimeSlider.tsx
+++ b/src/Slider/TimeSlider/TimeSlider.tsx
@@ -2,8 +2,10 @@ import React, { useMemo } from 'react';
 
 import { Slider } from 'antd';
 import dayjs, { Dayjs } from 'dayjs';
+import { Duration, parse, toSeconds } from 'iso8601-duration';
 import _isArray from 'lodash/isArray';
 import _isFunction from 'lodash/isFunction';
+import _isNil from 'lodash/isNil';
 import { MarkObj } from 'rc-slider/lib/Marks';
 
 import { CSS_PREFIX } from '../../constants';
@@ -16,9 +18,11 @@ export interface TimeSliderMark {
 interface OwnProps {
   className?: string;
   defaultValue?: Dayjs | [Dayjs, Dayjs];
+  duration?: Duration | string;
   formatString?: string;
   marks?: TimeSliderMark[];
   max?: Dayjs;
+  maxNumberOfMarks?: number;
   min?: Dayjs;
   onChange?: (val: Dayjs | [Dayjs, Dayjs]) => void;
   onChangeComplete?: (val: Dayjs | [Dayjs, Dayjs]) => void;
@@ -31,6 +35,7 @@ export type TimeSliderProps = OwnProps;
 const TimeSlider: React.FC<TimeSliderProps> = ({
   className,
   defaultValue = dayjs(),
+  duration,
   formatString = 'DD.MM. HH:mm',
   marks,
   max = dayjs(),
@@ -83,6 +88,16 @@ const TimeSlider: React.FC<TimeSliderProps> = ({
     }
   };
 
+  const step = useMemo(() => {
+    if (_isNil(duration)) {
+      return null;
+    }
+    if (typeof duration === 'string') {
+      return toSeconds(parse(duration));
+    }
+    return toSeconds(duration);
+  }, [duration]);
+
   const finalClassName = className ? `${className} ${CSS_PREFIX}timeslider` : `${CSS_PREFIX}timeslider`;
 
   return useRange ? (
@@ -95,6 +110,7 @@ const TimeSlider: React.FC<TimeSliderProps> = ({
       onChange={valueUpdated}
       onChangeComplete={valueUpdated}
       range={true}
+      step={step}
       tooltip={{ formatter: val => formatTimestamp(val as number) }}
       value={convertDayjsToUnix(value) as [number, number]}
       {...passThroughProps}
@@ -109,6 +125,7 @@ const TimeSlider: React.FC<TimeSliderProps> = ({
       onChange={valueUpdated}
       onChangeComplete={valueUpdated}
       range={false}
+      step={step}
       tooltip={{
         formatter: val => formatTimestamp(val as number)
       }}


### PR DESCRIPTION
## Description

<!-- Please give a short description of the changes you propose. Please use prose and try not to be too technical, if possible. Make sure to mention people that you think should know about the PR. -->

* Add support for ISO 8601 duration strings (e.g., "PT1H")  in `TimeSlider` / `TimeSliderPanel` to automatically generate appropriate step intervals.
* Add a new property `markFormatString` to allow user-defined formatting of the mark labels on the slider.
* When duration is passed, marks are determined automatically (`TimeSliderPanel`).  The maximum number of marks can be limited with `maxNumberOfMarks`
* Improvement: Both `formatString` and `duration` can now be passed either as component props or via the corresponding layer properties — ensuring consistent and flexible configuration.

Plz review @terrestris/devs 

## Related issues or pull requests

<!-- Please list issues or pull requests that the changes you propose are related to. It does not matter if they are still open and/or unmerged, any link is appreciated. -->

## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [X] Bugfix
- [x] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [X] No

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the
  [BSD-2-Clause](https://github.com/terrestris/react-geo/blob/main/LICENSE).
- [X] I have followed the [guidelines for contributing](https://github.com/terrestris/react-geo/blob/main/CONTRIBUTING.md).
- [X] The proposed change fits to the content of the [Code of Conduct](https://github.com/terrestris/react-geo/blob/main/CODE_OF_CONDUCT.md).
- [X] I have added or updated tests and documentation, and the test suite passes (run `npm run check` locally).
- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
