### PR TITLE
allow SearchField with external data display

### DIFF
--- a/src/Field/SearchField/SearchField.less
+++ b/src/Field/SearchField/SearchField.less
@@ -1,3 +1,7 @@
 .react-geo-search {
   width: 100%;
 }
+
+.ant-select-dropdown.autocomplete-disabled {
+    padding: 0;
+}


### PR DESCRIPTION
## Description

<!-- Please give a short description of the changes you propose. Please use prose and try not to be too technical, if possible. Make sure to mention people that you think should know about the PR. -->

Makes the `SearchField` usable in more generic contexts:

- new property `onSearchCompleted` is a callback that returns all the search results
- new property `autoCompleteDisabled` (default: false) allows to disable the autocomplete dropdown
  - in this case, the property `getValue` is no longer required

With these new properties, the `SearchField` can be used with a custom result display, e.g.:

```tsx
  [...]
  const onSearchCompleted = async (result: FeatureCollection | undefined) => {
    setData(result);
  };

  return (
    <div>
      <SearchField
        zoomToFeature={false}
        onSearchCompleted={onSearchCompleted}
        searchFunction={wfsSearchFunction}
        autoCompleteDisabled={true}
      />
      {
        (
          <AgFeatureGrid
            features={features}
            loading={isLoading}
            zoomToExtent={false}
          />
        )
      }
    </div>
 );
```

## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [ ] Bugfix
- [x] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the
  [BSD-2-Clause](https://github.com/terrestris/react-geo/blob/main/LICENSE).
- [x] I have followed the [guidelines for contributing](https://github.com/terrestris/react-geo/blob/main/CONTRIBUTING.md).
- [x] The proposed change fits to the content of the [Code of Conduct](https://github.com/terrestris/react-geo/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm run check` locally).
- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.

@terrestris/devs Please review.
