### PR TITLE
chore: fix misspelled command

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "clean:build": "rimraf ./build/*",
     "clean:dist": "rimraf ./dist/*",
     "clean:test": "rimraf ./coverage/*",
-    "lint": "npm rum clean && npm run lint:styleguide && npm run lint:src",
+    "lint": "npm run clean && npm run lint:styleguide && npm run lint:src",
     "lint:fix": "npm run lint:styleguide -- --fix && npm run lint:src -- --fix",
     "lint:src": "eslint -c eslint.config.mjs",
     "lint:styleguide": "eslint -c eslintrc.styleguide.mjs",


### PR DESCRIPTION
## Description

This Pr suggests to correct the spelling of an npm command. I am not sure how this could live so long undetected herein.

## Related issues or pull requests

none

## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the
  [BSD-2-Clause](https://github.com/terrestris/react-geo/blob/main/LICENSE).
- [x] I have followed the [guidelines for contributing](https://github.com/terrestris/react-geo/blob/main/CONTRIBUTING.md).
- [x] The proposed change fits to the content of the [Code of Conduct](https://github.com/terrestris/react-geo/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm run check` locally).
- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
