### PR TITLE
fix: Conflate dublicated Unittests

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -36,7 +36,12 @@ module.exports = {
   },
   collectCoverageFrom: [
     'src/**/*.{ts,tsx}',
-    '!src/**/*example*.*'
+    '!src/**/*example*.*',
+    '!src/**/*.d.ts',
+    '!src/index.ts',
+    '!src/Context/MapContext/MapContext.tsx', // only a placeholder
+    '!src/Hook/useDropTargetMap.ts', // only a placeholder
+    '!src/Hook/useMap.ts' // only a placeholder
   ],
   coverageDirectory: '<rootDir>/coverage',
   testEnvironment: 'jsdom',

--- a/src/BackgroundLayerChooser/BackgroundLayerChooser.tsx
+++ b/src/BackgroundLayerChooser/BackgroundLayerChooser.tsx
@@ -115,9 +115,10 @@ export const BackgroundLayerChooser: React.FC<BackgroundLayerChooserProps> = ({
   }, [map, layerOptionsVisible]);
 
   useEffect(() => {
-    const activeLayerCand = layers.find(l => l.getVisible());
-
-    if (!initiallySelectedLayer) {
+    if (initiallySelectedLayer) {
+      setSelectedLayer(initiallySelectedLayer);
+    } else {
+      const activeLayerCand = layers.find(l => l.getVisible());
       setSelectedLayer(activeLayerCand as OlLayer);
     }
   }, [initiallySelectedLayer, layers]);
@@ -227,7 +228,7 @@ export const BackgroundLayerChooser: React.FC<BackgroundLayerChooserProps> = ({
         layerOptionsVisible && (
           <div className="layer-cards">
             {
-              layers.map(layer => (
+              layers.filter(backgroundLayerFilter).map(layer => (
                 <BackgroundLayerPreview
                   key={getUid(layer)}
                   activeLayer={selectedLayer}

--- a/src/FeatureLabelModal/FeatureLabelModal.spec.tsx
+++ b/src/FeatureLabelModal/FeatureLabelModal.spec.tsx
@@ -44,6 +44,7 @@ describe('<CopyButton />', () => {
         onCancel={onCancel}
       />
     );
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
     expect(screen.getByText('Test label')).toBeInTheDocument();
   });
 

--- a/src/Field/SearchField/SearchField.spec.tsx
+++ b/src/Field/SearchField/SearchField.spec.tsx
@@ -5,12 +5,12 @@ import OlFeature from 'ol/Feature';
 import OlPoint from 'ol/geom/Point';
 import OlMap from 'ol/Map';
 import OlView from 'ol/View';
-import { render, fireEvent, waitFor } from '@testing-library/react';
+import { render, fireEvent, waitFor, screen } from '@testing-library/react';
 
 import { SearchField, SearchProps } from './SearchField';
 
 describe('<CopyButton />', () => {
-  const coord = [829729, 6708850];
+  const coord = [1, 2];
   let map: OlMap;
   let feature: OlFeature<OlPoint>;
 
@@ -81,5 +81,14 @@ describe('<CopyButton />', () => {
     waitFor(() => {
       expect(mockProps.onSearchCompleted).toHaveBeenCalledWith(searchCollection);
     });
+  });
+
+   it('disables autocomplete popup if autoCompleteDisabled is true', async () => {
+    render(<SearchField searchFunction={jest.fn()} autoCompleteDisabled={true} />);
+    const input = screen.getByRole('combobox');
+    fireEvent.change(input, { target: { value: 'A' } });
+    // Wait a bit to ensure popup would have rendered if enabled
+    await new Promise(res => setTimeout(res, 300));
+    expect(screen.queryByText('A')).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Description

This PR joins Unittests from #4394 and #4379 since they were dublicated.

## Related issues or pull requests

<!-- Please list issues or pull requests that the changes you propose are related to. It does not matter if they are still open and/or unmerged, any link is appreciated. -->

## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the
  [BSD-2-Clause](https://github.com/terrestris/react-geo/blob/main/LICENSE).
- [x] I have followed the [guidelines for contributing](https://github.com/terrestris/react-geo/blob/main/CONTRIBUTING.md).
- [x] The proposed change fits to the content of the [Code of Conduct](https://github.com/terrestris/react-geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added or updated tests and documentation, and the test suite passes (run `npm run check` locally).
- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
