### PR TITLE
Rewrite isURL to remove potential security risk

### DIFF
--- a/src/Grid/PropertyGrid/PropertyGrid.spec.tsx
+++ b/src/Grid/PropertyGrid/PropertyGrid.spec.tsx
@@ -83,4 +83,64 @@ describe('<PropertyGrid />', () => {
     expect(link).toHaveAttribute('href', 'https://www.example.com');
   });
 
+  describe('isUrl behavior cases (URL-based impl)', () => {
+    const goodCases = [
+      'http://example.com',
+      'https://example.com/path?x=1',
+      '//example.com', // protocol-relative
+      'http://localhost:8080',
+      'http://example', // short host without dot
+      'http://sub.domain.co.uk',
+      'https://127.0.0.1',
+      'http://a.b',
+      'http://example.com/some/page.html#hash',
+      'https://example.com:8443/path',
+      'https://user:password@pasexample.com:8443/some/path?foo=bar&baz=qux',
+      'https://🪨🎸🤘'
+    ];
+
+    const badCases = [
+      'ftp://example.com',
+      'mailto:user@example.com',
+      'example.com', // bare host
+      '/relative/path',
+      '://missing-scheme.com',
+      '',
+      '   ',
+      'http://',
+      'http://.com',
+      '////weird'
+    ];
+
+    goodCases.forEach((value) => {
+      it(`treats '${value}' as URL (true)`, () => {
+        const feature = new OlFeature({ geometry: new OlGeomPoint([0, 0]), attr: value });
+        render(
+          <PropertyGrid
+            feature={feature}
+            attributeFilter={[ 'attr' ]}
+          />
+        );
+
+        const link = screen.queryByRole('link', { name: value });
+        expect(!!link).toBe(true);
+      });
+    });
+
+    badCases.forEach((value) => {
+      it(`treats '${value}' as non-URL (false)`, () => {
+        const feature = new OlFeature({ geometry: new OlGeomPoint([0, 0]), attr: value });
+        render(
+          <PropertyGrid
+            feature={feature}
+            attributeFilter={[ 'attr' ]}
+          />
+        );
+
+        const link = screen.queryByRole('link', { name: value });
+        expect(!!link).toBe(false);
+      });
+    });
+  });
+
 });


### PR DESCRIPTION
## Description

SonarQube marked the regular expresion based implementation of isURL as a potential security risk:

> Make sure the regex used here, which is vulnerable to super-linear
> runtime due to backtracking, cannot lead to denial of service.
> Using slow regular expressions is security-sensitive

This commit changes the implementation to use URL() object, and it enforces some rules that are more strict than technically needed. See the tests for accepted and declined cases. It is quite verbose, but should remove the flagging as security risk.

The method itself should probably be moved to a generic library, e.g. https://github.com/terrestris/base-util but I'll leave this for others to decide.

I checked refactoring below, but there might be some cases handled differently.

## Related issues or pull requests

none

## Pull request type

- [ ] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the
  [BSD-2-Clause](https://github.com/terrestris/react-geo/blob/main/LICENSE).
- [x] I have followed the [guidelines for contributing](https://github.com/terrestris/react-geo/blob/main/CONTRIBUTING.md).
- [x] The proposed change fits to the content of the [Code of Conduct](https://github.com/terrestris/react-geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added or updated tests and documentation, and the test suite passes (run `npm run check` locally).
- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
