### PR TITLE
fix: popover for data range button

### DIFF
--- a/src/Panel/TimeLayerSliderPanel/TimeLayerSliderPanel.tsx
+++ b/src/Panel/TimeLayerSliderPanel/TimeLayerSliderPanel.tsx
@@ -439,10 +439,13 @@ export const TimeLayerSliderPanel: React.FC<TimeLayerSliderPanelProps> = ({
           />
         }
       >
-        <SimpleButton
-          className="change-datarange-button"
-          icon={<FontAwesomeIcon icon={faCalendar} />}
-        />
+        <span>
+          <SimpleButton
+            className="change-datarange-button"
+            style={{ width: 'auto' }}
+            icon={<FontAwesomeIcon icon={faCalendar} />}
+          />
+        </span>
       </Popover>
       <SimpleButton
         icon={<FontAwesomeIcon icon={faSync} />}


### PR DESCRIPTION
## Description

This PR fixes the display of the popover of the data range button.

## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the
  [BSD-2-Clause](https://github.com/terrestris/react-geo/blob/main/LICENSE).
- [x] I have followed the [guidelines for contributing](https://github.com/terrestris/react-geo/blob/main/CONTRIBUTING.md).
- [x] The proposed change fits to the content of the [Code of Conduct](https://github.com/terrestris/react-geo/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm run check` locally).
- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
